### PR TITLE
fix(footer): all grid-template-areas show gap regardless of existing

### DIFF
--- a/.changeset/ten-sloths-argue.md
+++ b/.changeset/ten-sloths-argue.md
@@ -1,0 +1,7 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-footer>` bug fix
+
+- all grid-template-areas show gap regardless of existing [#575](https://github.com/RedHat-UX/red-hat-design-system/issues/575)

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -31,6 +31,10 @@
   height: var(--rh-size-icon-04, 40px);
 }
 
+[slot="links"]:is(h1, h2, h3, h4, h5):nth-of-type(n+5) {
+  --_link-header-margin: calc(var(--rh-space-2xl, 32px) - var(--rh-space-lg, 16px));
+}
+
 rh-footer [slot^="links"] a {
   gap: var(--rh-footer-links-gap, var(--rh-space-2xs, 8px));
 }

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -228,7 +228,7 @@ pfe-accordion {
 [part="base"]:not(.isMobile) .links {
   display: grid;
   grid-template-columns: repeat(1fr, 25%);
-  grid-template-rows: repeat(2, min-content auto);
+  grid-template-rows: repeat(1, min-content auto);
   grid-auto-columns: minmax(0, 1fr);
   row-gap: var(--rh-space-lg, 16px);
   column-gap: var(--rh-space-2xl, 32px);
@@ -328,6 +328,7 @@ pfe-accordion {
 :is(.links, .global-links-primary, .global-links-secondary) ::slotted(:is(h1, h2, h3, h4, h5)) {
   font-weight: var(--rh-font-weight-heading-medium, 500) !important;
   margin-block: 0 !important;
+  margin-block-start: var(--_link-header-margin, 0) !important;
   font-size:
     var(
       --rh-footer-link-header-font-size,

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -59,6 +59,22 @@ const KITCHEN_SINK = html`
       <li><a href="#">Red Hat newsletter</a></li>
       <li><a href="#">Email preferences</a></li>
     </ul>
+    <h3 id="communicate" slot="links">Lorem ipsum</h3>
+    <ul slot="links">
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+    </ul>
+    <h3 id="communicate" slot="links">Lorem ipsum</h3>
+    <ul slot="links">
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+      <li><a href="#">Lorem ipsum</a></li>
+    </ul>
     <rh-footer-block slot="main-secondary">
       <h3 slot="header">About Red Hat</h3>
       <p>We’re the world’s leading provider of enterprise open source solutions―including Linux, cloud, container, and Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
@@ -97,6 +113,7 @@ const KITCHEN_SINK = html`
       </div>
     </rh-global-footer>
   </rh-footer>
+  <link rel="stylesheet" href="/elements/rh-footer/rh-footer-lightdom.css" />
 `;
 
 const GLOBAL_FOOTER = html`
@@ -125,6 +142,7 @@ const GLOBAL_FOOTER = html`
       <a href="#">*We’ve updated our privacy statement effective December 30, 202X.</a>
     </div>
   </rh-global-footer>
+  <link rel="stylesheet" href="/elements/rh-footer/rh-footer-lightdom.css" />
 `;
 
 describe('<rh-footer>', function() {
@@ -221,6 +239,27 @@ describe('<rh-footer>', function() {
 
       it.skip('global is accessible', function() {
         return expect(element).to.be.accessible();
+      });
+    });
+
+    describe('ensure primary links supports second row.', function() {
+      let element: RhFooter;
+
+      beforeEach(async function() {
+        element = await fixture<RhFooter>(KITCHEN_SINK);
+      });
+
+      it('Tablet, landscape', async function() {
+        await setViewport({ width: 992, height: 800 });
+        await element.updateComplete;
+
+        const firstPrimaryLink = element.querySelector('ul[slot=links]:first-of-type');
+        const secondPrimaryLink = element.querySelector('h3[slot=links]:nth-of-type(n+2)');
+        const fifthPrimaryLink = element.querySelector('h3[slot=links]:nth-of-type(n+5)');
+        // 32px between the link items
+        expect(Math.abs(firstPrimaryLink.getBoundingClientRect().right - secondPrimaryLink.getBoundingClientRect().left)).to.equal(32);
+        // 32px between the first and second row
+        expect(Math.abs(firstPrimaryLink.getBoundingClientRect().bottom - fifthPrimaryLink.getBoundingClientRect().top)).to.equal(32);
       });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rhds/elements",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "license": "MIT",
       "dependencies": {
         "@patternfly/pfe-accordion": "next",


### PR DESCRIPTION
fixes #575

## What I did

1. Instead of using row-gap to separate the first and second rows of primary links we are going to use [quantity queries](https://alistapart.com/article/quantity-queries-for-css/) in our lightdom file and margin-block-start.


## Testing Instructions

1.

## Notes to Reviewers
