### PR TITLE
fix(footer): fix styles when used on redhat.com

### DIFF
--- a/.changeset/cold-ravens-develop.md
+++ b/.changeset/cold-ravens-develop.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Fix `<rh-footer>` styles when used on redhat.com

--- a/elements/rh-footer/demo/proxy.html
+++ b/elements/rh-footer/demo/proxy.html
@@ -1,0 +1,99 @@
+<link href="/elements/rh-footer/rh-footer-lightdom.css" rel="stylesheet">
+</link>
+<template id="rh-footer-spandx-template">
+  <rh-footer>
+    <a slot="logo" href="/en">
+      <img src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg" alt="Red Hat logo"
+        loading="lazy" />
+    </a>
+    <h3 slot="links">Products</h3>
+    <ul slot="links">
+      <li><a href="#">Red Hat Ansible Automation Platform</a></li>
+      <li><a href="#">Red Hat Enterprise Linux</a></li>
+      <li><a href="#">Red Hat OpenShift</a></li>
+      <li><a href="#">Red Hat OpenShift Container Storage</a></li>
+      <li><a href="#">Red Hat OpenStack Platform</a></li>
+      <li><a href="#">See all products</a></li>
+    </ul>
+    <h3 slot="links">Tools</h3>
+    <ul slot="links">
+      <li><a href="#">My account</a></li>
+      <li><a href="#">Customer support</a></li>
+      <li><a href="#">Red Hat OpenShift</a></li>
+      <li><a href="#">Contact training</a></li>
+      <li><a href="#">Red Hat OpenStack Platform</a></li>
+      <li><a href="#">See all products</a></li>
+    </ul>
+    <h3 slot="links">Try, buy, sell</h3>
+    <ul slot="links">
+      <li><a href="#">Red Hat Store</a></li>
+      <li><a href="#">Red Hat Enterprise Linux</a></li>
+      <li><a href="#">Red Hat OpenShift</a></li>
+      <li><a href="#">Contact training</a></li>
+      <li><a href="#">Red Hat OpenStack Platform</a></li>
+      <li><a href="#">See all products</a></li>
+    </ul>
+    <h3 id="communicate" slot="links">Communicate</h3>
+    <ul slot="links">
+      <li><a href="#">Contact us</a></li>
+      <li><a href="#">Feedback</a></li>
+      <li><a href="#">Social</a></li>
+      <li><a href="#">Red Hat newsletter</a></li>
+      <li><a href="#">Email preferences</a></li>
+    </ul>
+    <rh-footer-block slot="main-secondary">
+      <h3 slot="header">About Red Hat</h3>
+      <p>We’re the world’s leading provider of enterprise open source solutions―including Linux, cloud, container,
+        and
+        Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and
+        environments, from the core datacenter to the network edge.
+      </p>
+      <p>Duis nulla esse ad id anim ipsum et magna amet laborum ex consectetur nulla. Est non ex ea ut ex laborum
+        id
+        aute eiusmod eu quis qui. <a href="#">Consequat consequat tempor elit nostrud non</a>.</p>
+    </rh-footer-block>
+    <rh-footer-block slot="main-secondary">
+      <h3 slot="header">Subscribe to our free newsletter, Red Hat Shares</h3>
+      <pfe-cta><a href="#blocks">Sign up now</a></pfe-cta>
+    </rh-footer-block>
+    <rh-footer-block slot="main-secondary">
+      <h3 slot="header">Select a language</h3>
+      <p>insert language switcher here...</p>
+    </rh-footer-block>
+    <h3 slot="footer-links-primary" hidden>Red Hat legal and privacy links</h3>
+    <ul slot="footer-links-primary">
+      <li><a href="#">About Red Hat</a></li>
+      <li><a href="#">Jobs</a></li>
+      <li><a href="#">Events</a></li>
+      <li><a href="#">Locations</a></li>
+      <li><a href="#">Contact Red Hat</a></li>
+      <li><a href="#">Red Hat Blog</a></li>
+      <li><a href="#">Cool Stuff Store</a></li>
+      <li><a href="#">Diversity, equity, and inclusion</a></li>
+    </ul>
+    <rh-footer-copyright slot="footer-links-secondary"></rh-footer-copyright>
+    <h3 slot="footer-links-secondary" hidden>Red Hat legal and privacy links</h3>
+    <ul slot="footer-links-secondary">
+      <li><a href="#">Privacy statement</a></li>
+      <li><a href="#">Terms of use</a></li>
+      <li><a href="#">All policies and guidelines</a></li>
+      <li><a href="#">Digital accessibility</a></li>
+      <li><a href="#">Cookie preferences</a></li>
+    </ul>
+    <div slot="footer-secondary-end">
+      <a href="#">*We’ve updated our privacy statement effective December 30, 202X.</a>
+    </div>
+    <a href="https://www.redhat.com/en/summit" slot="footer-tertiary">
+      <img src="https://access.redhat.com/chrome_themes/nimbus/img/rh-summit-red-a.svg" alt="Red Hat Summit"
+        loading="lazy" width="73px" />
+    </a>
+  </rh-footer>
+</template>
+
+<script type="module">
+  import '@rhds/elements/rh-footer/rh-footer.js';
+  const tpl = document.getElementById('rh-footer-spandx-template');
+  const footer = tpl.content.cloneNode(true);
+  document.querySelector('.page > footer').remove();
+  document.querySelector('body').appendChild(footer);
+</script>

--- a/elements/rh-footer/demo/rh-footer.html
+++ b/elements/rh-footer/demo/rh-footer.html
@@ -1,6 +1,5 @@
 <link rel="stylesheet" href="https://static.redhat.com/libs/redhat/redhat-font/4/webfonts/red-hat-font.min.css" />
 <link rel="stylesheet" href="https://static.redhat.com/libs/redhat/redhat-theme/6/advanced-theme.css" />
-<link rel="stylesheet" href="https://unpkg.com/@patternfly/pfe-styles@2.0.0-next.2/pfe-base.css" />
 <link rel="stylesheet" href="/elements/rh-footer/rh-footer-lightdom.css" />
 
 <style>

--- a/elements/rh-footer/rh-footer-block.css
+++ b/elements/rh-footer/rh-footer-block.css
@@ -20,15 +20,14 @@
 }
 
 ::slotted(:is(h1, h2, h3, h4, h5)) {
-  font-weight: 500;
-  font-size: 14px;
-  margin-top: 0px;
+  font-weight: 500 !important;
+  font-size: 14px !important;
+  margin-block-start: 0px !important;
+  margin-block-end: 1em !important;
 }
 
 .content ::slotted(*) {
   color: #d2d2d2;
-  font-size: 0.875rem;
-  font-family: 'Red Hat Text', 'RedHatText', 'Overpass', Overpass, Arial,
-    sans-serif;
+  font-family: 'Red Hat Text', 'RedHatText', 'Overpass', Overpass, Arial, sans-serif;
   font-weight: 400;
 }

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -20,3 +20,21 @@ rh-footer :is([slot^=links], [slot=footer-links-primary], [slot=footer-links-sec
 rh-footer :is([slot^=links], [slot=footer-links-primary], [slot=footer-links-secondary]) a:is(:hover, :focus-within) {
   text-decoration: underline;
 }
+
+/* Via pfe-base.css */
+rh-footer a {
+  color: var(--rh-color-link-inline-on-light, var(--rh-color-blue-500, #06c));
+  text-decoration: none;
+}
+rh-footer a:hover {
+  color: var(--rh-color-link-inline-hover-on-light, var(--rh-color-blue-600, #004080));
+  text-decoration: underline;
+}
+rh-footer a:focus {
+  color: var(--rh-color-link-inline-hover-on-light, var(--rh-color-blue-600, #004080));
+  text-decoration: underline;
+}
+rh-footer a:visited {
+  color: var(--rh-color-link-inline-visited-on-dark, var(--rh-color-purple-300, #a18fff));
+  text-decoration: none;
+}

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -184,8 +184,8 @@ pfe-accordion {
 
 .social-links {
   display: flex;
-  margin-left: 0;
-  padding-left: 0;
+  margin-inline-start: 0;
+  padding-inline-start: 0;
 }
 
 .social-links rh-footer-links,
@@ -288,12 +288,12 @@ pfe-accordion {
   display: flex;
   flex-direction: column;
   gap: var(--rh-footer-links-gap, 10px);
-  margin-top:
+  margin-block-start:
     calc(
       var(--rh-footer-links-column-gap, 32px)
       * -1
       + var(--rh-footer-links-gap, 10px)
-    );
+    ) !important;
 }
 
 :host([is-mobile]) .links ::slotted(ul) {
@@ -316,10 +316,9 @@ pfe-accordion {
 }
 
 :is(.links, .footer-links-primary, .footer-links-secondary) ::slotted(:is(h1, h2, h3, h4, h5)) {
-  font-weight: 500;
-  margin-top: 0;
-  margin-bottom: 0;
-  font-size: var(--link-header-font-size, 14px);
+  font-weight: 500 !important;
+  margin-block: 0 !important;
+  font-size: var(--link-header-font-size, 14px) !important;
 }
 
 :host([is-mobile]) {


### PR DESCRIPTION
## What I did

1. Ported styles from `@patternfly/pfe-styles/pfe-base.css`.  `pfe-base.css` has a mixed bag of styles that have negative consequences.
2. This is a branch off of #302 


## Testing instructions

1. Start dev server `npm run dev`
3. Start the proxy server in a separate process `npm run proxy`
4. Open the the proxy url http://localhost:8001
5. Scroll to the bottom and you should see the rh-footer in context of the RHDC site.
6. Ensure it matches the footer in the dev server http://localhost:8000/demo/rh-footer/

## Todos

- [x] Port a styles from `pfe-base.css`
- [x] Add CSS overrides / resets for header & ul styles
