### PR TITLE
chore: update build script

### DIFF
--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -60,10 +60,10 @@ module.exports = function(eleventyConfig) {
   ];
 
   /** Copy and manage site assets from the monorepo */
-  eleventyConfig.addPlugin(pfeAssetsPlugin, {
-    prefix: 'rh',
-    additionalPackages,
-  });
+  // eleventyConfig.addPlugin(pfeAssetsPlugin, {
+  //   prefix: 'rh',
+  //   additionalPackages,
+  // });
 
   /** Generate and consume custom elements manifests */
   eleventyConfig.addPlugin(customElementsManifestPlugin);
@@ -222,7 +222,10 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy('docs/robots.txt');
   eleventyConfig.addPassthroughCopy('docs/assets/**/*');
   eleventyConfig.addPassthroughCopy('docs/js/**/*');
-  eleventyConfig.addPassthroughCopy({ 'docs/pfe.min.*': 'assets' });
+  eleventyConfig.addPassthroughCopy({ 'rhds.min.*': 'assets' });
+
+  eleventyConfig.on('eleventy.before', async () => import('execa')
+    .then(({ execaCommand }) => execaCommand('npm run build:elements')));
 
   return {
     templateFormats: [

--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -59,12 +59,6 @@ module.exports = function(eleventyConfig) {
       .filter(x => x && x !== '@patternfly/pfe-styles'),
   ];
 
-  /** Copy and manage site assets from the monorepo */
-  // eleventyConfig.addPlugin(pfeAssetsPlugin, {
-  //   prefix: 'rh',
-  //   additionalPackages,
-  // });
-
   /** Generate and consume custom elements manifests */
   eleventyConfig.addPlugin(customElementsManifestPlugin);
 

--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -224,8 +224,11 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy('docs/js/**/*');
   eleventyConfig.addPassthroughCopy({ 'rhds.min.*': 'assets' });
 
-  eleventyConfig.on('eleventy.before', async () => import('execa')
-    .then(({ execaCommand }) => execaCommand('npm run build:elements')));
+  const buildElements = async () =>
+    import('./scripts/build.js')
+      .then(m => m.build());
+
+  eleventyConfig.on('eleventy.before', buildElements);
 
   return {
     templateFormats: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rhds/elements",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "1.0.0-beta.0",
+      "version": "1.0.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -43,7 +43,7 @@
         "@patternfly/create-element": "^1.0.0 || ^1.0.0-next.9",
         "@patternfly/eslint-config-elements": "next",
         "@patternfly/pfe-sass": "next",
-        "@patternfly/pfe-tools": "^1.0.0-next.18",
+        "@patternfly/pfe-tools": "^1.0.0-next.20",
         "autoprefixer": "^10.4.4",
         "cssnano": "^5.1.7",
         "custom-elements-manifest": "^1.0.0",
@@ -2795,9 +2795,9 @@
       }
     },
     "node_modules/@patternfly/pfe-tools": {
-      "version": "1.0.0-next.19",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-tools/-/pfe-tools-1.0.0-next.19.tgz",
-      "integrity": "sha512-sOpmplSQk/wlZdKc55+6FhHdr9VU4rKkB6p3YKl13jUGuax74Kh7NaSiZMuyUyzWfgr3TmswiR0Tr/icChftBA==",
+      "version": "1.0.0-next.20",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-tools/-/pfe-tools-1.0.0-next.20.tgz",
+      "integrity": "sha512-T1yelCO/mQqOTHSkZv2vMyy6vgu9rjyEmpxfJsuCDhxkFY+Gp1x5mRhX2pRAyS7En1K8q4cBy6cGg3tSy1cE6Q==",
       "dev": true,
       "dependencies": {
         "@11ty/eleventy": "^1.0.1",
@@ -2846,6 +2846,7 @@
         "esbuild-plugin-lit-css": "^2.0.0",
         "esbuild-plugin-minify-html-literals": "^1.0.1",
         "eslint": "^8.14.0",
+        "execa": "^6.1.0",
         "glob": "^8.0.1",
         "html-include-element": "^0.3.0",
         "koa-send": "^5.0.1",
@@ -2879,6 +2880,29 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/@patternfly/pfe-tools/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/@patternfly/pfe-tools/node_modules/glob": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
@@ -2899,6 +2923,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@patternfly/pfe-tools/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@patternfly/pfe-tools/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@patternfly/pfe-tools/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@patternfly/pfe-tools/node_modules/minimatch": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -2909,6 +2966,60 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@patternfly/pfe-tools/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@patternfly/pfe-tools/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@patternfly/pfe-tools/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@patternfly/pfe-tools/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@patternfly/pfelement": {
@@ -22070,9 +22181,9 @@
       }
     },
     "@patternfly/pfe-tools": {
-      "version": "1.0.0-next.19",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-tools/-/pfe-tools-1.0.0-next.19.tgz",
-      "integrity": "sha512-sOpmplSQk/wlZdKc55+6FhHdr9VU4rKkB6p3YKl13jUGuax74Kh7NaSiZMuyUyzWfgr3TmswiR0Tr/icChftBA==",
+      "version": "1.0.0-next.20",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-tools/-/pfe-tools-1.0.0-next.20.tgz",
+      "integrity": "sha512-T1yelCO/mQqOTHSkZv2vMyy6vgu9rjyEmpxfJsuCDhxkFY+Gp1x5mRhX2pRAyS7En1K8q4cBy6cGg3tSy1cE6Q==",
       "dev": true,
       "requires": {
         "@11ty/eleventy": "^1.0.1",
@@ -22121,6 +22232,7 @@
         "esbuild-plugin-lit-css": "^2.0.0",
         "esbuild-plugin-minify-html-literals": "^1.0.1",
         "eslint": "^8.14.0",
+        "execa": "^6.1.0",
         "glob": "^8.0.1",
         "html-include-element": "^0.3.0",
         "koa-send": "^5.0.1",
@@ -22151,6 +22263,23 @@
             "balanced-match": "^1.0.0"
           }
         },
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
         "glob": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
@@ -22165,6 +22294,24 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
         "minimatch": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -22173,6 +22320,36 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@patternfly/create-element": "^1.0.0 || ^1.0.0-next.9",
     "@patternfly/eslint-config-elements": "next",
     "@patternfly/pfe-sass": "next",
-    "@patternfly/pfe-tools": "^1.0.0-next.18",
+    "@patternfly/pfe-tools": "^1.0.0-next.20",
     "autoprefixer": "^10.4.4",
     "cssnano": "^5.1.7",
     "custom-elements-manifest": "^1.0.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,29 +3,36 @@ import { readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 import { build } from 'esbuild';
-import { minifyHTMLLiteralsPlugin } from 'esbuild-plugin-minify-html-literals';
 import { litCssPlugin } from 'esbuild-plugin-lit-css';
+import { singleFileBuild } from '@patternfly/pfe-tools/esbuild.js';
+// import { minifyHTMLLiteralsPlugin } from 'esbuild-plugin-minify-html-literals';
 
 const elements = await readdir(new URL('../elements', import.meta.url));
 
 const entryPoints = elements.map(x =>
-  fileURLToPath(new URL(`../elements/${x}/${x}.ts`, import.meta.url)));
+  fileURLToPath(new URL(`../elements/${x}/${x}.js`, import.meta.url)));
 
-await build({
-  entryPoints,
+const componentsEntryPointContents = entryPoints.reduce((acc, x) => `${acc}
+export * from '${x}';`, '');
+
+const litCssOptions = {
+  include: /elements\/rh-(.*)\/(.*)\.css$/,
+  uglify: true,
+};
+
+const external = [
+  '@*',
+  'prism*',
+  'lit*',
+  'tslib',
+];
+
+await singleFileBuild({
+  componentsEntryPointContents,
   outfile: 'rhds.min.js',
-  format: 'esm',
-  minify: true,
-  bundle: true,
-  legalComments: 'linked',
-  sourcemap: 'linked',
-  plugins: [
-    minifyHTMLLiteralsPlugin(),
-    litCssPlugin({
-      include: /elements\/rh-(.*)\/(.*)\.css$/,
-      uglify: true,
-    }),
-  ],
+  litCssOptions,
+  external,
+  minify: false,
 });
 
 await build({
@@ -34,23 +41,15 @@ await build({
   outbase: 'elements',
   entryNames: '[dir]/[name]',
   bundle: true,
-  external: [
-    '@*',
-    '@patternfly/*',
-    'prism*',
-    'lit*',
-    'tslib'
-  ],
+  external,
   format: 'esm',
   sourcemap: 'linked',
-  minify: true,
+  minify: false,
   legalComments: 'linked',
   plugins: [
-    minifyHTMLLiteralsPlugin(),
-    litCssPlugin({
-      include: /elements\/rh-(.*)\/(.*)\.css$/,
-      uglify: true,
-    }),
+    // BUG: https://github.com/asyncLiz/minify-html-literals/issues/37
+    // minifyHTMLLiteralsPlugin(),
+    litCssPlugin(litCssOptions),
   ],
 });
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -58,12 +58,12 @@ export async function build() {
 }
 
 const stripExtension = x => x.replace(/\.\w+$/, '');
-const and = (x, y) => x && y;
+const eqeqeq = (x, y) => x === y;
 
 /** Was the module was run directly? */
 const INVOKED_VIA_CLI = [process.argv[1], fileURLToPath(import.meta.url)]
   .map(stripExtension) // fun with functional programming
-  .reduce(and, false);
+  .reduce(eqeqeq);
 
 if (INVOKED_VIA_CLI) {
   await build();

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,23 +2,10 @@
 import { readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
-import { build } from 'esbuild';
+import { build as esBuild } from 'esbuild';
 import { litCssPlugin } from 'esbuild-plugin-lit-css';
 import { singleFileBuild } from '@patternfly/pfe-tools/esbuild.js';
 // import { minifyHTMLLiteralsPlugin } from 'esbuild-plugin-minify-html-literals';
-
-const elements = await readdir(new URL('../elements', import.meta.url));
-
-const entryPoints = elements.map(x =>
-  fileURLToPath(new URL(`../elements/${x}/${x}.js`, import.meta.url)));
-
-const componentsEntryPointContents = entryPoints.reduce((acc, x) => `${acc}
-export * from '${x}';`, '');
-
-const litCssOptions = {
-  include: /elements\/rh-(.*)\/(.*)\.css$/,
-  uglify: true,
-};
 
 const external = [
   '@*',
@@ -27,29 +14,57 @@ const external = [
   'tslib',
 ];
 
-await singleFileBuild({
-  componentsEntryPointContents,
-  outfile: 'rhds.min.js',
-  litCssOptions,
-  external,
-  minify: false,
-});
+export async function build() {
+  const elements = await readdir(new URL('../elements', import.meta.url));
 
-await build({
-  entryPoints,
-  outdir: 'elements',
-  outbase: 'elements',
-  entryNames: '[dir]/[name]',
-  bundle: true,
-  external,
-  format: 'esm',
-  sourcemap: 'linked',
-  minify: false,
-  legalComments: 'linked',
-  plugins: [
-    // BUG: https://github.com/asyncLiz/minify-html-literals/issues/37
-    // minifyHTMLLiteralsPlugin(),
-    litCssPlugin(litCssOptions),
-  ],
-});
+  const entryPoints = elements.map(x =>
+    fileURLToPath(new URL(`../elements/${x}/${x}.js`, import.meta.url)));
 
+  const componentsEntryPointContents = entryPoints.reduce((acc, x) => `${acc}
+  export * from '${x}';`, '');
+
+  const litCssOptions = {
+    include: /elements\/rh-(.*)\/(.*)\.css$/,
+    uglify: true,
+  };
+
+  await singleFileBuild({
+    componentsEntryPointContents,
+    outfile: 'rhds.min.js',
+    litCssOptions,
+    allowOverwrite: true,
+    external,
+    minify: false,
+  });
+
+  await esBuild({
+    entryPoints,
+    outdir: 'elements',
+    outbase: 'elements',
+    entryNames: '[dir]/[name]',
+    allowOverwrite: true,
+    bundle: true,
+    external,
+    format: 'esm',
+    sourcemap: 'linked',
+    minify: false,
+    legalComments: 'linked',
+    plugins: [
+      // BUG: https://github.com/asyncLiz/minify-html-literals/issues/37
+      // minifyHTMLLiteralsPlugin(),
+      litCssPlugin(litCssOptions),
+    ],
+  });
+}
+
+const stripExtension = x => x.replace(/\.\w+$/, '');
+const and = (x, y) => x && y;
+
+/** Was the module was run directly? */
+const INVOKED_VIA_CLI = [process.argv[1], fileURLToPath(import.meta.url)]
+  .map(stripExtension) // fun with functional programming
+  .reduce(and, false);
+
+if (INVOKED_VIA_CLI) {
+  await build();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "./declaration.d.ts"
   ],
   "exclude": [
-    "node_modules",
+    "**/node_modules/**/*",
     "_site",
     "docs/**/*.js",
     "scripts/*.js",


### PR DESCRIPTION


## What I did

1. disables bundle minification due to a [bug in
  `minify-html-literals`](https://github.com/asyncLiz/minify-html-literals/issues/37)
2. uses [new APIs in `@patternfly/pfe-tools/esbuild.js`](https://github.com/patternfly/patternfly-elements/pull/2030) to bundle PFE and RHDS for the docs site
  NB: once PFE components are done porting over, we'll remove the
  pfe.min.js altogether, and use exclusively `<rh-*` elements in the
  docs site


## Testing Instructions

1. see https://github.com/patternfly/patternfly-elements/pull/2030

## Notes to Reviewers
https://github.com/patternfly/patternfly-elements/pull/2030 must merge and release first before testing this