### PR TITLE
refactor(secondary-nav): token values and focus fix

### DIFF
--- a/.changeset/modern-rings-deny.md
+++ b/.changeset/modern-rings-deny.md
@@ -1,0 +1,10 @@
+---
+"@rhds/elements": patch
+---
+
+Changes to `<rh-secondary-nav>`:
+  - Removed component scaling with user font size preference by replacing em based spacers with space tokens. 
+  - Updated font-family stacks with font tokens
+  - Fixed nav bar height not adjusting when logo text wraps to 3 lines
+  - Fixed button background on color-palette="darker"
+  - Fixed focus out handler bug closing menu when clicking on flyout menu

--- a/elements/rh-secondary-nav/demo/demo.css
+++ b/elements/rh-secondary-nav/demo/demo.css
@@ -1,17 +1,3 @@
-:root {
-  --pfe-theme--font-family: "Red Hat Text", "Overpass", helvetica, arial, sans-serif;
-  --pfe-theme--font-family--heading: "Red Hat Display", "Overpass", helvetica, arial, sans-serif;
-}
-
-html,
-body {
-  margin: 0;
-  font-family: "Red Hat Text", sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-}
-
 /* :host is the html-include element hosting this demo */
 :host {
   display: block;

--- a/elements/rh-secondary-nav/demo/rh-secondary-nav.html
+++ b/elements/rh-secondary-nav/demo/rh-secondary-nav.html
@@ -184,7 +184,7 @@
 <div class="space-holder">
   <pfe-band size="large" color-palette="lighest">
     <h2 slot="header">Dev/Tester Note</h2>
-    <p>This component's media query break points are set in understanding that the component will exist at full screen width.  The breakpoints will appear off if the component isn't 100% page width. You can use the fullscreen button above to test media query breakpoint.  However doing so will break position: sticky of the menu.</p>
+    <p>This component's media query break points are set in understanding that the component will exist at full screen width.  The breakpoints will appear off if the component isn't 100% page width. You can use the fullscreen button above to test media query breakpoint.</p>
   </pfe-band>
   <pfe-band size="large" color-palette="lighter">
     <h2 slot="header">Content Placeholder</h2>

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -63,7 +63,7 @@ rh-secondary-nav > [slot="logo"] {
   font-size: var(--rh-font-size-body-text-md, 1rem);
   letter-spacing: var(--rh-letter-spacing-body-text, 0.01125em);
   line-height: 1.6875em; /* WARNING: not a recognized token value */
-  margin-inline-start: var(--rh-length-lg, 16px);
+  margin-inline-start: var(--rh-space-lg, 16px);
   font-family: var(--rh-font-family-heading, RedHatDisplay, "Red Hat Display", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Overpass, Helvetica, Arial, sans-serif);
   font-weight: var(--rh-font-weight-heading-medium, 500);
 }
@@ -82,9 +82,9 @@ rh-secondary-nav > [slot="nav"] {
   background-color: var(--rh-color-surface-lightest, #ffffff);
   margin: 0;
   padding: 
-    var(--rh-length-2xl, 32px)
-    var(--rh-length-lg, 16px)
-    var(--rh-length-lg, 16px);
+    var(--rh-space-2xl, 32px)
+    var(--rh-space-lg, 16px)
+    var(--rh-space-lg, 16px);
 }
 
 rh-secondary-nav > [slot="cta"] {
@@ -94,9 +94,9 @@ rh-secondary-nav > [slot="cta"] {
   align-items: center;
   background-color: var(--rh-color-surface-lightest, #ffffff);
   padding: 
-    var(--rh-length-lg, 16px)
-    var(--rh-length-lg, 16px)
-    var(--rh-length-2xl, 32px);
+    var(--rh-space-lg, 16px)
+    var(--rh-space-lg, 16px)
+    var(--rh-space-2xl, 32px);
   margin: 0;
   max-width: 100%;
 }
@@ -126,7 +126,7 @@ rh-secondary-nav-dropdown > a {
   font-size: 1em;
   font-weight: 500;
   line-height: 1em;
-  padding: var(--rh-length-lg, 16px) var(--rh-length-xl, 24px);
+  padding: var(--rh-space-lg, 16px) var(--rh-space-xl, 24px);
   text-decoration: none !important;
   text-align: center;
   border-block-start: 3px solid transparent;
@@ -155,7 +155,7 @@ rh-secondary-nav-menu-section > [slot="header"] {
   font-size: 1em;
   font-weight: 500;
   color: var(--rh-color-text-primary-on-light, #151515);
-  margin: 0 0 var(--rh-length-lg, 16px);
+  margin: 0 0 var(--rh-space-lg, 16px);
 }
 
 rh-secondary-nav-menu-section > [slot="header"] > a {
@@ -164,7 +164,7 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
 
 @media screen and (min-width: 768px) {
   rh-secondary-nav > [slot="logo"] {
-    margin-inline-start: var(--rh-length-2xl, 32px);
+    margin-inline-start: var(--rh-space-2xl, 32px);
   }
 }
 
@@ -217,7 +217,7 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
   rh-secondary-nav-dropdown > a {
     height: 100%;
     font-weight: 400;
-    padding: 0 var(--rh-length-lg, 16px);
+    padding: 0 var(--rh-space-lg, 16px);
   }
 
   rh-secondary-nav > [slot="nav"] > li > a:focus,
@@ -236,19 +236,19 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
     display: flex;
     flex-direction: row-reverse;
     background-color: transparent;
-    margin-inline-end: var(--rh-length-2xl, 32px);
+    margin-inline-end: var(--rh-space-2xl, 32px);
     padding: unset;
   }
 
   @media screen and (min-width: 1440px) {
     rh-secondary-nav:not(:defined) > [slot="logo"],
     rh-secondary-nav > [slot="logo"] {
-      margin-inline-start: var(--rh-length-4xl, 64px);
+      margin-inline-start: var(--rh-space-4xl, 64px);
     }
 
     rh-secondary-nav:not(:defined) > [slot="cta"],
     rh-secondary-nav > [slot="cta"] {
-      margin-inline-end: var(--rh-length-4xl, 64px);
+      margin-inline-end: var(--rh-space-4xl, 64px);
     }
   }
 }

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -1,26 +1,27 @@
 rh-secondary-nav {
+  --_rh-secondary-nav-max-height: max-content;
+  --_rh-secondary-nav-min-height: 74px;
+  --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-light, #151515);
+  --_rh-secondary-nav-logo-link-color: var(--rh-color-text-primary-on-light, #151515);
+  --_rh-secondary-nav-chevron-color: var(--rh-color-text-primary-on-light, #151515);
+
   display: block;
   position: sticky;
   top: 0;
   background-color: var(--rh-color-surface-light, #f0f0f0);
   border-block-end: 1px solid transparent;
   box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
-  height: 4.625em;
+  height: var(--_rh-secondary-nav-max-height);
+  min-height: var(--_rh-secondary-nav-min-height);
   font-size: initial;
   font-family: var(--rh-font-family-body-text, RedHatText, "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Overpass, Helvetica, Arial, sans-serif);
-
-  --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-light, #151515);
-  --_rh-secondary-nav-logo-link-color: var(--rh-color-text-primary-on-light, #151515);
-  --_rh-secondary-nav-chevron-color: var(--rh-color-text-primary-on-light, #151515);
 }
 
 rh-secondary-nav:not(:defined) {
   display: grid;
   position: relative;
   gap: 0 var(--rh-space-2xl, 32px);
-
-  /* WARNING: not a recognized token value */
-  grid-template-rows: 4.625em max-content max-content; /* 74px */
+  grid-template-rows: minmax(var(--_rh-secondary-nav-min-height), var(--_rh-secondary-nav-max-height)) max-content max-content;
   grid-template-columns: 1fr max-content;
   grid-template-areas:
     "logo logo"
@@ -29,12 +30,12 @@ rh-secondary-nav:not(:defined) {
 }
 
 rh-secondary-nav[color-palette="darker"] {
+  --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-light, #151515);
+  --_rh-secondary-nav-logo-link-color: var(--rh-color-text-primary-on-dark, #ffffff);
+
   background-color: var(--rh-color-surface-dark, #3c3f42);
   border-block-end-color: var(--rh-color-border-subtle-on-dark, #6a6e73);
   box-shadow: none;
-
-  --_rh-secondary-nav-nav-link-color: var(--rh-color-text-primary-on-light, #151515);
-  --_rh-secondary-nav-logo-link-color: var(--rh-color-text-primary-on-dark, #ffffff);
 }
 
 rh-secondary-nav * {
@@ -60,9 +61,9 @@ rh-secondary-nav > [slot="logo"] {
   max-width: var(--rh-secondary-nav-logo-max-width, 10em);
   text-decoration: none;
   font-size: var(--rh-font-size-body-text-md, 1rem);
-  letter-spacing: 0.01125em; /* WARNING: not a recognized token value */
+  letter-spacing: var(--rh-letter-spacing-body-text, 0.01125em);
   line-height: 1.6875em; /* WARNING: not a recognized token value */
-  margin-inline-start: var(--rh-space-2xl, 32px);
+  margin-inline-start: var(--rh-length-lg, 16px);
   font-family: var(--rh-font-family-heading, RedHatDisplay, "Red Hat Display", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Overpass, Helvetica, Arial, sans-serif);
   font-weight: var(--rh-font-weight-heading-medium, 500);
 }
@@ -80,10 +81,10 @@ rh-secondary-nav > [slot="nav"] {
   overflow-y: auto;
   background-color: var(--rh-color-surface-lightest, #ffffff);
   margin: 0;
-  padding:
-    var(--rh-space-4xl, 64px)
-    var(--rh-space-2xl, 32px)
-    var(--rh-space-2xl, 32px);
+  padding: 
+    var(--rh-length-2xl, 32px)
+    var(--rh-length-lg, 16px)
+    var(--rh-length-lg, 16px);
 }
 
 rh-secondary-nav > [slot="cta"] {
@@ -92,7 +93,10 @@ rh-secondary-nav > [slot="cta"] {
   height: 100%;
   align-items: center;
   background-color: var(--rh-color-surface-lightest, #ffffff);
-  padding: 1em 1em 2em;
+  padding: 
+    var(--rh-length-lg, 16px)
+    var(--rh-length-lg, 16px)
+    var(--rh-length-2xl, 32px);
   margin: 0;
   max-width: 100%;
 }
@@ -122,7 +126,7 @@ rh-secondary-nav-dropdown > a {
   font-size: 1em;
   font-weight: 500;
   line-height: 1em;
-  padding: 1em 1.5em;
+  padding: var(--rh-length-lg, 16px) var(--rh-length-xl, 24px);
   text-decoration: none !important;
   text-align: center;
   border-block-start: 3px solid transparent;
@@ -151,7 +155,7 @@ rh-secondary-nav-menu-section > [slot="header"] {
   font-size: 1em;
   font-weight: 500;
   color: var(--rh-color-text-primary-on-light, #151515);
-  margin: 0 0 1em;
+  margin: 0 0 var(--rh-length-lg, 16px);
 }
 
 rh-secondary-nav-menu-section > [slot="header"] > a {
@@ -160,7 +164,7 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
 
 @media screen and (min-width: 768px) {
   rh-secondary-nav > [slot="logo"] {
-    margin-inline-start: 2em;
+    margin-inline-start: var(--rh-length-2xl, 32px);
   }
 }
 
@@ -213,7 +217,7 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
   rh-secondary-nav-dropdown > a {
     height: 100%;
     font-weight: 400;
-    padding: 0 1em;
+    padding: 0 var(--rh-length-lg, 16px);
   }
 
   rh-secondary-nav > [slot="nav"] > li > a:focus,
@@ -232,19 +236,19 @@ rh-secondary-nav-menu-section > [slot="header"] > a {
     display: flex;
     flex-direction: row-reverse;
     background-color: transparent;
-    margin-inline-end: 2em;
+    margin-inline-end: var(--rh-length-2xl, 32px);
     padding: unset;
   }
 
   @media screen and (min-width: 1440px) {
     rh-secondary-nav:not(:defined) > [slot="logo"],
     rh-secondary-nav > [slot="logo"] {
-      margin-inline-start: 4em;
+      margin-inline-start: var(--rh-length-4xl, 64px);
     }
 
     rh-secondary-nav:not(:defined) > [slot="cta"],
     rh-secondary-nav > [slot="cta"] {
-      margin-inline-end: 4em;
+      margin-inline-end: var(--rh-length-4xl, 64px);
     }
   }
 }

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu-section.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu-section.css
@@ -20,11 +20,11 @@
 }
 
 ::slotted([slot="cta"]) {
-  padding: 1.5em 0 0;
+  padding: var(--rh-length-xl, 24px) 0 0;
 }
 
 ::slotted([slot="cta"]:last-of-type) {
-  padding: 1.5em 0;
+  padding: var(--rh-length-xl, 24px) 0;
 }
 
 @media screen and (min-width: 992px) {

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu-section.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu-section.css
@@ -20,11 +20,11 @@
 }
 
 ::slotted([slot="cta"]) {
-  padding: var(--rh-length-xl, 24px) 0 0;
+  padding: var(--rh-space-xl, 24px) 0 0;
 }
 
 ::slotted([slot="cta"]:last-of-type) {
-  padding: var(--rh-length-xl, 24px) 0;
+  padding: var(--rh-space-xl, 24px) 0;
 }
 
 @media screen and (min-width: 992px) {

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.css
@@ -15,7 +15,7 @@
 }
 
 #sections {
-  padding: var(--rh-length-xl, 24px);
+  padding: var(--rh-space-xl, 24px);
 }
 
 :host(:not([type="fixed-width"])) #sections {
@@ -26,7 +26,7 @@
       repeat(auto-fit, minmax(15.5em, 1fr))
     );
   grid-template-rows: auto;
-  gap: var(--rh-secondary-nav-menu-section-grid-gap, var(--rh-length-2xl, 32px));
+  gap: var(--rh-secondary-nav-menu-section-grid-gap, var(--rh-space-2xl, 32px));
 }
 
 ::slotted(:is(ul, ol)) {
@@ -46,9 +46,9 @@
     top: var(--_nav-height);
     padding: 4em 2em 3em;
     padding: 
-      var(--rh-length-4xl, 64px)
-      var(--rh-length-2xl, 32px)
-      var(--rh-length-3xl, 48px);
+      var(--rh-space-4xl, 64px)
+      var(--rh-space-2xl, 32px)
+      var(--rh-space-3xl, 48px);
     box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
     z-index: -1;
   }
@@ -70,19 +70,19 @@
   }
 
   :host([layout="fixed-width"]) #sections {
-    padding: var(--rh-length-2xl, 32px);
+    padding: var(--rh-space-2xl, 32px);
   }
 }
 
 @media screen and (min-width: 1200px) {
   #container.visible {
-    padding: var(--rh-length-3xl, 48px) var(--rh-length-2xl, 32px);
+    padding: var(--rh-space-3xl, 48px) var(--rh-space-2xl, 32px);
   }
 }
 
 @media screen and (min-width: 1440px) {
   #container.visible {
-    padding: var(--rh-length-3xl, 48px) var(--rh-length-4xl, 64px);
+    padding: var(--rh-space-3xl, 48px) var(--rh-space-4xl, 64px);
   }
 }
 

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.css
@@ -15,7 +15,7 @@
 }
 
 #sections {
-  padding: 1.5em;
+  padding: var(--rh-length-xl, 24px);
 }
 
 :host(:not([type="fixed-width"])) #sections {
@@ -26,7 +26,7 @@
       repeat(auto-fit, minmax(15.5em, 1fr))
     );
   grid-template-rows: auto;
-  gap: var(--rh-secondary-nav-menu-section-grid-gap, 2em);
+  gap: var(--rh-secondary-nav-menu-section-grid-gap, var(--rh-length-2xl, 32px));
 }
 
 ::slotted(:is(ul, ol)) {
@@ -45,6 +45,10 @@
     right: 0;
     top: var(--_nav-height);
     padding: 4em 2em 3em;
+    padding: 
+      var(--rh-length-4xl, 64px)
+      var(--rh-length-2xl, 32px)
+      var(--rh-length-3xl, 48px);
     box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
     z-index: -1;
   }
@@ -66,19 +70,19 @@
   }
 
   :host([layout="fixed-width"]) #sections {
-    padding: 2em;
+    padding: var(--rh-length-2xl, 32px);
   }
 }
 
 @media screen and (min-width: 1200px) {
   #container.visible {
-    padding: 3em 2em;
+    padding: var(--rh-length-3xl, 48px) var(--rh-length-2xl, 32px);
   }
 }
 
 @media screen and (min-width: 1440px) {
   #container.visible {
-    padding: 3em 4em;
+    padding: var(--rh-length-3xl, 48px) var(--rh-length-4xl, 64px);
   }
 }
 

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -47,7 +47,7 @@ nav.rtl {
   min-height: var(--_rh-secondary-nav-min-height);
   z-index: var(--rh-secondary-nav-z-index, 102);
   background-color: var(--rh-color-surface-light, #f0f0f0);
-  gap: 0 var(--rh-length-lg, 16px);
+  gap: 0 var(--rh-space-lg, 16px);
   grid-template-rows: minmax(var(--_nav-min-height), var(--_nav-max-height)) max-content max-content;
   grid-template-columns: 1fr max-content;
   grid-template-areas:
@@ -78,10 +78,10 @@ nav.rtl {
   flex-direction: column;
   padding: 2em 1em 0;
   padding: 
-    var(--rh-length-2xl, 32px)
-    var(--rh-length-lg, 16px)
+    var(--rh-space-2xl, 32px)
+    var(--rh-space-lg, 16px)
     0
-    var(--rh-length-lg, 16px);
+    var(--rh-space-lg, 16px);
   margin: 0 !important;
   max-height: calc(100vh - var(--_nav-min-height));
   overflow-y: auto;
@@ -107,9 +107,9 @@ button {
   align-items: center;
   font-family: "Red Hat Display", Arial, sans-serif;
   font-size: 1em;
-  padding: var(--rh-length-lg, 16px);
+  padding: var(--rh-space-lg, 16px);
   border-block-start: var(--rh-border-width-lg, 3px) solid transparent;
-  margin-inline-end: var(--rh-length-lg, 16px);
+  margin-inline-end: var(--rh-space-lg, 16px);
   color: var(--_button-font-color);
   background-color: var(--rh-color-surface-light, #f0f0f0);
 }
@@ -161,19 +161,19 @@ button[aria-expanded="true"],
 
 @media screen and (min-width: 768px) {
   button {
-    margin-inline-end: var(--rh-length-2xl, 32px);
+    margin-inline-end: var(--rh-space-2xl, 32px);
   }
 
   #container.expanded ::slotted([slot="nav"]) {
     padding: 2em 2em 0 !important;
     padding: 
-      var(--rh-length-2xl, 32px) 
-      var(--rh-length-2xl, 32px)
+      var(--rh-space-2xl, 32px) 
+      var(--rh-space-2xl, 32px)
       0 !important;
   }
 
   #container.expanded ::slotted([slot="cta"]) {
-    padding: var(--rh-length-2xl, 32px) !important;
+    padding: var(--rh-space-2xl, 32px) !important;
   }
 }
 

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -11,7 +11,8 @@
     rotate(var(--_chevron-down-angle))
     translate(var(--_chevron-thickness), calc(var(--_chevron-inverse, -1) * var(--_chevron-size)));
   --_button-font-color: var(--rh-color-text-primary-on-light, #151515);
-  --_nav-height: 4.625em;
+  --_nav-max-height: var(--_rh-secondary-nav-max-height, max-content);
+  --_nav-min-height: var(--_rh-secondary-nav-min-height, 74px);
 
   z-index: var(--rh-secondary-nav-z-index, 102);
 }
@@ -24,6 +25,7 @@
 nav {
   position: relative;
   height: 100%;
+  min-height: var(--_rh-secondary-nav-min-height);
   z-index: var(--rh-secondary-nav-z-index, 102);
 }
 
@@ -42,10 +44,11 @@ nav.rtl {
   display: grid;
   position: relative;
   height: fit-content;
+  min-height: var(--_rh-secondary-nav-min-height);
   z-index: var(--rh-secondary-nav-z-index, 102);
   background-color: var(--rh-color-surface-light, #f0f0f0);
-  gap: 0 var(--rh-space-2xl, 32px);
-  grid-template-rows: var(--_nav-height) max-content max-content;
+  gap: 0 var(--rh-length-lg, 16px);
+  grid-template-rows: minmax(var(--_nav-min-height), var(--_nav-max-height)) max-content max-content;
   grid-template-columns: 1fr max-content;
   grid-template-areas:
     "logo menu"
@@ -74,8 +77,13 @@ nav.rtl {
   list-style: none;
   flex-direction: column;
   padding: 2em 1em 0;
+  padding: 
+    var(--rh-length-2xl, 32px)
+    var(--rh-length-lg, 16px)
+    0
+    var(--rh-length-lg, 16px);
   margin: 0 !important;
-  max-height: calc(100vh - var(--_nav-height));
+  max-height: calc(100vh - var(--_nav-min-height));
   overflow-y: auto;
 }
 
@@ -99,9 +107,9 @@ button {
   align-items: center;
   font-family: "Red Hat Display", Arial, sans-serif;
   font-size: 1em;
-  padding: 1em;
-  border-block-start: 0.25em solid transparent;
-  margin-inline-end: 1em;
+  padding: var(--rh-length-lg, 16px);
+  border-block-start: var(--rh-border-width-lg, 3px) solid transparent;
+  margin-inline-end: var(--rh-length-lg, 16px);
   color: var(--_button-font-color);
   background-color: var(--rh-color-surface-light, #f0f0f0);
 }
@@ -130,7 +138,7 @@ button:focus {
   border-block-start-color: var(--rh-color-text-brand-on-light, #ee0000);
 }
 
-:host([color-palette="dark"]) button {
+:host([color-palette="darker"]) button {
   background-color: var(--rh-color-surface-dark, #3c3f42);
 }
 
@@ -153,15 +161,19 @@ button[aria-expanded="true"],
 
 @media screen and (min-width: 768px) {
   button {
-    margin-inline-end: 2em;
+    margin-inline-end: var(--rh-length-2xl, 32px);
   }
 
   #container.expanded ::slotted([slot="nav"]) {
     padding: 2em 2em 0 !important;
+    padding: 
+      var(--rh-length-2xl, 32px) 
+      var(--rh-length-2xl, 32px)
+      0 !important;
   }
 
   #container.expanded ::slotted([slot="cta"]) {
-    padding: 2em !important;
+    padding: var(--rh-length-2xl, 32px) !important;
   }
 }
 

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -212,12 +212,17 @@ export class RhSecondaryNav extends LitElement {
   @bound
   private _focusOutHandler(event: FocusEvent) {
     const target = event.relatedTarget as HTMLElement;
-    if (target === null || (target && !target.closest('rh-secondary-nav'))) {
-      if (this._compact) {
-        this._mobileMenuExpanded = false;
+    if (target) {
+      if (target.closest('rh-secondary-nav') === this) {
+        // if the focus is still inside the rh-secondary-nav exit
+        return;
+      } else {
+        if (this._compact) {
+          this._mobileMenuExpanded = false;
+        }
+        this.close();
+        this._overlay.open = false;
       }
-      this.close();
-      this._overlay.open = false;
     }
   }
 


### PR DESCRIPTION
## What I did

1.  Replaced em-based space values with space tokens.
2. Fixed issue with focus closing menu when a click happens inside of secondary-nav fly out menu closing menu


## Testing Instructions

1.  View the netlify demo link.  Adjust browser font-size preference, only fonts should scale.
2. Click / tab around menu make sure menu opens and closes appropriately

## Notes to Reviewers

Please double-check any design spec spacing mistakes with [XD specs](https://xd.adobe.com/view/72d9148d-c898-4d7d-beaa-b9f746acdbbf-278a/specs/) for user error in copying/changing values to token usage. 
