### PR TITLE
feat: change screen size queries to min-width

### DIFF
--- a/lib/RHDSScreenSizeController.ts
+++ b/lib/RHDSScreenSizeController.ts
@@ -26,11 +26,11 @@ export class RHDSScreenSizeController implements ReactiveController {
 
   static queries = new Map<BreakpointKey, MediaQueryList>([
     ['mobile', matchMedia(`screen and (max-width: ${mobileBreakpoint})`)],
-    ['mobilePortrait', matchMedia(`screen and (max-width: ${mobilePortraitBreakpoint})`)],
-    ['mobileLandscape', matchMedia(`screen and (max-width: ${mobileLandscapeBreakpoint})`)],
-    ['tabletPortait', matchMedia(`screen and (max-width: ${tabletPortaitBreakpoint})`)],
-    ['tabletLandscape', matchMedia(`screen and (max-width: ${tabletLandscapeBreakpoint})`)],
     ['mobileXl', matchMedia(`screen and (max-width: ${mobileXlBreakpoint})`)],
+    ['mobilePortrait', matchMedia(`screen and (min-width: ${mobilePortraitBreakpoint})`)],
+    ['mobileLandscape', matchMedia(`screen and (min-width: ${mobileLandscapeBreakpoint})`)],
+    ['tabletPortait', matchMedia(`screen and (min-width: ${tabletPortaitBreakpoint})`)],
+    ['tabletLandscape', matchMedia(`screen and (min-width: ${tabletLandscapeBreakpoint})`)],
     ['desktopSmall', matchMedia(`screen and (min-width: ${mobileXlBreakpoint}) and (max-width: ${desktopSmallBreakpoint})`)],
     ['desktopLarge', matchMedia(`screen and (min-width: ${desktopLargeBreakpoint})`)],
   ]);
@@ -38,6 +38,8 @@ export class RHDSScreenSizeController implements ReactiveController {
   public mobile = RHDSScreenSizeController.queries.get('mobile')?.matches ?? false;
 
   public size: Omit<BreakpointKey, 'mobile'>;
+
+  public matches = new Set();
 
   constructor(
     /** reference to the host element using this controller */
@@ -48,6 +50,7 @@ export class RHDSScreenSizeController implements ReactiveController {
     for (const [key, list] of RHDSScreenSizeController.queries) {
       if (key !== 'mobile' && list.matches) {
         this.size = key;
+        this.matches.add(key);
       }
     }
   }
@@ -74,7 +77,10 @@ for (const [key, list] of RHDSScreenSizeController.queries) {
       for (const instance of RHDSScreenSizeController.instances) {
         if (event.matches) {
           instance.size = key;
+          instance.matches.add(key);
           instance.host.requestUpdate();
+        } else {
+          instance.matches.delete(key);
         }
       }
     });

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,13 +1,17 @@
 import { unsafeCSS } from 'lit';
 
+/* min-width mobile breakpoints */
+export const mobilePortraitBreakpoint = unsafeCSS`320px`;
+export const mobileLandscapeBreakpoint = unsafeCSS`576px`;
+/* max-width mobile breakpoints*/
 export const mobileBreakpoint = unsafeCSS`700px`;
 export const mobileXlBreakpoint = unsafeCSS`1008px`;
-export const desktopLargeBreakpoint = unsafeCSS`1368px`;
-export const desktopSmallBreakpoint = unsafeCSS`1200px`;
-export const tabletLandscapeBreakpoint = unsafeCSS`992px`;
+/* min-width tablet breakpoints */
 export const tabletPortaitBreakpoint = unsafeCSS`768px`;
-export const mobileLandscapeBreakpoint = unsafeCSS`576px`;
-export const mobilePortraitBreakpoint = unsafeCSS`320px`;
+export const tabletLandscapeBreakpoint = unsafeCSS`992px`;
+/* min-width desktop breakpoints */
+export const desktopSmallBreakpoint = unsafeCSS`1200px`;
+export const desktopLargeBreakpoint = unsafeCSS`1368px`;
 
 export const pfGlobalSpacer = {
   xs: '--pf-global--spacer--xs', // 4px


### PR DESCRIPTION
## What I did

1. Converted media queries to `min-width` based queries for standard breakpoints.  I feel this is the proper approach for responsively designed websites.  Breakpoints matching css cascading to larger sizes so that it is additive : 
```
[no-break-point] 
 ⬇️
[320px] /* mobilePortraitBreakpoint */
 ⬇️
[576px] /* mobileTabletBreakpoint */
 ⬇️
[768px] 
 ⬇️
[992px]
 ⬇️
[1200px] 
 ⬇️
etc...
```
```css

/* no breakpoint */
div {
 color: blue;
}

@media and screen(min-width: 320px) {
  /* mobilePortraitBreakpoint */
  div {
    padding: 0.5em;
  }
}

@media and screen(min-width: 576px) {
  /* mobileTabletBreakpoint */
  div {
    padding: 1em;
  }
}

etc...

```


2. Ordered tokens smallest to biggest, and added comments for what I think might be special breakpoints tokens which are based on `max-width` such as `mobile` and `mobileXL`.  
3. Added `matches` property to return all current  matching `BreakPointKey`.  Resulting in a stack such as `['mobile', 'mobilePortrait', 'mobileLandscape', 'mobileLandscape', 'tabletPortait']`  if the screen size is `< 992px` as defined in the token value: 
```
export const tabletLandscapeBreakpoint = unsafeCSS`992px`;
```

The implementation of `matches` allows you to set a class based on if a specific breakpoint is or isn't in the stack, then we know we've gone beyond the size in which the interface needs to react.

```
/* Looking for if `tabletLandscape` breakpoint has been reached. If not we add `is-mobile` to classes */
const mobile = !this.#screenSize.matches.has('tabletLandscape');
const classes = { 'is-mobile': mobile };
```

The reasoning behind this change is that the `size` attribute is only set to the current breakpoint giving nothing to base the logic of checking all matched breakpoints from if the current state returned was less than the `tabletLandscapeBreakpoint`.  Because `min-width` is additive, the `matches` will include all breakpoints that match.

This is also working around the idea of `this.mobile` in the context of the controller which is based on the max-width breakpoint value of `700px` defining what is or isn't mobile.  I'm not convinced we should have a specific definition of `mobile` at a specific breakpoint, rather being more content-specific on when things shift.  

In the case of `secondary-nav` that content specific happens under 992px per spec due to limited width for content at a smallish screen size.  Not that 992px specifies what is and what isn't `mobile`.
