### PR TITLE
fix (footer): add em based tokens example

### DIFF
--- a/elements/rh-footer/RhFooter.ts
+++ b/elements/rh-footer/RhFooter.ts
@@ -158,7 +158,7 @@ export class RhFooter extends LitElement {
       <slot name="links"></slot>
       ` : html`
       <pfe-accordion on="dark" color-palette="darkest">${children.map((child, index) => staticHtml`
-        <pfe-accordion-${unsafeStatic(child.type)} part="links-accordion-${unsafeStatic(child.type)}">
+        <pfe-accordion-${unsafeStatic(child.type)} part="links-accordion-${child.type}">
           <slot name="links-${index}"></slot>
          </pfe-accordion-${unsafeStatic(child.type)}>`)}
       </pfe-accordion>

--- a/elements/rh-footer/RhFooter.ts
+++ b/elements/rh-footer/RhFooter.ts
@@ -59,7 +59,6 @@ function isHeader(tagName: string) {
  * @cssprop --rh-footer-border-color - {@default #6a6e73}
  * @cssprop --rh-footer-accent-color - {@default #e00}
  * @cssprop --rh-footer-section-side-gap - {@default 32px}
- * @cssprop --rh-footer-links-column-gap - {@default 32px}
  * @cssprop --rh-footer-links-gap - {@default 8px}
  * @cssprop --rh-footer-link-header-font-size - {@default 0.875em}
  */

--- a/elements/rh-footer/RhFooter.ts
+++ b/elements/rh-footer/RhFooter.ts
@@ -44,8 +44,12 @@ function isHeader(tagName: string) {
  * @csspart social-links - social links container `<rh-footer-links>`
  * @slot    main - main footer content. Overrides `main-*`
  * @csspart main - main content container.
- * @slot    main-primary - main footer links. typically a columnar grid
+ * @slot    main-primary - main footer region. typically a columnar grid
  * @csspart main-primary - container for main footer links
+ * @slot    links - main footer links
+ * @csspart links - container for main footer links
+ * @csspart links-accordion-header - mobile links accordion header element
+ * @csspart links-accordion-panel - mobile links panel container element
  * @slot    main-secondary - typically contains prose or promotional content
  * @csspart main-secondary - container fro prose or promotional content
  * @slot    global - must contain `<rh-global-footer>`
@@ -155,7 +159,7 @@ export class RhFooter extends LitElement {
       <slot name="links"></slot>
       ` : html`
       <pfe-accordion on="dark" color-palette="darkest">${children.map((child, index) => staticHtml`
-        <pfe-accordion-${unsafeStatic(child.type)}>
+        <pfe-accordion-${unsafeStatic(child.type)} part="links-accordion-${unsafeStatic(child.type)}">
           <slot name="links-${index}"></slot>
          </pfe-accordion-${unsafeStatic(child.type)}>`)}
       </pfe-accordion>

--- a/elements/rh-footer/demo/proxy.html
+++ b/elements/rh-footer/demo/proxy.html
@@ -1,14 +1,17 @@
 <link href="/elements/rh-footer/rh-footer-lightdom.css" rel="stylesheet">
 </link>
 <style>
-:root {
-  --rh-font-size-text-xl: 1.125em;
-  --rh-line-height-body-text: 150%;
-  --rh-font-size-body-text-xs: 0.75em;
-  --rh-font-size-body-text-sm: 0.875em;
-  --rh-font-size-code-xs: 0.75em;
-  --rh-footer-link-header-mobile-font-size: 0.875em;
-}
+  :root {
+    --rh-font-size-text-xl: 1.125em;
+    --rh-line-height-body-text: 150%;
+    --rh-font-size-body-text-xs: 0.75em;
+    --rh-font-size-body-text-sm: 0.875em;
+    --rh-font-size-code-xs: 0.75em;
+    --rh-footer-link-header-mobile-font-size: 0.875em;
+  }
+  rh-footer::part(links-accordion-header) {
+    --rh-footer-link-header-font-size: 0.875em;
+  }
 </style>
 <script type="module">
   import '@rhds/elements/rh-cta/rh-cta.js';

--- a/elements/rh-footer/demo/proxy.html
+++ b/elements/rh-footer/demo/proxy.html
@@ -1,5 +1,18 @@
 <link href="/elements/rh-footer/rh-footer-lightdom.css" rel="stylesheet">
 </link>
+<style>
+:root {
+  --rh-font-size-text-xl: 1.125em;
+  --rh-line-height-body-text: 150%;
+  --rh-font-size-body-text-xs: 0.75em;
+  --rh-font-size-body-text-sm: 0.875em;
+  --rh-font-size-code-xs: 0.75em;
+  --rh-footer-link-header-mobile-font-size: 0.875em;
+}
+</style>
+<script type="module">
+  import '@rhds/elements/rh-cta/rh-cta.js';
+</script>
 <template id="rh-footer-spandx-template">
   <rh-footer>
     <a slot="logo" href="/en">

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -206,6 +206,10 @@ pfe-accordion {
   display: contents;
 }
 
+.isMobile .links {
+  --rh-footer-link-header-font-size: var(--rh-footer-link-header-mobile-font-size, var(--rh-font-size-body-text-lg, 1.125rem));
+}
+
 .isMobile .links ::slotted(ul) {
   --rh-footer-link-font-size: 1em;
 

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -215,15 +215,16 @@ pfe-accordion {
 
   display: grid;
   grid-template-columns: 1fr;
-  gap: calc(var(--rh-footer-links-column-gap, var(--rh-space-2xl, 32px)) / 2);
+  gap: calc(var(--rh-space-2xl, 32px) / 2);
 }
 
 [part="base"]:not(.isMobile) .links {
   display: grid;
   grid-template-columns: repeat(1fr, 25%);
   grid-template-rows: repeat(2, min-content auto);
-  gap: var(--rh-footer-links-column-gap, var(--rh-space-2xl, 32px));
   grid-auto-columns: minmax(0, 1fr);
+  row-gap: var(--rh-space-lg, 16px);
+  column-gap: var(--rh-space-2xl, 32px);
   grid-auto-flow: column;
 }
 
@@ -308,15 +309,9 @@ pfe-accordion {
 }
 
 [part="base"]:not(.isMobile) .links ::slotted(ul) {
-  gap: var(--rh-footer-links-gap, var(--rh-space-md, 8px));
+  gap: var(--rh-footer-links-gap, var(--rh-space-lg, 16px));
   display: flex;
   flex-direction: column;
-  margin-block-start:
-    calc(
-      var(--rh-footer-links-column-gap, var(--rh-space-2xl, 32px))
-      * -1
-      + var(--rh-footer-links-gap, var(--rh-space-md, 8px))
-    ) !important;
 }
 
 #footer-logo {

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -207,7 +207,7 @@ pfe-accordion {
 }
 
 .isMobile .links {
-  --rh-footer-link-header-font-size: var(--rh-footer-link-header-mobile-font-size, var(--rh-font-size-body-text-lg, 1.125rem));
+  --rh-footer-link-header-font-size: var(--rh-font-size-body-text-lg, 1.125rem);
 }
 
 .isMobile .links ::slotted(ul) {


### PR DESCRIPTION
## What I did

1.  Added CSS parts for accordion-header and accordion-panel
2. Added RHDC specific `em` based overrides to the proxy demo
3. Cleaned up some of the previously incorrect grid gap settings around primary links

## Note to reviewers

Some of the margins in the rh-global-footer are visibly incorrect.  These are being fixed in #476.

## Testing Instructions

1. Visit `http://localhost:8000/components/footer/demo/`
2. Verify that, on desktop, the primary links have a 
  - column gap of 32px
  - row gap of 16px
  
## Screenshots

Desktop primary links gaps

![Screen Shot 2022-09-03 at 10 54 02 AM](https://user-images.githubusercontent.com/3428964/188276614-abf7d709-6788-4bec-88d8-6ce5df9a2de6.png)

RHDC Desktop

![Screen Shot 2022-09-03 at 11 07 21 AM](https://user-images.githubusercontent.com/3428964/188276802-6add8be3-bdf4-47ea-ad14-66c20ae93627.png)

RHDC Mobile

![localhost_8001_en (6)](https://user-images.githubusercontent.com/3428964/188276815-47419066-e52e-4711-99d4-cc2a11cefe84.png)


