### PR TITLE
feat(label): add `<rh-label>`

### DIFF
--- a/elements/rh-label/README.md
+++ b/elements/rh-label/README.md
@@ -1,0 +1,11 @@
+# Label
+Add a description of the component here.
+
+## Usage
+Describe how best to use this web component along with best practices.
+
+```html
+<rh-label>
+
+</rh-label>
+```

--- a/elements/rh-label/demo/demo.css
+++ b/elements/rh-label/demo/demo.css
@@ -1,0 +1,16 @@
+/* :host is the html-include element hosting this demo */
+:host {
+  display: block;
+}
+
+.visually-hidden-class {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/elements/rh-label/demo/rh-label.html
+++ b/elements/rh-label/demo/rh-label.html
@@ -1,0 +1,34 @@
+<link rel="stylesheet" href="./demo.css"/>
+<script type="module" src="./rh-label.js"></script>
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Filled Color</h2>
+  <rh-label color="blue">Blue</rh-label>
+  <rh-label color="green">Green</rh-label>
+  <rh-label color="orange">Orange</rh-label>
+  <rh-label color="red"><span>Red <span class="visually-hidden-class">Hat</span></span></rh-label>
+  <rh-label color="purple">Purple</rh-label>
+  <rh-label color="cyan">Cyan</rh-label>
+  <rh-label>Grey</rh-label>
+  <div class="example">
+      Example:
+      <pfe-codeblock><div codeblock-container code-language="html"><code>&lt;rh-label color="blue"&gt;Blue&lt;/rh-label&gt;</code></div></pfe-codeblock>
+  </div>
+</pfe-band>
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">With Icon</h2>
+  <div>
+    <rh-label icon="web-icon-alert-danger">Default</rh-label>
+    <rh-label color="blue" icon="web-icon-alert-danger">Blue label</rh-label>
+    <rh-label color="green">Green label <svg slot="icon" height="1em" width: "1em" fill="currentColor" viewBox="0 0 512 512" aria-hidden="true" role="img"><path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"></path></svg></rh-label>
+    <rh-label color="orange" icon="web-icon-alert-danger">Orange label</rh-label>
+    <rh-label color="red" icon="web-icon-alert-danger">Red label</rh-label>
+    <rh-label color="purple" icon="web-icon-alert-danger">Purple label <svg slot="icon" height="1em" width: "1em" fill="currentColor" viewBox="0 0 512 512" aria-hidden="true" role="img"><path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"></path></svg></rh-label>
+    <rh-label color="cyan" icon="web-icon-alert-danger">Cyan label</rh-label>
+  </div>
+  <div class="example">
+    Example:
+    <pfe-codeblock><div codeblock-container code-language="html"><code>&lt;rh-label color="blue" icon="web-icon-alert-danger"&gt;Blue&lt;/rh-label&gt;</code></div></pfe-codeblock>
+</div>
+</pfe-band>

--- a/elements/rh-label/demo/rh-label.js
+++ b/elements/rh-label/demo/rh-label.js
@@ -1,0 +1,5 @@
+import '@rhds/elements/rh-label/rh-label.js';
+
+const root = document.querySelector('[data-demo="rh-label"]')?.shadowRoot ?? document;
+
+root.querySelector('rh-label');

--- a/elements/rh-label/docs/rh-label.md
+++ b/elements/rh-label/docs/rh-label.md
@@ -1,0 +1,17 @@
+{% renderOverview %}
+  <rh-label></rh-label>
+{% endrenderOverview %}
+
+{% band header="Usage" %}{% endband %}
+
+{% renderSlots %}{% endrenderSlots %}
+
+{% renderAttributes %}{% endrenderAttributes %}
+
+{% renderMethods %}{% endrenderMethods %}
+
+{% renderEvents %}{% endrenderEvents %}
+
+{% renderCssCustomProperties %}{% endrenderCssCustomProperties %}
+
+{% renderCssParts %}{% endrenderCssParts %}

--- a/elements/rh-label/rh-label.css
+++ b/elements/rh-label/rh-label.css
@@ -1,0 +1,124 @@
+:host {
+  --_content-color: var(--rh-color-black-900, #151515);
+  --_before-border-color: var(--rh-color-black-300, #d2d2d2);
+  --_background-color: var(--rh-color-surface-lighter, #f5f5f5);
+  --pfe-icon--color: currentColor;
+
+  position: relative;
+  padding: 
+    var(--rh-label-padding-block-start, var(--rh-space-xs, 4px)) 
+    var(--rh-label-padding-inline-end, var(--rh-space-md, 8px))
+    var(--rh-label-padding-block-end, var(--rh-space-xs, 4px))
+    var(--rh-label-padding-inline-start, var(--rh-space-md, 8px));
+  font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+  color: var(--_content-color);
+  white-space: nowrap;
+  background-color: var(--_background-color);
+  border: 0;
+  border-radius: var(--rh-border-radius-pill, 64px);
+}
+
+:host,
+#container {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+#container {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  color: var(--_content-color);
+  border-width: 0;
+}
+
+#container::before {
+  --pfe-icon--color: currentColor;
+
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  content: "";
+  border-radius: var(--rh-border-radius-pill, 64px);
+  border: 
+    var(--rh-border-width-sm, 1px) 
+    solid
+    var(--_before-border-color);
+}
+
+:host([color="blue"]) {
+  --_content-color: var(--rh-color-blue-600, #002952);
+  --_background-color: var(--rh-color-blue-50, #e7f1fa);
+  --_before-border-color: var(--rh-color-blue-100, #bee1f4);
+}
+
+:host([color="cyan"]) {
+  --_content-color: var(--rh-color-cyan-500, #003737);
+  --_background-color: var(--rh-color-cyan-50, #f2f9f9);
+  --_before-border-color: var(--rh-color-cyan-100, #a2d9d9);
+}
+
+:host([color="green"]) {
+  --_content-color: var(--rh-color-green-600, #1e4f18);
+  --_background-color: var(--rh-color-green-50, #f3faf2);
+  --_before-border-color: var(--rh-color-green-100, #bde5b8);
+}
+
+:host([color="orange"]) {
+  --_content-color: var(--rh-color-orange-700, #3b1f00);
+  --_background-color: var(--rh-color-orange-50, #fff6ec);
+  --_before-border-color: var(--rh-color-orange-100, #f4b678);
+}
+
+:host([color="purple"]) {
+  --_content-color: var(--rh-color-purple-700, #1f0066);
+  --_background-color: var(--rh-color-purple-50, #f2f0fc);
+  --_before-border-color: var(--rh-color-purple-100, #cbc1ff);
+}
+
+:host([color="red"]) {
+  --_content-color: var(--rh-color-red-800, #5f0000);
+  --_background-color: var(--rh-color-red-50, #faeae8);
+  --_before-border-color: var(--rh-color-red-600, #be0000);
+}
+
+[part=icon] {
+  display: none;
+  pointer-events: none;
+}
+
+.hasIcon [part=icon] {
+  display: inline-flex;
+  margin-inline-end: var(--rh-label-margin-inline-end, var(--rh-space-xs, 4px));
+}
+
+:host([color="blue"]) .hasIcon [part=icon] {
+  color: var(--rh-color-accent-base-on-light, #0066cc);
+}
+
+:host([color="cyan"]) .hasIcon [part=icon] {
+  color: var(--rh-color-cyan-300, #009596);
+}
+
+:host([color="green"]) .hasIcon [part=icon] {
+  color: var(--rh-color-green-500, #3e8635);
+}
+
+:host([color="orange"]) .hasIcon [part=icon] {
+  color: var(--rh-color-orange-300, #ec7a08);
+}
+
+:host([color="purple"]) .hasIcon [part=icon] {
+  color: var(--rh-color-purple-500, #6753ac);
+}
+
+:host([color="red"]) .hasIcon [part=icon] {
+  color: var(--rh-color-red-600, #be0000);
+  
+}
+

--- a/elements/rh-label/rh-label.ts
+++ b/elements/rh-label/rh-label.ts
@@ -1,0 +1,59 @@
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { BaseLabel } from '@patternfly/pfe-label/BaseLabel.js';
+
+import styles from './rh-label.css';
+
+export type LabelVariant = (
+  | 'filled'
+);
+
+export type LabelColor = (
+  | 'blue'
+  | 'cyan'
+  | 'green'
+  | 'orange'
+  | 'purple'
+  | 'red'
+  | 'grey'
+)
+
+/**
+ * Tooltip
+ * @slot - Place element content here
+ */
+@customElement('rh-label')
+export class RhLabel extends BaseLabel {
+  static readonly version = '{{version}}';
+
+  static readonly styles = [styles];
+
+  /**
+   * If rh-icon uses the set attribute from pfe-icon proposal
+   * we'll need to pass the set along to the embedded rh-icon
+   * however this will be updated in the BaseLabel class and would
+   * not appear here.  Acting only as a reminder.
+   */
+  /* @property({ reflect: true }) set = ''; */
+
+  /**
+   * RhIcon does not yet exist, so we are using pfe-icon until available
+   * <rh-icon ?hidden=${!this.icon} icon=${this.icon} set="${this.set}" size="sm"></rh-icon>
+   */
+  protected renderDefaultIcon() {
+    return !this.icon ? '' : html`
+      <pfe-icon ?hidden=${!this.icon} icon=${this.icon} size="sm"></pfe-icon>
+    `;
+  }
+
+  protected renderSuffix() {
+    return html``;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rh-label': RhLabel;
+  }
+}

--- a/elements/rh-label/test/rh-label.e2e.spec.ts
+++ b/elements/rh-label/test/rh-label.e2e.spec.ts
@@ -1,0 +1,12 @@
+import { test } from '@playwright/test';
+import { PfeDemoPage } from '@patternfly/pfe-tools/test/playwright/PfeDemoPage.js';
+
+const tagName = 'rh-label';
+
+test.describe(tagName, () => {
+  test('snapshot', async ({ page }) => {
+    const componentPage = new PfeDemoPage(page, tagName);
+    await componentPage.navigate();
+    await componentPage.snapshot();
+  });
+});

--- a/elements/rh-label/test/rh-label.spec.ts
+++ b/elements/rh-label/test/rh-label.spec.ts
@@ -1,0 +1,18 @@
+import { expect, html } from '@open-wc/testing';
+import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
+import { RhLabel } from '@rhds/elements/rh-label/rh-label.js';
+
+const element = html`
+  <rh-label></rh-label>
+`;
+
+describe('<rh-label>', function() {
+  it('should upgrade', async function() {
+    const el = await createFixture <RhLabel>(element);
+    const klass = customElements.get('rh-label');
+    expect(el)
+      .to.be.an.instanceOf(klass)
+      .and
+      .to.be.an.instanceOf(RhLabel);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rhds/elements",
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "1.0.0-beta.16",
+      "version": "1.0.0-beta.18",
       "license": "MIT",
       "dependencies": {
         "@patternfly/pfe-accordion": "next",
@@ -24,6 +24,7 @@
         "@patternfly/pfe-icon": "next",
         "@patternfly/pfe-icon-panel": "next",
         "@patternfly/pfe-jump-links": "next",
+        "@patternfly/pfe-label": "^1.0.0-next.4",
         "@patternfly/pfe-markdown": "next",
         "@patternfly/pfe-modal": "next",
         "@patternfly/pfe-number": "next",
@@ -2824,12 +2825,24 @@
       }
     },
     "node_modules/@patternfly/pfe-button": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-button/-/pfe-button-2.0.0-next.4.tgz",
-      "integrity": "sha512-8nCS1RPUNsqEfbeHqowr1HjqYNSYp++NAFrfqk928tYRCNK6OXvcU1sHag2lrWjMc5ZqET+OViws86DcrarB7Q==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-button/-/pfe-button-2.0.0-next.5.tgz",
+      "integrity": "sha512-7KuLN02Z+oa6/dfbw0FgZv0utyi7cibmTHN2zwxiskDb9ixAf/2sByr8C+PXAXEDOfDcxix+ibi0je3tdlDsNg==",
       "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-next.6",
-        "lit": "^2.1.2"
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "@patternfly/pfe-icon": "^2.0.0-next.4",
+        "@patternfly/pfe-progress-indicator": "^2.0.0-next.4",
+        "lit": "2.3.0"
+      }
+    },
+    "node_modules/@patternfly/pfe-button/node_modules/lit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.3.0"
       }
     },
     "node_modules/@patternfly/pfe-card": {
@@ -2851,12 +2864,22 @@
       }
     },
     "node_modules/@patternfly/pfe-core": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.7.tgz",
-      "integrity": "sha512-73JKSeKo1JRm+K6FMyUtcQ7mErL8NYU8UuEVsmQyYke6jP+h0pmW+5d9gGZkPRt5mDBUYD2+pW0D+D6IGaHQMA==",
+      "version": "2.0.0-next.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.8.tgz",
+      "integrity": "sha512-FFXmMMHm4Y2mC9jniznm5gBLjmlGVVekZ2IBmAqssZUdKh8+TkTkio7kq3uT7BjtjArAixy0W0XPd9L+DYizPA==",
       "dependencies": {
-        "@popperjs/core": "^2.11.5",
-        "lit": "^2.1.2"
+        "@popperjs/core": "2.11.6",
+        "lit": "2.3.0"
+      }
+    },
+    "node_modules/@patternfly/pfe-core/node_modules/lit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.3.0"
       }
     },
     "node_modules/@patternfly/pfe-cta": {
@@ -2896,12 +2919,12 @@
       }
     },
     "node_modules/@patternfly/pfe-icon": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-2.0.0-next.3.tgz",
-      "integrity": "sha512-WnuHPHVrD0Fxxud27erYe1fWBdwjM+5RmoiOIPDqZcCJmdMLGjeB31cOmiZC34tvMX5/TwheRWqdBkF0WRCaNw==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-2.0.0-next.4.tgz",
+      "integrity": "sha512-Mpn5gopaM2owohCGC9MUojx3fyg5daZFB0ga15iTADNCwuFu3KEJrs8lD2GvBseHM95VCchvpL2oeb1FUpd25w==",
       "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-next.4",
-        "lit": "^2.1.2"
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "lit": "2.3.0"
       }
     },
     "node_modules/@patternfly/pfe-icon-panel": {
@@ -2914,6 +2937,16 @@
         "lit": "^2.1.2"
       }
     },
+    "node_modules/@patternfly/pfe-icon/node_modules/lit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.3.0"
+      }
+    },
     "node_modules/@patternfly/pfe-jump-links": {
       "version": "2.0.0-next.4",
       "resolved": "https://registry.npmjs.org/@patternfly/pfe-jump-links/-/pfe-jump-links-2.0.0-next.4.tgz",
@@ -2922,6 +2955,27 @@
         "@patternfly/pfe-accordion": "^2.0.0-next.4",
         "@patternfly/pfe-core": "^2.0.0-next.4",
         "lit": "^2.1.2"
+      }
+    },
+    "node_modules/@patternfly/pfe-label": {
+      "version": "1.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-label/-/pfe-label-1.0.0-next.4.tgz",
+      "integrity": "sha512-rKoEieDcmMxoO51GyXZv8ou6XhM7WuKWl2cmzcmAwNTRp0xfJ3Rbw1ODi3T/wd6yvR46MeH8eQFOrZ92nqP0+Q==",
+      "dependencies": {
+        "@patternfly/pfe-button": "^2.0.0-next.5",
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "@patternfly/pfe-icon": "^2.0.0-next.4",
+        "lit": "2.3.0"
+      }
+    },
+    "node_modules/@patternfly/pfe-label/node_modules/lit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.3.0"
       }
     },
     "node_modules/@patternfly/pfe-markdown": {
@@ -2963,12 +3017,22 @@
       }
     },
     "node_modules/@patternfly/pfe-progress-indicator": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-progress-indicator/-/pfe-progress-indicator-2.0.0-next.3.tgz",
-      "integrity": "sha512-cgnq5ahIXnEY1gjwTc9PouZQEPv62i0LBP34IR9jt/kArskBmAxtjalekB9qek+1c6e8PSw5l4geDZh7341NeA==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-progress-indicator/-/pfe-progress-indicator-2.0.0-next.4.tgz",
+      "integrity": "sha512-sQmWZpH/MzdMXBLiKC3aI0ol4//CP9h2Plsr8x5V+ThgS7Jm1QDBijP0tXOlNhRRo/qtObdnG69nqcNuLQSc7w==",
       "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-next.6",
-        "lit": "^2.1.2"
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "lit": "2.3.0"
+      }
+    },
+    "node_modules/@patternfly/pfe-progress-indicator/node_modules/lit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.3.0"
       }
     },
     "node_modules/@patternfly/pfe-sass": {
@@ -3637,8 +3701,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "license": "MIT",
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -26070,12 +26135,26 @@
       }
     },
     "@patternfly/pfe-button": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-button/-/pfe-button-2.0.0-next.4.tgz",
-      "integrity": "sha512-8nCS1RPUNsqEfbeHqowr1HjqYNSYp++NAFrfqk928tYRCNK6OXvcU1sHag2lrWjMc5ZqET+OViws86DcrarB7Q==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-button/-/pfe-button-2.0.0-next.5.tgz",
+      "integrity": "sha512-7KuLN02Z+oa6/dfbw0FgZv0utyi7cibmTHN2zwxiskDb9ixAf/2sByr8C+PXAXEDOfDcxix+ibi0je3tdlDsNg==",
       "requires": {
-        "@patternfly/pfe-core": "^2.0.0-next.6",
-        "lit": "^2.1.2"
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "@patternfly/pfe-icon": "^2.0.0-next.4",
+        "@patternfly/pfe-progress-indicator": "^2.0.0-next.4",
+        "lit": "2.3.0"
+      },
+      "dependencies": {
+        "lit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+          "requires": {
+            "@lit/reactive-element": "^1.4.0",
+            "lit-element": "^3.2.0",
+            "lit-html": "^2.3.0"
+          }
+        }
       }
     },
     "@patternfly/pfe-card": {
@@ -26097,12 +26176,24 @@
       }
     },
     "@patternfly/pfe-core": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.7.tgz",
-      "integrity": "sha512-73JKSeKo1JRm+K6FMyUtcQ7mErL8NYU8UuEVsmQyYke6jP+h0pmW+5d9gGZkPRt5mDBUYD2+pW0D+D6IGaHQMA==",
+      "version": "2.0.0-next.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.8.tgz",
+      "integrity": "sha512-FFXmMMHm4Y2mC9jniznm5gBLjmlGVVekZ2IBmAqssZUdKh8+TkTkio7kq3uT7BjtjArAixy0W0XPd9L+DYizPA==",
       "requires": {
-        "@popperjs/core": "^2.11.5",
-        "lit": "^2.1.2"
+        "@popperjs/core": "2.11.6",
+        "lit": "2.3.0"
+      },
+      "dependencies": {
+        "lit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+          "requires": {
+            "@lit/reactive-element": "^1.4.0",
+            "lit-element": "^3.2.0",
+            "lit-html": "^2.3.0"
+          }
+        }
       }
     },
     "@patternfly/pfe-cta": {
@@ -26142,12 +26233,24 @@
       }
     },
     "@patternfly/pfe-icon": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-2.0.0-next.3.tgz",
-      "integrity": "sha512-WnuHPHVrD0Fxxud27erYe1fWBdwjM+5RmoiOIPDqZcCJmdMLGjeB31cOmiZC34tvMX5/TwheRWqdBkF0WRCaNw==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-2.0.0-next.4.tgz",
+      "integrity": "sha512-Mpn5gopaM2owohCGC9MUojx3fyg5daZFB0ga15iTADNCwuFu3KEJrs8lD2GvBseHM95VCchvpL2oeb1FUpd25w==",
       "requires": {
-        "@patternfly/pfe-core": "^2.0.0-next.4",
-        "lit": "^2.1.2"
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "lit": "2.3.0"
+      },
+      "dependencies": {
+        "lit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+          "requires": {
+            "@lit/reactive-element": "^1.4.0",
+            "lit-element": "^3.2.0",
+            "lit-html": "^2.3.0"
+          }
+        }
       }
     },
     "@patternfly/pfe-icon-panel": {
@@ -26168,6 +26271,29 @@
         "@patternfly/pfe-accordion": "^2.0.0-next.4",
         "@patternfly/pfe-core": "^2.0.0-next.4",
         "lit": "^2.1.2"
+      }
+    },
+    "@patternfly/pfe-label": {
+      "version": "1.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-label/-/pfe-label-1.0.0-next.4.tgz",
+      "integrity": "sha512-rKoEieDcmMxoO51GyXZv8ou6XhM7WuKWl2cmzcmAwNTRp0xfJ3Rbw1ODi3T/wd6yvR46MeH8eQFOrZ92nqP0+Q==",
+      "requires": {
+        "@patternfly/pfe-button": "^2.0.0-next.5",
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "@patternfly/pfe-icon": "^2.0.0-next.4",
+        "lit": "2.3.0"
+      },
+      "dependencies": {
+        "lit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+          "requires": {
+            "@lit/reactive-element": "^1.4.0",
+            "lit-element": "^3.2.0",
+            "lit-html": "^2.3.0"
+          }
+        }
       }
     },
     "@patternfly/pfe-markdown": {
@@ -26209,12 +26335,24 @@
       }
     },
     "@patternfly/pfe-progress-indicator": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-progress-indicator/-/pfe-progress-indicator-2.0.0-next.3.tgz",
-      "integrity": "sha512-cgnq5ahIXnEY1gjwTc9PouZQEPv62i0LBP34IR9jt/kArskBmAxtjalekB9qek+1c6e8PSw5l4geDZh7341NeA==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-progress-indicator/-/pfe-progress-indicator-2.0.0-next.4.tgz",
+      "integrity": "sha512-sQmWZpH/MzdMXBLiKC3aI0ol4//CP9h2Plsr8x5V+ThgS7Jm1QDBijP0tXOlNhRRo/qtObdnG69nqcNuLQSc7w==",
       "requires": {
-        "@patternfly/pfe-core": "^2.0.0-next.6",
-        "lit": "^2.1.2"
+        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "lit": "2.3.0"
+      },
+      "dependencies": {
+        "lit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+          "requires": {
+            "@lit/reactive-element": "^1.4.0",
+            "lit-element": "^3.2.0",
+            "lit-html": "^2.3.0"
+          }
+        }
       }
     },
     "@patternfly/pfe-sass": {
@@ -26729,7 +26867,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.5"
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@patternfly/pfe-icon": "next",
     "@patternfly/pfe-icon-panel": "next",
     "@patternfly/pfe-jump-links": "next",
+    "@patternfly/pfe-label": "^1.0.0-next.4",
     "@patternfly/pfe-markdown": "next",
     "@patternfly/pfe-modal": "next",
     "@patternfly/pfe-number": "next",


### PR DESCRIPTION
## What I did

1. add rh-label (wip) closes #398 


## Testing Instructions

1. due to a bug with `pfe-label` the `BaseLabel.ts` file needs to be deleted from the `node_modules/@patternfly/pfe-label` directory before the dev server will correctly load `rh-label` demo and styles
2. `rh-label` is dependant on `rh-icon`, until that gets built `pfe-icon` is implemented as a placeholder.

## Notes to Reviewers

1. Please review font, icon, background, and border colors for correct token usage.

## TODO:

- [ ] Replace `pfe-icon` with `rh-icon` when available
