### PR TITLE
fix(footer): manifest for global footer

### DIFF
--- a/elements/rh-footer/rh-global-footer.ts
+++ b/elements/rh-footer/rh-global-footer.ts
@@ -11,7 +11,6 @@ import { responsiveStyles } from './rh-footer-responsive.css.js';
 import './rh-footer-copyright.js';
 
 /**
- * @element 'rh-global-footer'
  * @csspart base
  * @csspart base
  * @slot    logo


### PR DESCRIPTION
when `@customElement` or `customElements.define` is used, there's no need for the `@element` jsdoc tag, and in fact, leaving this here corrupts the manifest.
