### PR TITLE
fix(secondary-nav): nav level cta color context on dark

### DIFF
--- a/.changeset/slimy-eyes-rescue.md
+++ b/.changeset/slimy-eyes-rescue.md
@@ -2,4 +2,6 @@
 "@rhds/elements": patch
 ---
 
-Fixes the nav level slotted cta color context when viewed in a mobile nav dropdown
+Changes to `<rh-secondary-nav>`:
+ - Fixes the nav level slotted cta color context when viewed in a mobile nav dropdown
+ - Fixes :hover color for dark variant logo text

--- a/.changeset/slimy-eyes-rescue.md
+++ b/.changeset/slimy-eyes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Fixes the nav level slotted cta color context when viewed in a mobile nav dropdown

--- a/elements/rh-secondary-nav/demo/analytics.html
+++ b/elements/rh-secondary-nav/demo/analytics.html
@@ -171,10 +171,6 @@
 </rh-secondary-nav>
 
 <div class="space-holder">
-  <pfe-band size="large" color-palette="lighest">
-    <h2 slot="header">Dev/Tester Note</h2>
-    <p>This component's media query break points are set in understanding that the component will exist at full screen width.  The breakpoints will appear off if the component isn't 100% page width. You can use the fullscreen button above to test media query breakpoint.  However doing so will break position: sticky of the menu.</p>
-  </pfe-band>
   <pfe-band size="large" color-palette="lighter">
     <h2 slot="header">Content Placeholder</h2>
     <a href="#">Link placeholder</a>

--- a/elements/rh-secondary-nav/demo/demo.css
+++ b/elements/rh-secondary-nav/demo/demo.css
@@ -18,7 +18,7 @@ rh-secondary-nav-menu#custom-grid::part(sections) {
 }
 
 /* Dark demo with long logo text */
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 358px) {
   rh-secondary-nav[color-palette="darker"] {
     --rh-secondary-nav-logo-max-width: 13.4em;
   }

--- a/elements/rh-secondary-nav/demo/rh-secondary-nav.html
+++ b/elements/rh-secondary-nav/demo/rh-secondary-nav.html
@@ -182,10 +182,6 @@
 </rh-secondary-nav>
 
 <div class="space-holder">
-  <pfe-band size="large" color-palette="lighest">
-    <h2 slot="header">Dev/Tester Note</h2>
-    <p>This component's media query break points are set in understanding that the component will exist at full screen width.  The breakpoints will appear off if the component isn't 100% page width. You can use the fullscreen button above to test media query breakpoint.</p>
-  </pfe-band>
   <pfe-band size="large" color-palette="lighter">
     <h2 slot="header">Content Placeholder</h2>
     <a href="#">Link placeholder</a>

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -74,6 +74,10 @@ rh-secondary-nav > [slot="logo"]:hover {
   color: var(--_nav-link-color);
 }
 
+rh-secondary-nav[color-palette="darker"] > [slot="logo"]:hover {
+  color: var(--_logo-link-color);
+}
+
 rh-secondary-nav > [slot="nav"] {
   grid-area: nav;
   display: none;

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -135,6 +135,10 @@ export class RhSecondaryNav extends LitElement {
   firstUpdated() {
     // after update the overlay should be available to attach an event listener to
     this._overlay.addEventListener('click', this._overlayClickHandler);
+    // if compact menu and dark variant then set cta color to lightest
+    if (this.colorPalette === 'darker' && this._compact) {
+      this._ctaColorPalette = 'lightest';
+    }
   }
 
   render() {
@@ -434,9 +438,6 @@ export class RhSecondaryNav extends LitElement {
       this._mobileMenuExpanded = false;
     } else {
       this._mobileMenuExpanded = true;
-      if (this.colorPalette === 'darker') {
-        this._ctaColorPalette = 'lightest';
-      }
     }
     this.dispatchEvent(new SecondaryNavOverlayChangeEvent(this._mobileMenuExpanded, this));
   }

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -4,6 +4,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { bound, observed } from '@patternfly/pfe-core/decorators.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
+import '../rh-context-provider/rh-context-provider.js';
+
 import './rh-secondary-nav-dropdown.js';
 import './rh-secondary-nav-menu.js';
 import './rh-secondary-nav-menu-section.js';
@@ -107,6 +109,12 @@ export class RhSecondaryNav extends LitElement {
   @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
 
   /**
+   * If the host color-palette attr is set to lighter, the cta color context should be lighest
+   * Otherwise use the the same as value as the host color-palette attr as default set value.
+   */
+  @state() private _ctaColorPalette = this.colorPalette === 'lighter' ? 'lighest' : this.colorPalette;
+
+  /**
    * Checks if passed in element is a RhSecondaryNavDropdown
    * @param element:
    * @returns {boolean}
@@ -140,7 +148,9 @@ export class RhSecondaryNav extends LitElement {
           <button aria-controls="container" aria-expanded="${this._mobileMenuExpanded}" @click="${this.#toggleMobileMenu}">Menu</button>
           <slot name="nav"></slot>
           <div id="cta" part="cta">
-            <slot name="cta"><slot>
+            <rh-context-provider color-palette="${this._ctaColorPalette}">
+              <slot name="cta"><slot>
+            </rh-context-provider>
           </div>
         </div>
       </nav>
@@ -266,6 +276,9 @@ export class RhSecondaryNav extends LitElement {
         if (this._overlay) {
           this._overlay.open = false;
         }
+      }
+      if (this.colorPalette === 'darker') {
+        this._ctaColorPalette = this.colorPalette;
       }
     }
   }
@@ -418,6 +431,9 @@ export class RhSecondaryNav extends LitElement {
       this._mobileMenuExpanded = false;
     } else {
       this._mobileMenuExpanded = true;
+      if (this.colorPalette === 'darker') {
+        this._ctaColorPalette = 'lightest';
+      }
     }
     this.dispatchEvent(new SecondaryNavOverlayChangeEvent(this._mobileMenuExpanded, this));
   }

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -109,10 +109,14 @@ export class RhSecondaryNav extends LitElement {
   @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
 
   /**
-   * If the host color-palette attr is set to lighter, the cta color context should be lighest
-   * Otherwise use the the same as value as the host color-palette attr as default set value.
+   * If the host color-palette="lighter", the cta color context should be on="light"
+   * by default.  However when the host color-palette="darker", the cta context should be
+   * on="dark" when in desktop mode, but on="light" when in mobile compact mode because the cta shifts
+   * to a white background in the mobile compact nav. This state property is set on firstUpdated()
+   * and __compactChanged() and is used on a wrapping `<rh-context-provider>` around the cta allowing
+   * it to dynamically change with viewport changes.
    */
-  @state() private _ctaColorPalette = this.colorPalette === 'lighter' ? 'lighest' : this.colorPalette;
+  @state() private _ctaColorPalette = this.colorPalette;
 
   /**
    * Checks if passed in element is a RhSecondaryNavDropdown

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -116,7 +116,7 @@ export class RhSecondaryNav extends LitElement {
    * and __compactChanged() and is used on a wrapping `<rh-context-provider>` around the cta allowing
    * it to dynamically change with viewport changes.
    */
-  @state() private _ctaColorPalette = this.colorPalette;
+  @state() private _ctaColorPalette: NavPalette | 'lightest' = this.colorPalette;
 
   /**
    * Checks if passed in element is a RhSecondaryNavDropdown

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -269,6 +269,9 @@ export class RhSecondaryNav extends LitElement {
       if (dropdownsOpen > 0) {
         this._mobileMenuExpanded = true;
       }
+      if (this.colorPalette === 'darker') {
+        this._ctaColorPalette = 'lightest';
+      }
     } else {
       this._mobileMenuExpanded = false;
       // Switching to Desktop


### PR DESCRIPTION
## What I did

1. Wrapped the `<slot name="cta"><slot>` with `<rh-context-provider>` and apply correct `color-palette` attribute when in mobile view.
2. Closes #546

## Testing Instructions

1. Go to the Secondary Nav Deploy Preview for the [Dark variant](https://deploy-preview-547--red-hat-design-system.netlify.app/components/secondary-nav/demo/dark-variant/) and the [Default](https://deploy-preview-547--red-hat-design-system.netlify.app/components/secondary-nav/demo/)
3. Set the viewport < 992px for the mobile compact nav view.
4. Open the mobile menu

## Notes to Reviewers

Look for any possible combination of the mobile menu open/closed and at changing to different screen sizes to see if the color context can get out of sync.
