### PR TITLE
docs: fix Patternkit link on FTS starter kit page

### DIFF
--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -19,7 +19,7 @@ includeComponent:
   </rh-cta>
 
   <rh-cta style="margin-left:32px;">
-    <a href="https://webrh-patternkit.int.open.paas.redhat.com/schema/pattern_page" target="_blank">Browse Patternkit patterns</a>
+    <a href="https://webrh-demo.apps.int.spoke.preprod.us-west-2.aws.paas.redhat.com/schema/pattern_page" target="_blank">Browse Patternkit patterns</a>
   </rh-cta>
 
 {%- endcall %}


### PR DESCRIPTION
## What I did

1. Fixed broken link to Patternkit on FTS starter kit page


## Testing Instructions

1. Visit Netlify demo and check "Browse Patternkit patterns" link on the FTS starter kit page.

## Notes to Reviewers
