### PR TITLE
docs: remove internal urls

### DIFF
--- a/docs/get-started.njk
+++ b/docs/get-started.njk
@@ -19,7 +19,7 @@ order: 0
   <p>All of our libraries are maintained in XD, it needs to be installed so you can use features like <a href="https://www.adobe.com/products/xd/learn/prototype/component-states/component-states-common-use-cases.html" target="_blank">Component States</a> and <a href="https://www.adobe.com/products/xd/learn/prototype.html" target="_blank">Prototyping</a>. After XD is installed, your Adobe account needs to be switched to the <strong>Adobe for Teams</strong> plan. Contact your manager for further assistance if necessary.</p>
 
   <pfe-cta priority="secondary">
-    <a href="https://redhat.service-now.com/help?id=sc_cat_item&sys_id=488f88c3956221004c71bb9efe94def5" target="_blank">Request an Adobe for Teams plan</a>
+    <a href="https://url.corp.redhat.com/adobecc" target="_blank">Request an Adobe for Teams plan</a>
   </pfe-cta>
 
   <pfe-cta style="margin-left:32px;">

--- a/docs/get-started/design-system-kit.njk
+++ b/docs/get-started/design-system-kit.njk
@@ -29,7 +29,7 @@ includeComponent:
   <p>The Design system kit is maintained in <strong>Adobe XD</strong> and <strong>Adobe Creative Cloud</strong>. They need to be installed if you want access to themed colors, character styles, and components. Once a license is granted, Associates can install their desired app(s) from within Adobe Creative Cloud. Contact your manager for further assistance if necessary.</p>
 
   <pfe-cta priority="secondary">
-    <a href="https://redhat.service-now.com/help?id=sc_cat_item&sys_id=488f88c3956221004c71bb9efe94def5" target="_blank">Request a Creative Cloud license</a>
+    <a href="https://url.corp.redhat.com/adobecc" target="_blank">Request a Creative Cloud license</a>
   </pfe-cta>
 
   <pfe-cta style="margin-left:32px;">

--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -49,7 +49,7 @@ includeComponent:
   <p>The FTS starter kit is maintained in <strong>Adobe XD</strong>, it needs to be installed if you want access to FTS patterns. After XD is installed, your Adobe account needs to be switched to the <strong>Adobe for Teams</strong> plan. Contact your manager for further assistance if necessary.</p>
 
   <pfe-cta priority="secondary">
-    <a href="https://redhat.service-now.com/help?id=sc_cat_item&sys_id=488f88c3956221004c71bb9efe94def5" target="_blank">Request an Adobe for Teams plan</a>
+    <a href="https://url.corp.redhat.com/adobecc" target="_blank">Request an Adobe for Teams plan</a>
   </pfe-cta>
 
   <pfe-cta style="margin-left:32px;">

--- a/docs/get-started/icon-library.njk
+++ b/docs/get-started/icon-library.njk
@@ -34,7 +34,7 @@ tags:
   <p>This library is maintained in <strong>Adobe XD</strong>, it needs to be installed if you want access to icons. After XD is installed, your Adobe account needs to be switched to the <strong>Adobe for Teams</strong> plan. Contact your manager for further assistance if necessary.</p>
 
   <pfe-cta priority="secondary">
-    <a href="https://redhat.service-now.com/help?id=sc_cat_item&sys_id=488f88c3956221004c71bb9efe94def5" target="_blank">Request an Adobe for Teams plan</a>
+    <a href="https://url.corp.redhat.com/adobecc" target="_blank">Request an Adobe for Teams plan</a>
   </pfe-cta>
 
   <pfe-cta style="margin-left:32px;">

--- a/docs/get-started/logo-library.njk
+++ b/docs/get-started/logo-library.njk
@@ -37,7 +37,7 @@ tags:
   <p>This library is maintained in <strong>Adobe XD</strong>, it needs to be installed if you want access to product logos. After XD is installed, your Adobe account needs to be switched to the <strong>Adobe for Teams</strong> plan. Contact your manager for further assistance if necessary.</p>
 
   <pfe-cta priority="secondary">
-    <a href="https://redhat.service-now.com/help?id=sc_cat_item&sys_id=488f88c3956221004c71bb9efe94def5" target="_blank">Request an Adobe for Teams plan</a>
+    <a href="https://url.corp.redhat.com/adobecc" target="_blank">Request an Adobe for Teams plan</a>
   </pfe-cta>
 
   <pfe-cta style="margin-left:32px;">


### PR DESCRIPTION
Fixes #344

## What I did

1. replace all instances of service-now urls (they were all the same) with the VPN link mark generated.