### PR TITLE
fix: Feat/dialog mp video fixes

### DIFF
--- a/elements/rh-dialog/rh-dialog.css
+++ b/elements/rh-dialog/rh-dialog.css
@@ -15,7 +15,7 @@ header ::slotted(:is(h1, h2, h3, h4, h5, h6)[slot="header"]) {
   max-width: min(90%, 1140px);
   border-radius: var(--rh-border-radius-default, 0.1875rem);
   color: var(--rh-color-text-primary-on-light, var(--rh-color-black-900, #151515));
-  font-family: inherit
+  font-family: inherit;
 }
 
 [part=content] {
@@ -52,8 +52,9 @@ header ::slotted(:is(h1, h2, h3, h4, h5, h6)[slot="header"]) {
 }
 
 :host([type=video][open]) [part=dialog] {
-  aspect-ratio: var(--rh-modal-video-aspect-ratio, 16/9);
-  max-width: 90%;
+  --_aspect-ratio: var(--rh-modal-video-aspect-ratio, 16/9);
+  aspect-ratio: var(--_aspect-ratio);
+  max-width: min(90%, calc(90vh * var(--_aspect-ratio) +  var(--offset-top)));
   padding: 0;
   margin: 0;
 }
@@ -66,8 +67,10 @@ header ::slotted(:is(h1, h2, h3, h4, h5, h6)[slot="header"]) {
 :host([type=video]) [part=content],
 :host([type=video]) ::slotted(:not([slot])) {
   aspect-ratio: var(--rh-modal-video-aspect-ratio, 16/9);
-  width: 100%;
+  /* account for a 1px descrepency between dialog and container aspect ratio */
+  width: calc(100% + 1px);
   position: absolute;
   inset: 0px;
+  max-height: none;
 }
 


### PR DESCRIPTION
## What I did

1. In Chrome and Safari there the video iframe wasn't expanding the full width of the dialog.
![Screen Shot 2022-06-12 at 12 39 48 PM](https://user-images.githubusercontent.com/3428964/173243643-425a58f8-d750-4ec6-8074-013691361c5d.png)

2. Added a calculation that prevents the video player from overflowing off the bottom of the screen.  Accounts for max-hight of the viewport and aspect ratio.
![Screen Shot 2022-06-12 at 12 40 54 PM](https://user-images.githubusercontent.com/3428964/173243856-dbe7a2f7-3536-4a2d-9777-f729dcc6a28b.png)

3. I noticed that there was an occasional 1px discrepancy between the dialog and the container of the video player so I added a 1px buffer so you don't see the background of the dialog bleed through.
 
![Screen Shot 2022-06-12 at 12 43 39 PM](https://user-images.githubusercontent.com/3428964/173243931-5c0475e3-83a8-41f0-9f73-d3ebe8d772c5.png)



## Testing Instructions

1. Visit `http://localhost:8000/demo/rh-dialog/` in Chrome or Safari
2. Open the video dialog example
3. Resize your browser between different aspect ratios to ensure the video player is completely visible at all times.
