### PR TITLE
fix(footer): dev handoff fixes

### DIFF
--- a/.changeset/metal-ants-mate.md
+++ b/.changeset/metal-ants-mate.md
@@ -2,6 +2,6 @@
 "@rhds/elements": patch
 ---
 
-Fixed [bug] <rh-footer> links should be styled to match dark context colors. #307
-Fixed the social-links slot to not override the social-links internal rh-footer-links
-Fixed the social-links hrefs to point to the default RHDC links
+Fixed [bug] `<rh-footer>` links should be styled to match dark context colors. #307
+Fixed the `social-links` slot to not override the `social-links` internal `rh-footer-links`
+Fixed the `social-links` hrefs to point to the default RHDC links

--- a/.changeset/metal-ants-mate.md
+++ b/.changeset/metal-ants-mate.md
@@ -2,4 +2,6 @@
 "@rhds/elements": patch
 ---
 
-rh-footer style <a> with dark context variables
+Fixed [bug] <rh-footer> links should be styled to match dark context colors. #307
+Fixed the social-links slot to not override the social-links internal rh-footer-links
+Fixed the social-links hrefs to point to the default RHDC links

--- a/.changeset/metal-ants-mate.md
+++ b/.changeset/metal-ants-mate.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+rh-footer style <a> with dark context variables

--- a/elements/rh-footer/RhFooter.ts
+++ b/elements/rh-footer/RhFooter.ts
@@ -131,34 +131,34 @@ export class RhFooter extends LitElement {
               <div class="header-secondary" part="header-secondary">
                 <slot name="header-secondary">
                   <div class="social-links">
-                    <slot name="social-links">
-                      <rh-footer-links class="social-links-item"
-                          part="social-links-item"
-                          aria-label="Red Hat social media links">
+                    <rh-footer-links class="social-links-item"
+                      part="social-links-item"
+                      aria-label="Red Hat social media links">
+                      <slot name="social-links">
                         <slot name="social-links-start"></slot>
                         <rh-footer-social-link class="social-link"
                             part="social-link"
                             icon="web-icon-linkedin">
-                          <a href="#LinkedIn">LinkedIn</a>
+                          <a href="http://www.linkedin.com/company/red-hat">LinkedIn</a>
                         </rh-footer-social-link>
                         <rh-footer-social-link class="social-link"
                             part="social-link"
                             icon="web-icon-youtube">
-                          <a href="#Youtube">Youtube</a>
+                          <a href="http://www.youtube.com/user/RedHatVideos">Youtube</a>
                         </rh-footer-social-link>
                         <rh-footer-social-link class="social-link"
                             part="social-link"
                             icon="web-icon-facebook">
-                          <a href="#Facebook">Facebook</a>
+                          <a href="https://www.facebook.com/redhatinc">Facebook</a>
                         </rh-footer-social-link>
                         <rh-footer-social-link class="social-link"
                             part="social-link"
                             icon="web-icon-twitter">
-                          <a href="#Twitter">Twitter</a>
+                          <a href="https://twitter.com/RedHat">Twitter</a>
                         </rh-footer-social-link>
                         <slot name="social-links-end"></slot>
-                      </rh-footer-links>
-                    </slot>
+                      </slot>
+                    </rh-footer-links>
                   </div>
                 </slot>
               </div>

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -23,18 +23,18 @@ rh-footer :is([slot^=links], [slot=footer-links-primary], [slot=footer-links-sec
 
 /* Via pfe-base.css */
 rh-footer a {
-  color: var(--rh-color-link-inline-on-light, var(--rh-color-blue-500, #06c));
+  color: var(--rh-color-link-inline-on-dark, var(--rh-color-blue-200, #73bcf7));
   text-decoration: none;
 }
 rh-footer a:hover {
-  color: var(--rh-color-link-inline-hover-on-light, var(--rh-color-blue-600, #004080));
+  color: var(--rh-color-link-inline-hover-on-dark, var(--rh-color-blue-100, #bee1f4));
   text-decoration: underline;
 }
 rh-footer a:focus {
-  color: var(--rh-color-link-inline-hover-on-light, var(--rh-color-blue-600, #004080));
+  color: var(--rh-color-link-inline-focus-on-dark, var(--rh-color-blue-100, #bee1f4));
   text-decoration: underline;
 }
 rh-footer a:visited {
-  color: var(--rh-color-link-inline-visited-on-dark, var(--rh-color-purple-300, #a18fff));
+  color: var(--rh-color-link-inline-visited-on-dark, var(--rh-color-blue-100, #bee1f4));
   text-decoration: none;
 }


### PR DESCRIPTION
## What I did

1. Fixed #307 
2. Fixed the social-links slot to not override the social-links internal `rh-footer-links`
3. Fixed the social-links hrefs to point to the default RHDC links

## Testing Instructions

1. checkout `fix/rh-footer/dev-handoff-fixes` branch
2. `npm run dev`
3. Visit http://localhost:8000/demo/rh-footer/
4. Verify that the `<a>` tags in the footer are correctly styled with the dark theme colors
5. Verify that the social links slot works correctly by editing with the following code `elements/rh-footer/demo/rh-footer.html`:
```html
        <rh-footer-social-link slot="social-links" icon="web-icon-github">
          <a aria-label="Github" href="#github">Github</a>
        </rh-footer-social-link>
        <rh-footer-social-link slot="social-links" icon="web-icon-github">
          <a aria-label="Github" href="#github">Github</a>
        </rh-footer-social-link>
        <rh-footer-social-link slot="social-links" icon="web-icon-github">
          <a aria-label="Github" href="#github">Github</a>
        </rh-footer-social-link>
```
