### PR TITLE
fix(secondary-nav): long logo title nav height

### DIFF
--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -178,6 +178,10 @@ button[aria-expanded="true"],
 }
 
 @media screen and (min-width: 992px) {
+  nav {
+    position: relative;
+  }
+
   #container {
     grid-template-areas: "logo nav cta";
     grid-template-rows: auto;


### PR DESCRIPTION
## What I did

1. Fixes nav height when a long logo title creates 3 lines
2. Closes #531 


## Testing Instructions

1. Check out project on `fix/secondary-nav-long-logo-titles-height`
1. Load dev server `npm start`
1. Open demo for secondary-nav in browser mobile view.
