### PR TITLE
docs(alert): adding dismissable and close event to readme

### DIFF
--- a/elements/rh-alert/README.md
+++ b/elements/rh-alert/README.md
@@ -15,6 +15,16 @@ An alert consists of the following slots:
 `Anonymous Slot`
 - This is the text that is inserted into the state to be displayed in the main content body. 
 
+An alert consists of the following attributes:
+
+`dismissable`
+- The dismissable attribute adds a close button to the top right of the alert allowing the user to dismiss the alert.  This dispatches a `close` event.
+
+An alert has the following events:
+
+`close`
+- This is fired when the user clicks the close button enabled by the `dismissable` attribute.  Can be prevented via js.
+
 ##  Installation
 
 If using npm/bundlers:

--- a/elements/rh-alert/README.md
+++ b/elements/rh-alert/README.md
@@ -18,12 +18,12 @@ An alert consists of the following slots:
 An alert consists of the following attributes:
 
 `dismissable`
-- The dismissable attribute adds a close button to the top right of the alert allowing the user to dismiss the alert.  This dispatches a `close` event.
+- The dismissable attribute adds a close button to the top right of the alert allowing the user to dismiss the alert. Clicking the close button dispatches a `close` event, then removes the alert from the page.
 
 An alert has the following events:
 
 `close`
-- This is fired when the user clicks the close button enabled by the `dismissable` attribute.  Can be prevented via js.
+- This is fired when the user clicks the close button enabled by the `dismissable` attribute. Cancelling the event prevents the alert from closing.
 
 ##  Installation
 


### PR DESCRIPTION
After our discovery today went in and added some README docs for the dismissable attribute and the close event it fires. 