### PR TITLE
docs: change demo link on the footer page

### DIFF
--- a/docs/components/footer.njk
+++ b/docs/components/footer.njk
@@ -37,7 +37,7 @@ Temporary Warning alert until web component release
   <p>View a live version of this component to see how it can be customized.</p>
 
   <rh-cta>
-    <a href="https://github.com/RedHat-UX/rh-footer-demo" target="_blank">View this component in action</a>
+    <a href="https://ux.redhat.com/components/footer/demo/">View this component in action</a>
   </rh-cta>
 
 {%- endcall %}


### PR DESCRIPTION
## What I did

1. Changed link for the Footer demo from https://github.com/RedHat-UX/rh-footer-demo to https://ux.redhat.com/components/footer/demo/.


## Testing Instructions

1.

## Notes to Reviewers

The [rh-footer-demo repo](https://github.com/RedHat-UX/rh-footer-demo) is going to be used for other component demos too, so it needed to be updated.