### PR TITLE
fix(secondary-nav): mobile menu overflow 

### DIFF
--- a/.changeset/brave-bobcats-attack.md
+++ b/.changeset/brave-bobcats-attack.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+Changes to `<rh-secondary-nav>`:
+ - Moved overflow from mobile menu list to outer container

--- a/.changeset/slimy-eyes-rescue.md
+++ b/.changeset/slimy-eyes-rescue.md
@@ -2,4 +2,6 @@
 "@rhds/elements": patch
 ---
 
-Fixes the nav level slotted cta color context when viewed in a mobile nav dropdown
+Changes to `<rh-secondary-nav>`:
+ - Fixes the nav level slotted cta color context when viewed in a mobile nav dropdown
+ - Fixes :hover color for dark variant logo text

--- a/.changeset/slimy-eyes-rescue.md
+++ b/.changeset/slimy-eyes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Fixes the nav level slotted cta color context when viewed in a mobile nav dropdown

--- a/elements/rh-secondary-nav/demo/analytics.html
+++ b/elements/rh-secondary-nav/demo/analytics.html
@@ -171,10 +171,6 @@
 </rh-secondary-nav>
 
 <div class="space-holder">
-  <pfe-band size="large" color-palette="lighest">
-    <h2 slot="header">Dev/Tester Note</h2>
-    <p>This component's media query break points are set in understanding that the component will exist at full screen width.  The breakpoints will appear off if the component isn't 100% page width. You can use the fullscreen button above to test media query breakpoint.  However doing so will break position: sticky of the menu.</p>
-  </pfe-band>
   <pfe-band size="large" color-palette="lighter">
     <h2 slot="header">Content Placeholder</h2>
     <a href="#">Link placeholder</a>

--- a/elements/rh-secondary-nav/demo/demo.css
+++ b/elements/rh-secondary-nav/demo/demo.css
@@ -18,7 +18,7 @@ rh-secondary-nav-menu#custom-grid::part(sections) {
 }
 
 /* Dark demo with long logo text */
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 358px) {
   rh-secondary-nav[color-palette="darker"] {
     --rh-secondary-nav-logo-max-width: 13.4em;
   }

--- a/elements/rh-secondary-nav/demo/rh-secondary-nav.html
+++ b/elements/rh-secondary-nav/demo/rh-secondary-nav.html
@@ -182,10 +182,6 @@
 </rh-secondary-nav>
 
 <div class="space-holder">
-  <pfe-band size="large" color-palette="lighest">
-    <h2 slot="header">Dev/Tester Note</h2>
-    <p>This component's media query break points are set in understanding that the component will exist at full screen width.  The breakpoints will appear off if the component isn't 100% page width. You can use the fullscreen button above to test media query breakpoint.</p>
-  </pfe-band>
   <pfe-band size="large" color-palette="lighter">
     <h2 slot="header">Content Placeholder</h2>
     <a href="#">Link placeholder</a>

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -83,13 +83,13 @@ rh-secondary-nav > [slot="nav"] {
   display: none;
   flex-direction: column;
   list-style: none;
-  overflow-y: auto;
   background-color: var(--rh-color-surface-lightest, #ffffff);
   margin: 0;
   padding:
     var(--rh-space-2xl, 32px)
     var(--rh-space-lg, 16px)
     var(--rh-space-lg, 16px);
+  overflow-y: auto;
 }
 
 rh-secondary-nav > [slot="cta"] {

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -74,6 +74,10 @@ rh-secondary-nav > [slot="logo"]:hover {
   color: var(--_nav-link-color);
 }
 
+rh-secondary-nav[color-palette="darker"] > [slot="logo"]:hover {
+  color: var(--_logo-link-color);
+}
+
 rh-secondary-nav > [slot="nav"] {
   grid-area: nav;
   display: none;

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.css
@@ -43,7 +43,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    top: var(--_nav-height);
+    /* top: var(--_nav-height); */
     padding: 4em 2em 3em;
     padding: 
       var(--rh-space-4xl, 64px)
@@ -51,6 +51,8 @@
       var(--rh-space-3xl, 48px);
     box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
     z-index: -1;
+    max-height: calc(100vh - (var(--rh-space-4xl, 64px)) - var(--_nav-min-height));
+    overflow-y: scroll;
   }
 
   :host([layout="fixed-width"]) #container {

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.ts
@@ -5,8 +5,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { observed } from '@patternfly/pfe-core/decorators.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 
-import { RhSecondaryNavDropdown } from './rh-secondary-nav-dropdown.js';
-
 import { ScreenSizeController } from '../../lib/ScreenSizeController.js';
 
 import styles from './rh-secondary-nav-menu.css';
@@ -54,15 +52,6 @@ export class RhSecondaryNavMenu extends LitElement {
    * `visible` property is false initially then when a dropdown is clicked is toggled
    */
   @state() visible = false;
-
-  /**
-   * Checks if passed in element is a RhSecondaryNavDropdown
-   * @param element:
-   * @returns {boolean}
-   */
-  static isDropdown(element: Element|null): element is RhSecondaryNavDropdown {
-    return element instanceof RhSecondaryNavDropdown;
-  }
 
   connectedCallback() {
     super.connectedCallback();

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -44,8 +44,6 @@ nav.rtl {
 #container {
   display: grid;
   position: relative;
-  height: fit-content;
-  min-height: var(--_min-height);
   z-index: var(--rh-secondary-nav-z-index, 102);
   background-color: var(--rh-color-surface-light, #f0f0f0);
   gap: 0 var(--rh-space-lg, 16px);
@@ -55,6 +53,10 @@ nav.rtl {
     "logo menu"
     "nav nav"
     "cta cta";
+  height: fit-content;
+  min-height: var(--_min-height);
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 #cta {
@@ -84,8 +86,6 @@ nav.rtl {
     0
     var(--rh-space-lg, 16px);
   margin: 0 !important;
-  max-height: calc(100vh - var(--_nav-min-height));
-  overflow-y: auto;
 }
 
 nav.compact #container.expanded ::slotted([slot="nav"]) {
@@ -188,6 +188,12 @@ button[aria-expanded="true"],
     grid-template-rows: auto;
     grid-template-columns: max-content 1fr max-content;
     height: 100%;
+    max-height: initial;
+    overflow-y: initial;
+  }
+
+  #container.expanded ::slotted([slot="nav"]) {
+    max-height: calc(100vh - var(--_nav-min-height));
   }
 
   button {

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -6,8 +6,6 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import '../rh-context-provider/rh-context-provider.js';
 
-import './rh-secondary-nav-dropdown.js';
-import './rh-secondary-nav-menu.js';
 import './rh-secondary-nav-menu-section.js';
 
 import type { RhSecondaryNavOverlay } from './rh-secondary-nav-overlay.js';

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -135,6 +135,10 @@ export class RhSecondaryNav extends LitElement {
   firstUpdated() {
     // after update the overlay should be available to attach an event listener to
     this._overlay.addEventListener('click', this._overlayClickHandler);
+    // if compact menu and dark variant then set cta color to lightest
+    if (this.colorPalette === 'darker' && this._compact) {
+      this._ctaColorPalette = 'lightest';
+    }
   }
 
   render() {
@@ -434,9 +438,6 @@ export class RhSecondaryNav extends LitElement {
       this._mobileMenuExpanded = false;
     } else {
       this._mobileMenuExpanded = true;
-      if (this.colorPalette === 'darker') {
-        this._ctaColorPalette = 'lightest';
-      }
     }
     this.dispatchEvent(new SecondaryNavOverlayChangeEvent(this._mobileMenuExpanded, this));
   }

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -4,6 +4,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { bound, observed } from '@patternfly/pfe-core/decorators.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
+import '../rh-context-provider/rh-context-provider.js';
+
 import './rh-secondary-nav-dropdown.js';
 import './rh-secondary-nav-menu.js';
 import './rh-secondary-nav-menu-section.js';
@@ -107,6 +109,12 @@ export class RhSecondaryNav extends LitElement {
   @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
 
   /**
+   * If the host color-palette attr is set to lighter, the cta color context should be lighest
+   * Otherwise use the the same as value as the host color-palette attr as default set value.
+   */
+  @state() private _ctaColorPalette = this.colorPalette === 'lighter' ? 'lighest' : this.colorPalette;
+
+  /**
    * Checks if passed in element is a RhSecondaryNavDropdown
    * @param element:
    * @returns {boolean}
@@ -140,7 +148,9 @@ export class RhSecondaryNav extends LitElement {
           <button aria-controls="container" aria-expanded="${this._mobileMenuExpanded}" @click="${this.#toggleMobileMenu}">Menu</button>
           <slot name="nav"></slot>
           <div id="cta" part="cta">
-            <slot name="cta"><slot>
+            <rh-context-provider color-palette="${this._ctaColorPalette}">
+              <slot name="cta"><slot>
+            </rh-context-provider>
           </div>
         </div>
       </nav>
@@ -266,6 +276,9 @@ export class RhSecondaryNav extends LitElement {
         if (this._overlay) {
           this._overlay.open = false;
         }
+      }
+      if (this.colorPalette === 'darker') {
+        this._ctaColorPalette = this.colorPalette;
       }
     }
   }
@@ -418,6 +431,9 @@ export class RhSecondaryNav extends LitElement {
       this._mobileMenuExpanded = false;
     } else {
       this._mobileMenuExpanded = true;
+      if (this.colorPalette === 'darker') {
+        this._ctaColorPalette = 'lightest';
+      }
     }
     this.dispatchEvent(new SecondaryNavOverlayChangeEvent(this._mobileMenuExpanded, this));
   }

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -269,6 +269,9 @@ export class RhSecondaryNav extends LitElement {
       if (dropdownsOpen > 0) {
         this._mobileMenuExpanded = true;
       }
+      if (this.colorPalette === 'darker') {
+        this._ctaColorPalette = 'lightest';
+      }
     } else {
       this._mobileMenuExpanded = false;
       // Switching to Desktop


### PR DESCRIPTION
## What I did

1.  Moved overflow mobile menu list to an outer container.
2. Removed orphaned code.

## Testing Instructions

1. Go to the Secondary Nav Deploy Preview for the [Dark variant](https://deploy-preview-547--red-hat-design-system.netlify.app/components/secondary-nav/demo/dark-variant/) and the [Default](http://placeholder.com)
2. Set the viewport with height < 850px such as an iPhone.
3. Open the mobile menu.
4. Click "Other examples".
5. Try and scroll to CTA.  It should be visible

## Notes to Reviewers

You should be able to scroll to and view the CTA when a mobile menu is open in the netlify preview.

However, if you run the code locally in the dev demo `npm start` you will have to remove the demo's overflows in order to see the change correctly due to conflicting CSS. 
