### PR TITLE
fix: added max-height to logo

### DIFF
--- a/.changeset/kind-suits-speak.md
+++ b/.changeset/kind-suits-speak.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Add max-height to footer logo

--- a/.changeset/kind-suits-speak.md
+++ b/.changeset/kind-suits-speak.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-Add max-height to footer logo
+Footer: Main footer logo fills height first

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -1,6 +1,12 @@
 /* ensure links fully wrap img tags */
 :is(rh-footer, rh-global-footer) a[slot^=logo] {
   display: block;
+  height: 36px;
+}
+
+:is(rh-footer) a[slot^=logo] > img {
+  width: auto;
+  height: 100%;
 }
 
 rh-footer [slot^=links] a {

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -179,12 +179,6 @@ pfe-accordion {
   line-height: 0px;
 }
 
-.logo slot::slotted(a),
-.logo a {
-  display: inline-flex;
-  width: 9.75em;
-}
-
 .social-links {
   display: flex;
   margin-inline-start: 0;


### PR DESCRIPTION
## What I did

1. Fixes #462
2. Added logo styles to lightdom to minimize layout shift.


## Testing Instructions

1. Visit https://deploy-preview-463--red-hat-design-system.netlify.app/components/footer/demo/
2. Replace the Red Hat logo with a partner logo by pasting the following code in the your browser console.
```
document.querySelector("rh-footer [slot=logo] img").setAttribute('src', 'https://catalog.redhat.com/img/svg/logo.svg')
```
3. Verify that the logo is 36px tall

## Screenshot

![Screen Shot 2022-08-09 at 5 49 47 PM](https://user-images.githubusercontent.com/3428964/183769054-b4e8f1e7-cde9-4e4b-a3b7-5096bcdcdce1.png)

