### PR TITLE
docs: automatically generate import map with subpaths

### DIFF
--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -137,6 +137,7 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.setLibrary('md', markdownLib);
+  eleventyConfig.setQuietMode(true);
 
   eleventyConfig.addPassthroughCopy('docs/public/red-hat-outfit.css');
   eleventyConfig.addPassthroughCopy('docs/CNAME');

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -49,7 +49,7 @@ module.exports = async function(configData) {
   map.imports = Object.fromEntries(Object.entries(map.imports).map(([k, v]) => [
     k, k === '@rhds/elements' ? '/assets/rhds.min.js'
       : k.startsWith('@rhds/elements') ? v.replace('./elements', '/assets/elements')
-      : v.replace('./node_modules', '/assets/node_modules')
+      : v
   ]));
 
   // This is unfortunate, but for now I couldn't find a better way - @bennyp

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -34,7 +34,7 @@ module.exports = async function(configData) {
 
   await generator.traceInstall(tmpfile);
 
-  await generator.install('tslib');
+  await generator.install(['tslib', '@patternfly/pfe-band']);
 
   const map = generator.importMap.flatten().combineSubpaths().toJSON();
 

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -4,7 +4,7 @@
 const crypto = require('crypto');
 const { tmpdir } = require('os');
 const { join } = require('node:path');
-const { readdir, writeFile } = require('node:fs/promises');
+const { readdir, writeFile, rm } = require('node:fs/promises');
 
 module.exports = async function(configData) {
   const { Generator } = await import('@jspm/generator');
@@ -59,6 +59,8 @@ module.exports = async function(configData) {
     }
   }
   map.imports = { ...map.scopes['./'], ...map.imports };
+
+  await rm(tmpfile);
 
   return map;
 };

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -34,8 +34,7 @@ module.exports = async function(configData) {
 
   await generator.traceInstall(tmpfile);
 
-  await generator.install([
-    'tslib',
+  await generator.traceInstall([
     // these are pfe-dependencies which aren't direct dependencies
     // tl;dr: we need these because some demos still use them.
     // remove when those demos are updated

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -34,12 +34,12 @@ module.exports = async function(configData) {
 
   await generator.traceInstall(tmpfile);
 
-  await generator.traceInstall([
+  await generator.install([
     // these are pfe-dependencies which aren't direct dependencies
     // tl;dr: we need these because some demos still use them.
     // remove when those demos are updated
-    '@patternfly/pfe-band',
-    '@patternfly/pfe-card',
+    '@patternfly/pfe-band@next',
+    '@patternfly/pfe-card@next',
   ]);
 
   const map = generator.importMap.flatten().combineSubpaths().toJSON();

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -39,6 +39,7 @@ module.exports = async function(configData) {
     // tl;dr: we need these because some demos still use them.
     // remove when those demos are updated
     '@patternfly/pfe-band@next',
+    '@patternfly/pfe-button@next',
     '@patternfly/pfe-card@next',
   ]);
 

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -34,7 +34,14 @@ module.exports = async function(configData) {
 
   await generator.traceInstall(tmpfile);
 
-  await generator.install(['tslib', '@patternfly/pfe-band']);
+  await generator.install([
+    'tslib',
+    // these are pfe-dependencies which aren't direct dependencies
+    // tl;dr: we need these because some demos still use them.
+    // remove when those demos are updated
+    '@patternfly/pfe-band',
+    '@patternfly/pfe-card',
+  ]);
 
   const map = generator.importMap.flatten().combineSubpaths().toJSON();
 

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -1,96 +1,57 @@
 /* eslint-disable no-console */
 // @ts-check
 
+const crypto = require('crypto');
+const { tmpdir } = require('os');
 const { join } = require('node:path');
-const { readdir } = require('node:fs/promises');
-
-const PFE_DEPS = [
-  '@patternfly/pfe-accordion@next',
-  '@patternfly/pfe-band@next',
-  '@patternfly/pfe-button@next',
-  '@patternfly/pfe-card@next',
-  '@patternfly/pfe-icon@next',
-  '@patternfly/pfe-modal@next',
-  '@patternfly/pfe-core@next',
-  '@patternfly/pfe-tooltip/BaseTooltip.js',
-  '@patternfly/pfe-core/decorators.js',
-  '@patternfly/pfe-core/controllers/cascade-controller.js',
-  '@patternfly/pfe-core/controllers/color-context.js',
-  '@patternfly/pfe-core/controllers/css-variable-controller.js',
-  '@patternfly/pfe-core/controllers/light-dom-controller.js',
-  '@patternfly/pfe-core/controllers/logger.js',
-  '@patternfly/pfe-core/controllers/perf-controller.js',
-  '@patternfly/pfe-core/controllers/property-observer-controller.js',
-  '@patternfly/pfe-core/controllers/slot-controller.js',
-  '@patternfly/pfe-core/controllers/style-controller.js',
-  '@patternfly/pfe-core/decorators/bound.js',
-  '@patternfly/pfe-core/decorators/cascades.js',
-  '@patternfly/pfe-core/decorators/color-context.js',
-  '@patternfly/pfe-core/decorators/deprecation.js',
-  '@patternfly/pfe-core/decorators/initializer.js',
-  '@patternfly/pfe-core/decorators/observed.js',
-  '@patternfly/pfe-core/decorators/pfelement.js',
-  '@patternfly/pfe-core/decorators/time.js',
-  '@patternfly/pfe-core/decorators/trace.js',
-  '@patternfly/pfe-core/functions/debounce.js',
-  '@patternfly/pfe-core/functions/deprecatedCustomEvent.js',
-  '@patternfly/pfe-core/functions/random.js',
-  '@lrnwebcomponents/code-sample',
-  '@popperjs/core'
-];
-
-const LIT_DEPS = [
-  'lit',
-  'lit/async-directive.js',
-  'lit/decorators.js',
-  'lit/directive-helpers.js',
-  'lit/directive.js',
-  'lit/directives/class-map.js',
-  'lit/directives/if-defined.js',
-  'lit/directives/repeat.js',
-  'lit/directives/style-map.js',
-  'lit/directives/unsafe-html.js',
-  'lit/directives/unsafe-svg.js',
-  'lit/experimental-hydrate-support.js',
-  'lit/experimental-hydrate.js',
-  'lit/static-html.js',
-];
+const { readdir, writeFile } = require('node:fs/promises');
 
 module.exports = async function(configData) {
   const { Generator } = await import('@jspm/generator');
 
   const elements = await readdir(join(__dirname, '..', '..', 'elements'));
+
   const generator = new Generator({
-    defaultProvider: 'jspm', // this is the default defaultProvider
     env: ['production', 'browser', 'module'],
+    inputMap: {
+      // In order for JSPM generator to find the files we need, we have to pass them as relative
+      // paths to the project root, but this won't work for the final site build,
+      // so we'll modify the import map manually afterward
+      imports: {
+        '@rhds/elements': './rhds.min.js',
+        ...Object.fromEntries(elements.map(x => [
+          `@rhds/elements/${x}/${x}.js`,
+          `./elements/${x}/${x}.js`
+        ])),
+      }
+    },
   });
+
+  const tmpfile = join(tmpdir(), `rhds-${crypto.randomUUID()}.js`);
+  const tmpcontent = elements.map(x =>
+    `import '@rhds/elements/${x}/${x}.js';`).join('\n');
+  await writeFile(tmpfile, tmpcontent);
+
+  await generator.traceInstall(tmpfile);
 
   await generator.install('tslib');
 
-  for (const pack of [...PFE_DEPS, ...LIT_DEPS]) {
-    await generator.install(pack);
-  }
+  const map = generator.importMap.flatten().combineSubpaths().toJSON();
 
-  await generator.install({
-    alias: '@rhds/elements',
-    target: '/assets/rhds.min.js'
-  });
-
-  const subpaths = (/** @type{`./${string}`[]}*/(elements.map(x => `./${x}/${x}.js`)));
-  await generator.install({
-    alias: `@rhds/elements`,
-    target: `/assets/elements/`,
-    subpaths
-  });
-
-  const map = generator.getMap();
-
+  // Now we redirect the previously-resolved local imports to the `/assets` dir
   map.imports = Object.fromEntries(Object.entries(map.imports).map(([k, v]) => [
     k, k === '@rhds/elements' ? '/assets/rhds.min.js'
       : k.startsWith('@rhds/elements') ? v.replace('./elements', '/assets/elements')
-      : v
+      : v.replace('./node_modules', '/assets/node_modules')
   ]));
 
-  map.imports['@popperjs/core'] = 'https://ga.jspm.io/npm:@popperjs/core@2.11.5/dist/umd/popper.js';
+  // This is unfortunate, but for now I couldn't find a better way - @bennyp
+  for (const scope in map.scopes) {
+    if (scope !== './') {
+      map.scopes['./'] = { ...map.scopes['./'], ...map.scopes[scope] };
+    }
+  }
+  map.imports = { ...map.scopes['./'], ...map.imports };
+
   return map;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@rhds/elements",
-  "version": "1.0.0-beta.24",
+  "version": "1.0.0-beta.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "1.0.0-beta.24",
+      "version": "1.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
         "@patternfly/pfe-accordion": "next",
         "@patternfly/pfe-autocomplete": "next",
         "@patternfly/pfe-avatar": "next",
         "@patternfly/pfe-badge": "next",
-        "@patternfly/pfe-band": "next",
+        "@patternfly/pfe-band": "^2.0.0-next.4",
         "@patternfly/pfe-button": "next",
         "@patternfly/pfe-card": "next",
         "@patternfly/pfe-collapse": "next",
@@ -36,7 +36,6 @@
         "@patternfly/pfe-tooltip": "next",
         "@rhds/tokens": "^1.0.0-beta.3",
         "lit": "^2.3.1",
-        "sinon": "^14.0.1",
         "tslib": "^2.4.0"
       },
       "devDependencies": {
@@ -67,6 +66,7 @@
         "postcss-pxtorem": "^6.0.0",
         "renamer": "^4.0.0",
         "sassdoc": "^2.7.4",
+        "sinon": "^14.0.1",
         "spandx": "^2.2.5",
         "stylelint": "^14.9.0",
         "stylelint-config-sass-guidelines": "^9.0.1",
@@ -2972,11 +2972,11 @@
       }
     },
     "node_modules/@patternfly/pfe-band": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-band/-/pfe-band-2.0.0-next.3.tgz",
-      "integrity": "sha512-jRqO+Kb76asXfRoEf4Ks04R6UIq0YhQIWTVPArONqybEr0mqllFXpBZ7CMZAVHRqDi/+E8OIhqfg422IQU4kzw==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-band/-/pfe-band-2.0.0-next.4.tgz",
+      "integrity": "sha512-yrnTPb+4vPuTr2vLLUKwjkiOdPP7cWrcTi8iTuFwGB8QmskBA6LwDrVfj53nHCOD397DtkKlySKmM+sTbFIq9A==",
       "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "@patternfly/pfe-core": "^2.0.0-next.10",
         "lit": "2.3.0"
       }
     },
@@ -3050,9 +3050,9 @@
       }
     },
     "node_modules/@patternfly/pfe-core": {
-      "version": "2.0.0-next.9",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.9.tgz",
-      "integrity": "sha512-cefeRcf/BdhIQLhtj0QUcixCKyZMF+q4ejX3vLMiElBnbCosJbSEQdF23Mkz0raW7/6CIofM3+W6BAS19mPMsA==",
+      "version": "2.0.0-next.10",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.10.tgz",
+      "integrity": "sha512-9ySuUTaUk/rwrPj/2nHFPxbSL3IFfGmYkRalLJ5LTHzNJbxIbDaRODLSPfSyMhg1q2Sdb4StIglyupttx6nNWg==",
       "dependencies": {
         "@popperjs/core": "2.11.6",
         "lit": "2.3.0"
@@ -4661,6 +4661,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
       "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -4669,6 +4670,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
       "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -4677,6 +4679,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
       "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -4686,7 +4689,8 @@
     "node_modules/@sinonjs/text-encoding": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
@@ -9629,6 +9633,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -15559,7 +15564,8 @@
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "node_modules/keygrip": {
       "version": "1.1.0",
@@ -16687,7 +16693,8 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.identity": {
       "version": "2.4.1",
@@ -17746,6 +17753,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
       "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": ">=5",
@@ -17757,12 +17765,14 @@
     "node_modules/nise/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/nise/node_modules/path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -22821,6 +22831,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.1.tgz",
       "integrity": "sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^9.1.2",
@@ -25592,6 +25603,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -29423,11 +29435,11 @@
       }
     },
     "@patternfly/pfe-band": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-band/-/pfe-band-2.0.0-next.3.tgz",
-      "integrity": "sha512-jRqO+Kb76asXfRoEf4Ks04R6UIq0YhQIWTVPArONqybEr0mqllFXpBZ7CMZAVHRqDi/+E8OIhqfg422IQU4kzw==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-band/-/pfe-band-2.0.0-next.4.tgz",
+      "integrity": "sha512-yrnTPb+4vPuTr2vLLUKwjkiOdPP7cWrcTi8iTuFwGB8QmskBA6LwDrVfj53nHCOD397DtkKlySKmM+sTbFIq9A==",
       "requires": {
-        "@patternfly/pfe-core": "^2.0.0-next.8",
+        "@patternfly/pfe-core": "^2.0.0-next.10",
         "lit": "2.3.0"
       },
       "dependencies": {
@@ -29509,9 +29521,9 @@
       }
     },
     "@patternfly/pfe-core": {
-      "version": "2.0.0-next.9",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.9.tgz",
-      "integrity": "sha512-cefeRcf/BdhIQLhtj0QUcixCKyZMF+q4ejX3vLMiElBnbCosJbSEQdF23Mkz0raW7/6CIofM3+W6BAS19mPMsA==",
+      "version": "2.0.0-next.10",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.10.tgz",
+      "integrity": "sha512-9ySuUTaUk/rwrPj/2nHFPxbSL3IFfGmYkRalLJ5LTHzNJbxIbDaRODLSPfSyMhg1q2Sdb4StIglyupttx6nNWg==",
       "requires": {
         "@popperjs/core": "2.11.6",
         "lit": "2.3.0"
@@ -30738,6 +30750,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
       "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -30746,6 +30759,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
       "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -30754,6 +30768,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
       "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -30763,7 +30778,8 @@
     "@sinonjs/text-encoding": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
@@ -34669,7 +34685,8 @@
     "diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -39223,7 +39240,8 @@
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "keygrip": {
       "version": "1.1.0",
@@ -40175,7 +40193,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "lodash.identity": {
       "version": "2.4.1",
@@ -41020,6 +41039,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
       "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": ">=5",
@@ -41031,12 +41051,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -44997,6 +45019,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.1.tgz",
       "integrity": "sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^9.1.2",
@@ -47230,7 +47253,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.21.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@patternfly/pfe-autocomplete": "next",
         "@patternfly/pfe-avatar": "next",
         "@patternfly/pfe-badge": "next",
-        "@patternfly/pfe-band": "^2.0.0-next.4",
         "@patternfly/pfe-button": "next",
         "@patternfly/pfe-card": "next",
         "@patternfly/pfe-collapse": "next",
@@ -2962,25 +2961,6 @@
       }
     },
     "node_modules/@patternfly/pfe-badge/node_modules/lit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
-      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
-      "dependencies": {
-        "@lit/reactive-element": "^1.4.0",
-        "lit-element": "^3.2.0",
-        "lit-html": "^2.3.0"
-      }
-    },
-    "node_modules/@patternfly/pfe-band": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-band/-/pfe-band-2.0.0-next.4.tgz",
-      "integrity": "sha512-yrnTPb+4vPuTr2vLLUKwjkiOdPP7cWrcTi8iTuFwGB8QmskBA6LwDrVfj53nHCOD397DtkKlySKmM+sTbFIq9A==",
-      "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-next.10",
-        "lit": "2.3.0"
-      }
-    },
-    "node_modules/@patternfly/pfe-band/node_modules/lit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
       "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
@@ -29419,27 +29399,6 @@
       "integrity": "sha512-NcxVUdiyQz3rM7fx8TXgTkUwGkJW9IHAiV3miDuihpgE+y4D2ovL5chFu82AigW2vs9XE3PPbcGWJ9K0oBDS/Q==",
       "requires": {
         "@patternfly/pfe-core": "^2.0.0-next.8",
-        "lit": "2.3.0"
-      },
-      "dependencies": {
-        "lit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
-          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
-          "requires": {
-            "@lit/reactive-element": "^1.4.0",
-            "lit-element": "^3.2.0",
-            "lit-html": "^2.3.0"
-          }
-        }
-      }
-    },
-    "@patternfly/pfe-band": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-band/-/pfe-band-2.0.0-next.4.tgz",
-      "integrity": "sha512-yrnTPb+4vPuTr2vLLUKwjkiOdPP7cWrcTi8iTuFwGB8QmskBA6LwDrVfj53nHCOD397DtkKlySKmM+sTbFIq9A==",
-      "requires": {
-        "@patternfly/pfe-core": "^2.0.0-next.10",
         "lit": "2.3.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -109,10 +109,10 @@
     "@patternfly/pfe-tooltip": "next",
     "@rhds/tokens": "^1.0.0-beta.3",
     "lit": "^2.3.1",
-    "sinon": "^14.0.1",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
+    "sinon": "^14.0.1",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@patternfly/pfe-autocomplete": "next",
     "@patternfly/pfe-avatar": "next",
     "@patternfly/pfe-badge": "next",
-    "@patternfly/pfe-band": "next",
+    "@patternfly/pfe-band": "^2.0.0-next.4",
     "@patternfly/pfe-button": "next",
     "@patternfly/pfe-card": "next",
     "@patternfly/pfe-collapse": "next",
@@ -112,7 +112,6 @@
     "tslib": "^2.4.0"
   },
   "devDependencies": {
-    "sinon": "^14.0.1",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
@@ -140,6 +139,7 @@
     "postcss-pxtorem": "^6.0.0",
     "renamer": "^4.0.0",
     "sassdoc": "^2.7.4",
+    "sinon": "^14.0.1",
     "spandx": "^2.2.5",
     "stylelint": "^14.9.0",
     "stylelint-config-sass-guidelines": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@patternfly/pfe-autocomplete": "next",
     "@patternfly/pfe-avatar": "next",
     "@patternfly/pfe-badge": "next",
-    "@patternfly/pfe-band": "^2.0.0-next.4",
     "@patternfly/pfe-button": "next",
     "@patternfly/pfe-card": "next",
     "@patternfly/pfe-collapse": "next",


### PR DESCRIPTION
## What I did

1. Got fed up with having to constantly update the docs demos import map
2. found out about `traceInstall`
3. scratch my head at why scopes aren't applying correctly to the importmap
4. give up and cludge it as usual, just this time a little nicer


## Testing Instructions

1. check the docs pages and demo pages in the DP

https://deploy-preview-626--red-hat-design-system.netlify.app/components/alert/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/blockquote/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/call-to-action/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/dialog/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/footer/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/pagination/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/secondary-nav/demo/
https://deploy-preview-626--red-hat-design-system.netlify.app/components/statistic/demo/



## Notes to Reviewers
Should make maintaining the demos/docs much easier