### PR TITLE
Changed two URLs on FTS starter kit page

### DIFF
--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -15,11 +15,11 @@ includeComponent:
   <p>The <strong>Flexible Template System</strong> (FTS) is a pattern system within Drupal that allows <a href="https://www.redhat.com/en" target="_blank">redhat.com</a> web properties to scale, it also serves as a powerful development tool and a comprehensive library of our patterns. Users can customize patterns within <strong>Patternkit</strong>, a prototyping tool, and they can also design and build pages within Drupal while staying aligned to our brand standards and design system.</p>
 
   <rh-cta variant="secondary">
-    <a href="https://source.redhat.com/departments/marketing/digitalmarketingstrategy/flexibletemplatingsystem" target="_blank">Learn how to use FTS</a>
+    <a href="https://red.ht/3zw5qKy" target="_blank">Learn how to use FTS</a>
   </rh-cta>
 
   <rh-cta style="margin-left:32px;">
-    <a href="https://webrh-demo.apps.int.spoke.preprod.us-west-2.aws.paas.redhat.com/schema/pattern_page" target="_blank">Browse Patternkit patterns</a>
+    <a href="https://red.ht/3No6R3N" target="_blank">Browse Patternkit patterns</a>
   </rh-cta>
 
 {%- endcall %}


### PR DESCRIPTION
## What I did

1. Changed URLs on the FTS starter kit page that were internal only using a URL shortener

## Testing Instructions

1. Go to `/get-started/fts-starter-kit/` and hover over the `Learn how to use FTS` and `Browse Patternkit patterns` links, they should start with `red.ht/...`