### PR TITLE
fix(secondary-nav): mobile menu overflow

### DIFF
--- a/.changeset/brave-bobcats-attack.md
+++ b/.changeset/brave-bobcats-attack.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+Changes to `<rh-secondary-nav>`:
+ - Moved overflow from mobile menu list to outer container

--- a/.changeset/brave-bobcats-attack.md
+++ b/.changeset/brave-bobcats-attack.md
@@ -4,3 +4,4 @@
 
 Changes to `<rh-secondary-nav>`:
  - Moved overflow from mobile menu list to outer container
+ - Fixes border on dark variant in compact view

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -83,13 +83,13 @@ rh-secondary-nav > [slot="nav"] {
   display: none;
   flex-direction: column;
   list-style: none;
-  overflow-y: auto;
   background-color: var(--rh-color-surface-lightest, #ffffff);
   margin: 0;
   padding:
     var(--rh-space-2xl, 32px)
     var(--rh-space-lg, 16px)
     var(--rh-space-lg, 16px);
+  overflow-y: auto;
 }
 
 rh-secondary-nav > [slot="cta"] {

--- a/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-lightdom.css
@@ -89,7 +89,6 @@ rh-secondary-nav > [slot="nav"] {
     var(--rh-space-2xl, 32px)
     var(--rh-space-lg, 16px)
     var(--rh-space-lg, 16px);
-  overflow-y: auto;
 }
 
 rh-secondary-nav > [slot="cta"] {

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.css
@@ -43,7 +43,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    top: var(--_nav-height);
+    /* top: var(--_nav-height); */
     padding: 4em 2em 3em;
     padding: 
       var(--rh-space-4xl, 64px)
@@ -51,6 +51,8 @@
       var(--rh-space-3xl, 48px);
     box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
     z-index: -1;
+    max-height: calc(100vh - (var(--rh-space-4xl, 64px)) - var(--_nav-min-height));
+    overflow-y: scroll;
   }
 
   :host([layout="fixed-width"]) #container {

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.css
@@ -43,8 +43,6 @@
     position: absolute;
     left: 0;
     right: 0;
-    /* top: var(--_nav-height); */
-    padding: 4em 2em 3em;
     padding: 
       var(--rh-space-4xl, 64px)
       var(--rh-space-2xl, 32px)

--- a/elements/rh-secondary-nav/rh-secondary-nav-menu.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav-menu.ts
@@ -5,8 +5,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { observed } from '@patternfly/pfe-core/decorators.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 
-import { RhSecondaryNavDropdown } from './rh-secondary-nav-dropdown.js';
-
 import { ScreenSizeController } from '../../lib/ScreenSizeController.js';
 
 import styles from './rh-secondary-nav-menu.css';
@@ -54,15 +52,6 @@ export class RhSecondaryNavMenu extends LitElement {
    * `visible` property is false initially then when a dropdown is clicked is toggled
    */
   @state() visible = false;
-
-  /**
-   * Checks if passed in element is a RhSecondaryNavDropdown
-   * @param element:
-   * @returns {boolean}
-   */
-  static isDropdown(element: Element|null): element is RhSecondaryNavDropdown {
-    return element instanceof RhSecondaryNavDropdown;
-  }
 
   connectedCallback() {
     super.connectedCallback();

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -44,8 +44,6 @@ nav.rtl {
 #container {
   display: grid;
   position: relative;
-  height: fit-content;
-  min-height: var(--_min-height);
   z-index: var(--rh-secondary-nav-z-index, 102);
   background-color: var(--rh-color-surface-light, #f0f0f0);
   gap: 0 var(--rh-space-lg, 16px);
@@ -55,6 +53,10 @@ nav.rtl {
     "logo menu"
     "nav nav"
     "cta cta";
+  height: fit-content;
+  min-height: var(--_min-height);
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 #cta {
@@ -84,8 +86,6 @@ nav.rtl {
     0
     var(--rh-space-lg, 16px);
   margin: 0 !important;
-  max-height: calc(100vh - var(--_nav-min-height));
-  overflow-y: auto;
 }
 
 nav.compact #container.expanded ::slotted([slot="nav"]) {
@@ -188,6 +188,12 @@ button[aria-expanded="true"],
     grid-template-rows: auto;
     grid-template-columns: max-content 1fr max-content;
     height: 100%;
+    max-height: initial;
+    overflow-y: initial;
+  }
+
+  #container.expanded ::slotted([slot="nav"]) {
+    max-height: calc(100vh - var(--_nav-min-height));
   }
 
   button {

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -30,6 +30,10 @@ nav {
   z-index: var(--rh-secondary-nav-z-index, 102);
 }
 
+nav.compact {
+  border-block-end: 1px solid var(--rh-color-border-subtle-on-dark, #6a6e73);
+}
+
 nav.rtl {
   --_chevron-up-angle: -45deg;
   --_chevron-down-angle: 135deg;

--- a/elements/rh-secondary-nav/rh-secondary-nav.css
+++ b/elements/rh-secondary-nav/rh-secondary-nav.css
@@ -30,7 +30,7 @@ nav {
   z-index: var(--rh-secondary-nav-z-index, 102);
 }
 
-nav.compact {
+:host([color-palette="darker"])nav.compact {
   border-block-end: 1px solid var(--rh-color-border-subtle-on-dark, #6a6e73);
 }
 

--- a/elements/rh-secondary-nav/rh-secondary-nav.ts
+++ b/elements/rh-secondary-nav/rh-secondary-nav.ts
@@ -6,8 +6,6 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import '../rh-context-provider/rh-context-provider.js';
 
-import './rh-secondary-nav-dropdown.js';
-import './rh-secondary-nav-menu.js';
 import './rh-secondary-nav-menu-section.js';
 
 import type { RhSecondaryNavOverlay } from './rh-secondary-nav-overlay.js';


### PR DESCRIPTION
## What I did

1.  Moved overflow mobile menu list to an outer container.
2. Removed orphaned code.
3. Closes #559 
4. Closes #557

## Testing Instructions

1. Go to the Secondary Nav Deploy Preview for the [Dark variant](https://deploy-preview-561--red-hat-design-system.netlify.app/components/secondary-nav/demo/dark-variant/) and the [Default](https://deploy-preview-561--red-hat-design-system.netlify.app/components/secondary-nav/demo/)
2. Set the viewport with height < 850px such as an iPhone.
5. Open the mobile menu.
6. Click "Other examples".
7. Try and scroll to CTA.  It should be visible

## Notes to Reviewers

You should be able to scroll to and view the CTA when the mobile menu is open when viewing on netlify deploy preview.

However, if you run the code locally in the dev demo `npm start` you will have to remove the demo's overflows in order to see the change correctly due to conflicting CSS. 