### PR TITLE
chore: build with typescript

### DIFF
--- a/.changeset/cool-parents-rescue.md
+++ b/.changeset/cool-parents-rescue.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": minor
+---
+
+Ship components unbundled

--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -128,8 +128,10 @@ module.exports = function(eleventyConfig) {
     [`${path.dirname(require.resolve('@patternfly/pfe-styles'))}/*.{css,css.map}`]: 'assets'
   });
 
+  // generate a bundle that packs all of rhds with all dependencies
+  // into a single large javascript file
   eleventyConfig.on('eleventy.before', async () =>
-    import('./scripts/build.js')
+    import('./scripts/bundle.js')
       .then(m => m.build({
         outfile: '_site/assets/rhds.min.js',
         external: [],

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/pfe.min*
 
 # Build artifacts
 elements/*/*.js
+lib/**/*.js
 !elements/**/demo/*.css
 *.map
 *.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rhds/elements",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@patternfly/pfe-accordion": "next",
@@ -62,7 +62,8 @@
         "sassdoc": "^2.7.4",
         "spandx": "^2.2.5",
         "stylelint": "^14.9.0",
-        "stylelint-config-sass-guidelines": "^9.0.1"
+        "stylelint-config-sass-guidelines": "^9.0.1",
+        "ttypescript": "^1.5.13"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -21314,6 +21315,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/ttypescript": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
+      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": ">=1.9.0"
+      },
+      "bin": {
+        "ttsc": "bin/tsc",
+        "ttsserver": "bin/tsserver"
+      },
+      "peerDependencies": {
+        "ts-node": ">=8.0.2",
+        "typescript": ">=3.2.2"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "dev": true,
@@ -37437,6 +37455,15 @@
             "yargs-parser": "^18.1.2"
           }
         }
+      }
+    },
+    "ttypescript": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
+      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "dev": true,
+      "requires": {
+        "resolve": ">=1.9.0"
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -39,15 +39,16 @@
     "watch:docs": "run-p watch:docs:*",
     "watch:docs:analyze": "npm run watch:analyze",
     "watch:docs:eleventy": "npm run build:docs -- --serve",
-    "watch:types": "tsc --watch",
+    "watch:compile": "ttsc --watch",
     "new": "npm init @patternfly/element",
     "-----BUILD------": "Prepare dist artifacts",
     "analyze": "cem analyze",
     "watch:analyze": "npm run analyze -- --watch",
     "build": "run-s build:*",
     "build:analyze": "npm run analyze",
-    "build:elements": "scripts/build.js",
-    "build:types": "tsc",
+    "build:compile": "ttsc",
+    "build:styles": "node scripts/transform-css.js",
+    "build:bundle": "node scripts/bundle.js",
     "build:docs": "eleventy --config=.eleventy.cjs",
     "-----TEST-------": "Test packages",
     "test": "wtr --group default",
@@ -128,6 +129,7 @@
     "sassdoc": "^2.7.4",
     "spandx": "^2.2.5",
     "stylelint": "^14.9.0",
-    "stylelint-config-sass-guidelines": "^9.0.1"
+    "stylelint-config-sass-guidelines": "^9.0.1",
+    "ttypescript": "^1.5.13"
   }
 }

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -2,10 +2,7 @@
 import { readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
-import { build as esBuild } from 'esbuild';
-import { litCssPlugin } from 'esbuild-plugin-lit-css';
 import { singleFileBuild } from '@patternfly/pfe-tools/esbuild.js';
-// import { minifyHTMLLiteralsPlugin } from 'esbuild-plugin-minify-html-literals';
 
 const external = [
   '@*',
@@ -29,43 +26,23 @@ export async function build(options) {
     `${entryPoints.reduce(toExportStatements, '')}
 ${additionalPackages.reduce(toExportStatements, '')}`;
 
-  const litCssOptions = {
-    include: /elements\/rh-(.*)\/(.*)\.css$/,
-    uglify: true,
-  };
-
   await singleFileBuild({
     componentsEntryPointContents,
     outfile: options?.outfile ?? 'rhds.min.js',
-    litCssOptions,
     allowOverwrite: true,
     external: options?.external ?? external,
     minify: false,
-  });
-
-  await esBuild({
-    entryPoints,
-    outdir: 'elements',
-    outbase: 'elements',
-    entryNames: '[dir]/[name]',
-    allowOverwrite: true,
-    bundle: true,
-    external,
-    format: 'esm',
-    sourcemap: 'linked',
-    minify: false,
-    legalComments: 'linked',
-    plugins: [
-      // BUG: https://github.com/asyncLiz/minify-html-literals/issues/37
-      // minifyHTMLLiteralsPlugin(),
-      litCssPlugin(litCssOptions),
-    ],
+    litCssOptions: {
+      include: /elements\/rh-(.*)\/(.*)\.css$/,
+      uglify: true,
+    },
   });
 }
 
 const stripExtension = x => x.replace(/\.\w+$/, '');
 const eqeqeq = (x, y) => x === y;
 
+/* eslint-env node */
 /** Was the module was run directly? */
 const INVOKED_VIA_CLI = [process.argv[1], fileURLToPath(import.meta.url)]
   .map(stripExtension) // fun with functional programming

--- a/scripts/transform-css.js
+++ b/scripts/transform-css.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/* eslint-env node */
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { transform } from '@pwrs/lit-css';
+
+import _glob from 'glob';
+const glob = promisify(_glob);
+
+export async function build() {
+  const entryPoints = await glob('./elements/**/*.css', {
+    ignore: ['./elements/**/*lightdom.css', './elements/**/demo/*.css'],
+    absolute: true,
+  });
+
+  await Promise.all(entryPoints.map(async inPath => {
+    const outPath = `${inPath}.js`;
+
+    const styleSheet = await readFile(inPath, 'utf8');
+    const result = await transform({ css: styleSheet, filePath: outPath });
+    await writeFile(outPath, result, 'utf8');
+  }));
+}
+
+const stripExtension = x => x.replace(/\.\w+$/, '');
+const eqeqeq = (x, y) => x === y;
+
+/** Was the module was run directly? */
+const INVOKED_VIA_CLI = [process.argv[1], fileURLToPath(import.meta.url)]
+  .map(stripExtension) // fun with functional programming
+  .reduce(eqeqeq);
+
+if (INVOKED_VIA_CLI) {
+  await build();
+}

--- a/transformers/css-import-specifiers.cjs
+++ b/transformers/css-import-specifiers.cjs
@@ -1,0 +1,28 @@
+// @ts-check
+const ts = require('typescript');
+
+/**
+ * Replace .css import specifiers with .css.js import specifiers
+ */
+module.exports = () =>
+  /** @param {import('typescript').TransformationContext} ctx */
+  ctx => {
+    /** @param {import('typescript').Node} node */
+    function visitor(node) {
+      if (ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) {
+        const specifier = node.moduleSpecifier.getText().replace(/^'(.*)'$/, '$1');
+        if (specifier.endsWith('.css')) {
+          return ctx.factory.createImportDeclaration(
+            node.decorators,
+            node.modifiers,
+            node.importClause,
+            ctx.factory.createStringLiteral(`${specifier}.js`)
+          );
+        }
+      }
+      return ts.visitEachChild(node, visitor, ctx);
+    }
+
+    /** @param {import('typescript').SourceFile} sourceFile */
+    return sourceFile => ts.visitEachChild(sourceFile, visitor, ctx);
+  };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,19 +10,20 @@
     "docs/**/*.js",
     "scripts/*.js",
     "elements/**/*.js",
+    "**/*.spec.ts",
+    "**/*.e2e.ts",
     "lib/**/*.js",
     "./*.config.js"
   ],
   "compilerOptions": {
-    "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "composite": true,
     "declaration": true,
     "downlevelIteration": true,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     "experimentalDecorators": true,
-    "importHelpers": false,
+    "importHelpers": true,
     "incremental": true,
     "inlineSources": true,
     "module": "es2020",
@@ -34,13 +35,14 @@
     "strict": true,
     "target": "es2020",
     "useDefineForClassFields": false,
+    "typeRoots": [
+      "./node_modules/@types",
+      "./@types"
+    ],
     "plugins": [
-      {
-        "name": "typescript-lit-html-plugin"
-      },
-      {
-        "name": "ts-lit-plugin"
-      }
+      { "transform": "./transformers/css-import-specifiers.cjs" },
+      { "name": "typescript-lit-html-plugin" },
+      { "name": "ts-lit-plugin" }
     ],
     "lib": [
       "DOM.iterable",


### PR DESCRIPTION
esbuild has [difficulty](https://github.com/evanw/esbuild/issues/708) with cases like "bundle these entry points, but don't bundle these specific files, treat them as separate imports, and don't bundle them into any other files that import them". This makes it hard to load `rh-gllobal-footer.js` separately.

Closes #429 
See https://github.com/RedHat-UX/red-hat-design-system/discussions/420#discussioncomment-3174377 (nice)
cc @eyevana

## What I did

1. This commit replaces the per-element esbuild builds with a typescript build that uses a
[typescript transform](https://npm.im/ttypescript) to replace import specifiers ending with `css` with `css.js`, 
2. uses the node filesystem api to directly build shadow DOM css into their own javascript modules.

## Testing Instructions

```
npm run build
```

check that the build is sane, try copying it into a separate node project and see that it works as expected. check that 11ty builds as expected