### PR TITLE
Fixes missing column in Component status table

### DIFF
--- a/docs/js/global.js
+++ b/docs/js/global.js
@@ -97,8 +97,8 @@ class RhdsComponentStatus extends HTMLElement {
           text-align: left;
         }
 
-        th:nth-child(n + 6),
-        td:nth-child(n + 6) {
+        th:nth-child(n + 7),
+        td:nth-child(n + 7) {
           display: none;
         }
 


### PR DESCRIPTION
## What I did

The WebRH column was missing in the `Component status` table, this is a fix for that