### PR TITLE
Add design tokens to rh-blockquote

### DIFF
--- a/.changeset/tough-apes-doubt.md
+++ b/.changeset/tough-apes-doubt.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Blockquote: Add design tokens to rh-blockquote's css files

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -1,16 +1,16 @@
 :host {
-  color: #151515;
+  color: var(--rh-color-black-900, #151515);
   margin: 0 auto;
   text-align: left;
   background-color: var(--rh-element-background-color);
-  font-size: 18px;
-  font-family: 'Red Hat Display', 'RedHatDisplay','Overpass', Overpass, Arial, sans-serif;
-  line-height: 1.5;
+  font-size: var(--rh-font-size-body-text-lg, 2.25rem);
+  font-family: var(--rh-font-family-heading, "RedHatDisplay","Overpass",Overpass,Helvetica,Arial,sans-serif);
+  line-height: var(--rh-line-height-body-text, 1.5);
 }
 
 @media (min-width: 700px) {
   :host{
-    font-size: 20px;
+    font-size: var(--rh-font-size-body-text-xl, 2.5rem);
   }
 }
 
@@ -23,9 +23,9 @@ blockquote ::slotted(p) {
 }
 
 figcaption {
-  color: #6A6E73;
-  font-family: 'Red Hat Text', 'RedHatText', 'Overpass', Overpass, Arial, sans-serif;
-  font-size: 14px;
+  color: var(--rh-color-black-600, #6a6e73);
+  font-family: var(--rh-font-family-text, "RedHatText","Overpass",Overpass,Helvetica,Arial,sans-serif);
+  font-size: var(--rh-font-size-body-text-sm, 1.5rem);
 }
 
 figcaption p {
@@ -46,12 +46,12 @@ svg {
 
 :host([size='large']) {
   font-size: 24px;
-  line-height: 1.3;
+  line-height: var(--rh-line-height-heading, 1.3);
 }
 
 @media (min-width: 700px) {
   :host([size='large']) {
-    font-size: 28px;
+    font-size: var(--rh-font-size-heading-md, 1.75rem);
   }
 }
 

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -19,7 +19,7 @@ blockquote {
 }
 
 blockquote ::slotted(p) {
-  margin: 16px 0;
+  margin: var(--rh-length-md, 1.0rem) 0;
 }
 
 figcaption {
@@ -37,7 +37,7 @@ figcaption p {
 }
 
 svg {
-  color: #e00;
+  color: var(--rh-color-brand-red-500, #ee0000);
 }
 
 :host([align='center']) {
@@ -45,7 +45,7 @@ svg {
 }
 
 :host([size='large']) {
-  font-size: 24px;
+  font-size: var(--rh-font-size-body-text-2xl, 2.5rem);
   line-height: var(--rh-line-height-heading, 1.3);
 }
 
@@ -63,17 +63,17 @@ svg {
 
 :host([highlight]) figure {
   border-inline-start: var(--BorderWidth) var(--BorderStyle) var(--BorderColor);
-  padding-inline-start: 24px;
+  padding-inline-start: var(--rh-length-lg, 1.5rem);
 }
 
 :host([color-palette='darkest']) {
-  color: #fff;
+  color: var(--rh-color-white, #ffffff);
 }
 
 :host([color-palette='darkest']) svg {
-  color: #f33;
+  color: var(--rh-color-brand-red-400, #ff3333);
 }
 
 :host([color-palette='darkest']) figcaption {
-  color: #d2d2d2;
+  color: var(--rh-color-black-300, #d2d2d2);
 }


### PR DESCRIPTION
## What I did

1. Replaced hardcoded values with design tokens.

## Testing Instructions

1. Check that Blockquote still renders as expected.

## Notes to Reviewers

We have a few one off values currently in Blockquote that aren't in our tokens. 
- Author is body text with a weight of 500
- The left highlight border is 8px
- The left highlight border color is #43ADAF
