### PR TITLE
chore: add lib directory to npm package

### DIFF
--- a/.changeset/nervous-walls-love.md
+++ b/.changeset/nervous-walls-love.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Include lib directory in npm package

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "!elements/*/docs/**/*.{js,html,css,md}",
     "!elements/*/demo/**/*.{js,html,css,md}",
     "!elements/*/test/*.{spec,e2e}.{ts,d.ts}",
+    "lib/*.{js,md,map,txt,d.ts}",
     "custom-elements.json",
     "rhds.min*"
   ],


### PR DESCRIPTION
## What I did

1. Added lib directory to `package.json` files block


## Notes to Reviewers
I was unsure if I needed to run `npm i --package-lock-only` to update the package-lock.json.  I don't believe the files block is referenced there.  