### PR TITLE
fix(secondary-nav): logo text padding

### DIFF
--- a/elements/rh-secondary-nav/demo/dark-variant.html
+++ b/elements/rh-secondary-nav/demo/dark-variant.html
@@ -159,7 +159,6 @@
         </rh-secondary-nav-menu>
       </rh-secondary-nav-dropdown>
     </li>
-    <li><a href="#">Extra Link</a></li>
   </ul>
   <rh-cta slot="cta">
     <a href="#">Get started</a>

--- a/elements/rh-secondary-nav/demo/demo.css
+++ b/elements/rh-secondary-nav/demo/demo.css
@@ -16,3 +16,10 @@ rh-secondary-nav-menu#custom-grid::part(sections) {
   display: block;
   grid: unset;
 }
+
+/* Dark demo with long logo text */
+@media screen and (min-width: 768px) {
+  rh-secondary-nav[color-palette="darker"] {
+    --rh-secondary-nav-logo-max-width: 13.4em;
+  }
+}

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -66,6 +66,7 @@ rh-secondary-nav > [slot="logo"] {
   margin-inline-start: var(--rh-space-lg, 16px);
   font-family: var(--rh-font-family-heading, RedHatDisplay, "Red Hat Display", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Overpass, Helvetica, Arial, sans-serif);
   font-weight: var(--rh-font-weight-heading-medium, 500);
+  padding-block: 10px; 
 }
 
 rh-secondary-nav > [slot="logo"]:hover {

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -66,7 +66,7 @@ rh-secondary-nav > [slot="logo"] {
   margin-inline-start: var(--rh-space-lg, 16px);
   font-family: var(--rh-font-family-heading, RedHatDisplay, "Red Hat Display", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Overpass, Helvetica, Arial, sans-serif);
   font-weight: var(--rh-font-weight-heading-medium, 500);
-  padding-block: 10px; 
+  padding-block: var(--rh-space-md, 8px);
 }
 
 rh-secondary-nav > [slot="logo"]:hover {

--- a/elements/rh-secondary-nav/rh-secondary-nav-overlay.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-overlay.css
@@ -1,8 +1,7 @@
 :host {
-  position: absolute;
+  position: fixed;
   background: rgb(21, 21, 21, 0.75);
   top: 0;
-  left: 0;
   width: 100vw;
   height: 100vh;
   z-index: var(--rh-secondary-nav-overlay-z-index, -1);


### PR DESCRIPTION
## What I did

1. Added padding of `10px` to the logo slot in lightdom.css
2. Corrected the dark variant demo to include adjusted logo type max-width for wider screens.
3. Removed "extra link" on the dark variant demo, long logo text has a direct effect on how many links you can include.
4. Reverts a previous change to `rh-secondary-nav-overlay` position styles made in misunderstanding of dev demo styles.
5. Closes #544 

### TODO
- [ ] Add changeset


## Testing Instructions

1.  View [dark variant demo](https://deploy-preview-545--red-hat-design-system.netlify.app/components/secondary-nav/demo/dark-variant/)
2. View [default demo](https://deploy-preview-545--red-hat-design-system.netlify.app/components/secondary-nav/demo/)

## Notes to Reviewers

Determine if 10px is appropriate padding around the logo text.   Please review in mobile view and desktop viewport sizes.  Look at both the dark variant and the default demo. This is a non-standard spacer, I would like to determine if this is more appropriate visually than using 16px or 8px, both available as tokenized values.
