### PR TITLE
refactor(secondary-nav)!: add color context and dir controller

### DIFF
--- a/.changeset/smooth-rats-care.md
+++ b/.changeset/smooth-rats-care.md
@@ -5,3 +5,4 @@
 - BREAKING: removes variant styles replace with `@colorContextProvider` and the color-palette property
 - replaces `#textDirection` method with `DirController` implementation for rtl support
 - updates documentation
+- add color-palette spec test

--- a/.changeset/smooth-rats-care.md
+++ b/.changeset/smooth-rats-care.md
@@ -2,7 +2,7 @@
 "@rhds/elements": patch
 ---
 
-- BREAKING: removes variant styles replace with `@colorContextProvider` and the color-palette property
-- replaces `#textDirection` method with `DirController` implementation for rtl support
-- updates documentation
-- add color-palette spec test
+Changes to `<rh-secondary-nav>`:
+  - **BREAKING**: replaces `variant="dark"` attribute with `color-palette="darker"`
+  - replaces internal `#textDirection` method with `DirController` implementation for consistent RTL support
+  - updates documentation

--- a/.changeset/smooth-rats-care.md
+++ b/.changeset/smooth-rats-care.md
@@ -1,0 +1,7 @@
+---
+"@rhds/elements": patch
+---
+
+- BREAKING: removes variant styles replace with `@colorContextProvider` and the color-palette property
+- replaces `#textDirection` method with `DirController` implementation for rtl support
+- updates documentation

--- a/elements/rh-secondary-nav/README.md
+++ b/elements/rh-secondary-nav/README.md
@@ -199,7 +199,7 @@ Please [open a discussion thread](https://github.com/orgs/RedHat-UX/discussions/
 | Name | Value | Description | Required | Example |
 |------|-------|-------------|----------|---------| 
 | **role** | navigation | Ensures an accessible experience before or on failed upgrade | Yes |  `<rh-secondary-nav role="navigation">` |
-
+| **color-palette** | "lighter" (default),  "darker" | Sets the color theme for the navigation | No | `<rh-secondary-nav color-palette="darker">` |
 
 ### CSS Parts
 | Name | Description |

--- a/elements/rh-secondary-nav/demo/dark-variant.html
+++ b/elements/rh-secondary-nav/demo/dark-variant.html
@@ -5,7 +5,7 @@
 <div class="mock-nav"></div>
 <rh-secondary-nav color-palette="darker" role="navigation" main>
   <a href="#" slot="logo" id="logo-id">
-    Red Hat Advanced Cluster Managment for Kubernetes
+    Red Hat Advanced Cluster Management for Kubernetes
   </a>
   <ul slot="nav" aria-labelledby="logo-id">
     <li>
@@ -66,7 +66,7 @@
     </li>
     <li>
       <rh-secondary-nav-dropdown>
-        <a href="#" slot="link">Other ex.</a>
+        <a href="#" slot="link">Other examples</a>
         <rh-secondary-nav-menu slot="menu">
           <pfe-card>
             <h2 slot="header">Hello world</h2>
@@ -165,7 +165,6 @@
     <a href="#">Get started</a>
   </rh-cta>
 </rh-secondary-nav>
-
 <div class="space-holder">
   <pfe-band size="large" color-palette="darkest">
     <h2 slot="header">Content Placeholder</h2>

--- a/elements/rh-secondary-nav/demo/dark-variant.html
+++ b/elements/rh-secondary-nav/demo/dark-variant.html
@@ -3,7 +3,7 @@
 <script type="module" src="rh-secondary-nav.js"></script>
 
 <div class="mock-nav"></div>
-<rh-secondary-nav variant="dark" role="navigation" main>
+<rh-secondary-nav color-palette="darker" role="navigation" main>
   <a href="#" slot="logo" id="logo-id">
     Red Hat Advanced Cluster Managment for Kubernetes
   </a>

--- a/elements/rh-secondary-nav/demo/proxy.html
+++ b/elements/rh-secondary-nav/demo/proxy.html
@@ -180,7 +180,7 @@
 </template>
 
 <template id="rh-secondary-nav-spandx-template-dark">
-  <rh-secondary-nav variant="dark" role="navigation">
+  <rh-secondary-nav color-palette="darker" role="navigation">
     <a href="#" slot="logo" id="logo-id">
       Red Hat Ansible Automation Platform
     </a>

--- a/elements/rh-secondary-nav/rh-secondary-nav-dropdown.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav-dropdown.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from 'lit';
-import { customElement, state, query } from 'lit/decorators.js';
+import { customElement, state, query, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import { ComposedEvent } from '@patternfly/pfe-core';
@@ -7,6 +7,8 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 import { bound, observed } from '@patternfly/pfe-core/decorators.js';
 import { SlotController } from '@patternfly/pfe-core/controllers/slot-controller.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
+
+import { colorContextProvider } from '../../lib/context/color.js';
 
 import { RhSecondaryNavMenu } from './rh-secondary-nav-menu.js';
 
@@ -45,6 +47,9 @@ export class RhSecondaryNavDropdown extends LitElement {
 
   @observed
   @state() expanded = false;
+
+  @colorContextProvider()
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette = 'lighter';
 
   connectedCallback(): void {
     super.connectedCallback();

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -227,17 +227,6 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
     padding: unset;
   }
 
-  /* rh-secondary-nav[color-palette="dark"] > [slot="cta"] {
-    --rh-cta-color: var(--rh-context-dark-color-text-link, #73BCF7);
-    --rh-cta-hover-color: var(--rh-context-dark-color-text-link-hover, #bee1f4);
-    --rh-cta-hover-color: var(--rh-context-dark-color-text-link-focus, #bee1f4);
-  } */
-
-  /* rh-secondary-nav[color-palette="dark"] > [slot="cta"]:hover,
-  rh-secondary-nav[color-palette="dark"] > [slot="cta"]:focus  {
-    --rh-cta-color: var(--rh-context-dark-color-text-link-hover, #bee1f4);
-  } */
-
   @media screen and (min-width: 1440px) {
     rh-secondary-nav:not(:defined) > [slot="logo"],
     rh-secondary-nav > [slot="logo"] {

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -24,7 +24,7 @@ rh-secondary-nav:not(:defined) {
   position: relative;
 }
 
-rh-secondary-nav[variant="dark"] {
+rh-secondary-nav[color-palette="darker"] {
   background-color: var(--rh-color-surface-dark, #3C3F42);
   border-block-end-color: var(--rh-color-border-subtle-on-dark, #6A6E73);
   box-shadow: none;
@@ -100,9 +100,9 @@ rh-secondary-nav-menu:not(:defined) {
   display: none;
 }
 
-rh-secondary-nav[variant="dark"] > [slot="cta"] {
+/* rh-secondary-nav[color-palette="dark"] > [slot="cta"] {
   --rh-cta-color: unset;
-}
+} */
 
 /* Top level links, styles are owned by lightdom elements */
 rh-secondary-nav > [slot="nav"] > li > a,
@@ -164,12 +164,12 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
     grid-template-rows: 4.625em max-content max-content;
   }
 
-  rh-secondary-nav[variant="dark"]  {
+  rh-secondary-nav[color-palette="darker"]  {
     --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-dark, #FFFFFF);
     --_rh-secondary-nav-chevron-color: var(--rh-color-text-primary-on-dark, #FFFFFF);
   }
 
-  rh-secondary-nav[variant="dark"] rh-secondary-nav-dropdown > a[aria-expanded="true"] {
+  rh-secondary-nav[color-palette="darker"] rh-secondary-nav-dropdown > a[aria-expanded="true"] {
     --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-light, #151515);
     --_rh-secondary-nav-chevron-color: var(--rh-color-text-primary-on-light, #151515);
     color: var(--_rh-secondary-nav-nav-link-color);
@@ -227,16 +227,16 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
     padding: unset;
   }
 
-  rh-secondary-nav[variant="dark"] > [slot="cta"] {
+  /* rh-secondary-nav[color-palette="dark"] > [slot="cta"] {
     --rh-cta-color: var(--rh-context-dark-color-text-link, #73BCF7);
     --rh-cta-hover-color: var(--rh-context-dark-color-text-link-hover, #bee1f4);
     --rh-cta-hover-color: var(--rh-context-dark-color-text-link-focus, #bee1f4);
-  }
+  } */
 
-  rh-secondary-nav[variant="dark"] > [slot="cta"]:hover,
-  rh-secondary-nav[variant="dark"] > [slot="cta"]:focus  {
+  /* rh-secondary-nav[color-palette="dark"] > [slot="cta"]:hover,
+  rh-secondary-nav[color-palette="dark"] > [slot="cta"]:focus  {
     --rh-cta-color: var(--rh-context-dark-color-text-link-hover, #bee1f4);
-  }
+  } */
 
   @media screen and (min-width: 1440px) {
     rh-secondary-nav:not(:defined) > [slot="logo"],

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -1,4 +1,11 @@
 :host {
+  --_chevron-size: 0.35em;
+  --_chevron-thickness: 0.125em;
+  --_chevron-up-angle: 45deg;
+  --_chevron-down-angle: -135deg;
+  --_chevron-color:  var(--rh-color-text-primary-on-light, #151515);
+  --_chevron-transform-collapsed: rotate(var(--_chevron-up-angle)) translate(calc(-1 * var(--_chevron-size)), var(--_chevron-thickness));
+  --_chevron-transform-expanded: rotate(var(--_chevron-down-angle)) translate(var(--_chevron-thickness), calc(var(--_chevron-inverse, -1) * var(--_chevron-size)));
   --_button-font-color:  var(--rh-color-text-primary-on-light, #151515);
   --_nav-height: 4.625em;
 
@@ -11,12 +18,6 @@
 }
 
 nav {
-  --_chevron-size: 0.35em;
-  --_chevron-thickness: 0.125em;
-  --_chevron-color:  var(--rh-color-text-primary-on-light, #151515);
-  --_chevron-transform-collapsed: rotate(var(--_chevron-up-angle, 45deg)) translate(calc(-1 * var(--_chevron-size)), var(--_chevron-thickness));
-  --_chevron-transform-expanded: rotate(var(--_chevron-down-angle, -135deg)) translate(var(--_chevron-thickness), calc(var(--_chevron-inverse, -1) * var(--_chevron-size)));
-
   position: relative;
   height: 100%;
   z-index: var(--rh-secondary-nav-z-index, 102);

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -1,24 +1,32 @@
 :host {
-  z-index: var(--rh-secondary-nav-z-index, 102);
-
-  --_chevron-size: 0.35em;
-  --_chevron-thickness: 0.125em;
-  --_chevron-color:  var(--rh-color-text-primary-on-light, #151515);
-  --_chevron-transform-collapsed: rotate(var(--_chevron-up-angle, 45deg)) translate(calc(-1 * var(--_chevron-size)), var(--_chevron-thickness));
-  --_chevron-transform-expanded: rotate(var(--_chevron-down-angle, -135deg)) translate(var(--_chevron-thickness), calc(var(--_chevron-inverse, -1) * var(--_chevron-size)));
   --_button-font-color:  var(--rh-color-text-primary-on-light, #151515);
   --_nav-height: 4.625em;
+
+  z-index: var(--rh-secondary-nav-z-index, 102);
 }
 
-:host([variant="dark"]) {
+:host([color-palette="darker"]) {
   --_button-font-color:  var(--rh-color-text-primary-on-dark, #FFFFFF);
   --_chevron-color:  var(--rh-color-text-primary-on-dark, #FFFFFF);
 }
 
 nav {
+  --_chevron-size: 0.35em;
+  --_chevron-thickness: 0.125em;
+  --_chevron-color:  var(--rh-color-text-primary-on-light, #151515);
+  --_chevron-transform-collapsed: rotate(var(--_chevron-up-angle, 45deg)) translate(calc(-1 * var(--_chevron-size)), var(--_chevron-thickness));
+  --_chevron-transform-expanded: rotate(var(--_chevron-down-angle, -135deg)) translate(var(--_chevron-thickness), calc(var(--_chevron-inverse, -1) * var(--_chevron-size)));
+
   position: relative;
   height: 100%;
   z-index: var(--rh-secondary-nav-z-index, 102);
+}
+
+nav.rtl {
+  --_chevron-up-angle: -45deg;
+  --_chevron-down-angle: 135deg;
+  --_chevron-transform-collapsed: rotate(var(--_chevron-up-angle)) translate(var(--_chevron-thickness), calc(-1 * var(--_chevron-thickness)));
+  --_chevron-transform-expanded: rotate(var(--_chevron-down-angle)) translate(var(--_chevron-thickness), calc(-1 * var(--_chevron-thickness)));
 }
 
 #container {
@@ -38,7 +46,7 @@ nav {
   --_chevron-color:  var(--rh-color-text-primary-on-light, #151515);
 }
 
-:host([variant="dark"]) #container {
+:host([color-palette="darker"]) #container {
   background-color: var(--rh-color-surface-dark, #3C3F42);
 }
 
@@ -107,24 +115,24 @@ button:focus {
   border-block-start-color: var(--rh-color-text-brand-on-light, #ee0000);
 }
 
-:host([variant="dark"]) button {
+:host([color-palette="dark"]) button {
   background-color: var(--rh-color-surface-dark, #3C3F42);
 }
 
 button:active,
 button[aria-expanded="true"],
-:host([variant="dark"]) button[aria-expanded="true"]  {
+:host([color-palette="darker"]) button[aria-expanded="true"]  {
   color: var(--rh-color-text-primary-on-light, #151515);
   background-color: var(--rh-color-surface-lightest, #FFFFFF);
   border-block-start-color: var(--rh-color-text-brand-on-light, #ee0000);
   border-block-end: none;
 }
 
-:host([variant="dark"]) button:active {
+:host([color-palette="darker"]) button:active {
   color: var(--rh-color-text-primary-on-dark, #FFFFFF);  
 }
 
-:host([variant="dark"]) button[aria-expanded="true"]:active {
+:host([color-palette="darker"]) button[aria-expanded="true"]:active {
   color: var(--rh-color-text-primary-on-light, #151515);
 }
 

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -13,7 +13,14 @@ import type { RhSecondaryNavOverlay } from './rh-secondary-nav-overlay.js';
 import { SecondaryNavOverlayChangeEvent } from './rh-secondary-nav-overlay.js';
 import { RhSecondaryNavDropdown, SecondaryNavDropdownExpandEvent } from './rh-secondary-nav-dropdown.js';
 
+import { DirController } from '../../lib/DirController.js';
 import { ScreenSizeController } from '../../lib/ScreenSizeController.js';
+import { colorContextProvider } from '../../lib/context/color.js';
+
+export type NavPalette = (
+  | 'lighter'
+  | 'darker'
+);
 
 import styles from './rh-secondary-nav.css';
 
@@ -42,6 +49,9 @@ export class RhSecondaryNav extends LitElement {
   #logger = new Logger(this);
 
   #logoCopy: HTMLElement | null = null;
+
+  /** Is the element in an RTL context? */
+  #dir = new DirController(this);
 
   /**
    * executes this.shadowRoot.querySelector('rh-secondary-nav-overlay')
@@ -92,6 +102,10 @@ export class RhSecondaryNav extends LitElement {
    */
   @property({ reflect: true, attribute: 'main', type: Boolean }) mainNav = false;
 
+
+  @colorContextProvider()
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
+
   /**
    * Checks if passed in element is a RhSecondaryNavDropdown
    * @param element:
@@ -108,8 +122,6 @@ export class RhSecondaryNav extends LitElement {
     this.addEventListener('focusout', this._focusOutHandler);
     this.addEventListener('keydown', this._keyboardControls);
     this.#updateAccessibility();
-    await this.updateComplete;
-    this.#textDirection();
   }
 
   firstUpdated() {
@@ -118,7 +130,7 @@ export class RhSecondaryNav extends LitElement {
   }
 
   render() {
-    const navClasses = { 'compact': this._compact };
+    const navClasses = { compact: this._compact, rtl: this.#dir.dir === 'rtl' };
     const containerClasses = { 'expanded': this._mobileMenuExpanded };
     return html`
       <nav part="nav" class="${classMap(navClasses)}" aria-label="${this.#setNavOrder()}">
@@ -399,23 +411,12 @@ export class RhSecondaryNav extends LitElement {
    * Toggles the mobile menu from `@click` of the _mobileMenuButton
    */
   #toggleMobileMenu() {
-    if (!this._mobileMenuExpanded) {
-      this._mobileMenuExpanded = true;
-      this.dispatchEvent(new SecondaryNavOverlayChangeEvent(true, this));
-    } else {
+    if (this._mobileMenuExpanded) {
       this._mobileMenuExpanded = false;
-      this.dispatchEvent(new SecondaryNavOverlayChangeEvent(false, this));
+    } else {
+      this._mobileMenuExpanded = true;
     }
-  }
-
-  #textDirection(): void {
-    const direction = this.closest('[dir]')?.getAttribute('dir');
-    if (direction === 'rtl') {
-      this._nav?.style.setProperty('--_chevron-up-angle', '-45deg');
-      this._nav?.style.setProperty('--_chevron-down-angle', '135deg');
-      this._nav?.style.setProperty('--_chevron-transform-collapsed', 'rotate(var(--_chevron-up-angle)) translate(var(--_chevron-thickness), calc(-1 * var(--_chevron-thickness)))');
-      this._nav?.style.setProperty('--_chevron-transform-expanded', 'rotate(var(--_chevron-down-angle)) translate(var(--_chevron-thickness), calc(-1 * var(--_chevron-thickness)))');
-    }
+    this.dispatchEvent(new SecondaryNavOverlayChangeEvent(this._mobileMenuExpanded, this));
   }
 
   /**

--- a/elements/rh-secondary-nav/test/fixtures.ts
+++ b/elements/rh-secondary-nav/test/fixtures.ts
@@ -87,7 +87,7 @@ export const NAV = html`
 `;
 
 export const DARKVARIANT = html`
-<rh-secondary-nav role="navigation" variant="dark">
+<rh-secondary-nav role="navigation" color-palette="darker">
   <a href="#" slot="logo">Red Hat Ansible Automation Platform</a>
   <ul slot="nav">
     <li>

--- a/elements/rh-secondary-nav/test/rh-secondary-nav.spec.ts
+++ b/elements/rh-secondary-nav/test/rh-secondary-nav.spec.ts
@@ -1,4 +1,4 @@
-import { expect, fixture, aTimeout, oneEvent } from '@open-wc/testing';
+import { expect, assert, fixture, aTimeout, oneEvent } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 
 import { RhSecondaryNav } from '../rh-secondary-nav.js';
@@ -6,7 +6,7 @@ import { RhSecondaryNavDropdown } from '../rh-secondary-nav-dropdown';
 import { SecondaryNavDropdownExpandEvent } from '../rh-secondary-nav-dropdown.js';
 import { RhSecondaryNavOverlay } from '../rh-secondary-nav-overlay';
 
-import { NAV } from './fixtures';
+import { DARKVARIANT, NAV } from './fixtures';
 
 function isDesktop() {
   const matches = !!window.matchMedia('(min-width: 992px)').matches;
@@ -36,6 +36,10 @@ describe('<rh-secondary-nav>', async function() {
 
   it('should remove role="navigation" after upgrade', async function() {
     expect(element.hasAttribute('role')).to.be.false;
+  });
+
+  it('should by default set color-palette="lighter"', async function() {
+    expect(element.getAttribute('color-palette') === 'lighter').to.be.true;
   });
 
   it('should have an overlay set to hidden after upgrade', async function() {
@@ -198,6 +202,24 @@ describe('<rh-secondary-nav>', async function() {
           });
         });
       });
+    });
+  });
+
+  describe('color-palette darker', function() {
+    beforeEach(async function() {
+      element = await fixture<RhSecondaryNav>(DARKVARIANT);
+      await element.updateComplete;
+      await aTimeout(150);
+    });
+
+    it('should have a dark themed menu bar', async function() {
+      expect(element.getAttribute('color-palette') === 'darker').to.be.true;
+      const container = element.shadowRoot?.querySelector('#container');
+      if (container) {
+        expect(getComputedStyle(container).getPropertyValue('background-color')).to.be.equal('rgb(60, 63, 66)');
+      } else {
+        assert.fail('container', 'null', 'No container found, did element upgrade?');
+      }
     });
   });
 });


### PR DESCRIPTION
## What I did

1.  BREAKING: added color context provider decorators in place of variant attribute styling.
2. Replaced `#textDirection` method with `DirController` implementation for rtl support
3. Updated documentation to reflect changes
4. Added spec test for color-palette attribute


## Testing Instructions

1. Locally test

## Notes to Reviewers

1.  View changes on dark variant demo page.   This page will not yet work on ux. deploy previews
