### PR TITLE
fix(secondary-nav): css style fixes

### DIFF
--- a/.changeset/sharp-frogs-sing.md
+++ b/.changeset/sharp-frogs-sing.md
@@ -1,0 +1,7 @@
+---
+"@rhds/elements": patch
+---
+
+* Fixes missing font-family stacks when base css isn't applied
+* Adds rh-token CSS custom properties for font family stacks
+* Fixes regression in spacing for slotted cta

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -7,6 +7,7 @@ rh-secondary-nav {
   box-shadow: var(--rh-box-shadow-sm, 0 0.125em 0.25em 0 rgba(21, 21, 21, 0.2));
   height: 4.625em;
   font-size: initial;
+  font-family: var(--rh-font-family-body-text, 'Red Hat Text', 'RedHatText', 'Overpass', Overpass, Arial, sans-serif);
 
   --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-light, #151515);
   --_rh-secondary-nav-logo-link-color: var(--rh-color-text-primary-on-light, #151515);
@@ -50,7 +51,6 @@ rh-secondary-nav > [slot="logo"] {
   display: flex;
   align-items: center;
   height: 100%;
-  font-family: 'Red Hat Display', Arial, sans-serif;
   color: var(--_rh-secondary-nav-logo-link-color);
   max-width:  var(--rh-secondary-nav-logo-max-width, 10em);
   text-decoration: none;
@@ -58,7 +58,7 @@ rh-secondary-nav > [slot="logo"] {
   letter-spacing: 0.01125em;
   line-height: 1.6875em;
   margin-inline-start: 1em;
-  font-family: 'Red Hat Display', Arial, sans-serif;
+  font-family: var(--rh-font-family-heading, "RedHatDisplay", "Overpass", Overpass, Helvetica, Arial, sans-serif);
   font-weight: 500;
 }
 
@@ -217,7 +217,6 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
 
   rh-secondary-nav > [slot="logo"] {
     margin-inline-start: 2em;
-    line-height: 1.4em;
   }
 
   rh-secondary-nav > [slot="cta"] {

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu-section.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu-section.css
@@ -6,6 +6,10 @@
   padding: 0;
 }
 
+::slotted(:is(h1,h2,h3,h4,h5,h6)) {
+  font-family: var(--rh-font-family-heading, "RedHatDisplay", "Overpass", Overpass, Helvetica, Arial, sans-serif) !important;
+}
+
 ::slotted([slot="links"]:is(ul, ol)) {
   list-style: none;
   margin: 0;

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -138,11 +138,11 @@ button[aria-expanded="true"],
   }
 
   #container.expanded ::slotted([slot="nav"]) {
-    padding: 2em 2em 0 2em;
+    padding: 2em 2em 0 2em !important;
   }
 
   #container.expanded ::slotted([slot="cta"]) {
-    padding: 2em;
+    padding: 2em !important;
   }
 }
 
@@ -150,10 +150,6 @@ button[aria-expanded="true"],
   #container {
     grid-template-areas: 'logo nav cta';
     grid-template-columns: max-content 1fr max-content;
-  }
-
-  #container.expanded ::slotted([slot="cta"]) {
-    padding: 1em;
   }
 
   button {


### PR DESCRIPTION
## What I did

1.  Fixed missing font-family stacks when base css isn't applied
2.  Added rh-token CSS custom properties for font family stacks
3.  Fixed regression in spacing for slotted cta


