### PR TITLE
chore: scan files for links in precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
-
+sh scripts/scan-links.sh

--- a/docs/about/how-we-build.njk
+++ b/docs/about/how-we-build.njk
@@ -129,7 +129,7 @@ tags:
   <p><a href="https://www.drupal.org/project/patternkit" target="_blank">Patternkit 2.x</a> is a Drupal 8+ module that connects libraries like WebRH to content management systems like Drupal. It leverages the <a href="https://github.com/json-editor/json-editor" target="_blank">JSON Schema Editor</a> to expose the fields defined within the component and pattern schemas, so content authors can add content and change settings while seeing the results in real time.<br /><br /><a href="https://github.com/PatternBuilder/pattern-kit" target="_blank">Patternkit 1.x</a> is used by developers to develop, test, and demo WebRH patterns. The <a href="https://webrh-patternkit.int.open.paas.redhat.com/schema/pattern_page" target="_blank">WebRH Schema Editor</a> (formerly known as Patternkit) is a playground to interact with the WebRH pattern library. It is hosted on OpenShift and is updated every three weeks to show the latest updates to WebRH.</p>
 
   <rh-cta>
-    <a href="https://webrh-demo.apps.int.spoke.preprod.us-west-2.aws.paas.redhat.com/schema/blog_page" target="_blank">Learn more about Patternkit</a>
+    <a href="https://url.corp.redhat.com/webrh-schema-editor" target="_blank">Learn more about Patternkit</a>
   </rh-cta>
 
 {%- endcall %}

--- a/scripts/scan-links.sh
+++ b/scripts/scan-links.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# get a temp dir
+TMP_DIR="$(mktemp -d)"
+
+# get a temp file to store filenames and line numbers
+MATCHES="$(mktemp)"
+
+# App domains
+APPS_RE="([\w\-\.]+\.)?apps\.(int|ext-waf)\.(spoke|mpp)\.(prod|preprod)\.(us-(east|west)-(1|2)|iad2)\.(aws|dc)\.paas\.redhat\.com"
+# Console domains
+CONS_RE="console-openshift-console\.apps\.mpp[\w\-\.]{0,20}\.(p1\.openshiftapps|dc\.paas\.redhat)\.com"
+
+# copy working files to temp dir
+git checkout-index -a --prefix="$TMP_DIR/"
+
+# for each regexp test
+for RE in $APPS_RE $CONS_RE; do
+  cd $TMP_DIR
+  # for docs and elements dirs
+  for DIR in docs "elements/**/*.md"; do
+    # check those dirs' files with that regexp
+    grep -EHrni --color "$RE" $DIR
+    # and save the output
+    grep -EHrni "$RE" $DIR >> $MATCHES
+  done
+done
+
+# if the output has lines in it (i.e. matching urls were found)
+# Then report to the user and fail
+if [ `cat $MATCHES | wc -l` -gt 0 ]; then
+  echo ""
+  echo "Sensitive links found!"
+  rm -rf $TMP_DIR
+  exit 1
+else
+  rm -rf $TMP_DIR
+fi

--- a/scripts/scan-links.sh
+++ b/scripts/scan-links.sh
@@ -5,9 +5,30 @@ TMP_DIR="$(mktemp -d)"
 # get a temp file to store filenames and line numbers
 MATCHES="$(mktemp)"
 
-# App domains
+## App domains:
+#       (
+#         (One of **WORD**, `-`, or `.` (_>= 1x_))
+#         `.`
+#       )(_optional_)
+#      `apps.`
+#      (Either `int` or `ext-waf`)
+#      `.`
+#      (Either `spoke` or `mpp`)
+#      `.`
+#      (Either `prod` or `preprod`)
+#      `.`
+#      (Either (`us-`, (Either `east` or `west`), `-`, (Either `1` or `2`)), or `iad2`
+#      `.`
+#      (Either `aws` or `dc`)
+#      `.paas.redhat.com`
 APPS_RE="([\w\-\.]+\.)?apps\.(int|ext-waf)\.(spoke|mpp)\.(prod|preprod)\.(us-(east|west)-(1|2)|iad2)\.(aws|dc)\.paas\.redhat\.com"
-# Console domains
+
+## Console domains
+#      `console-openshift-console.apps.mpp`
+#      One of **WORD**, `-`, or `.` (_0-20x_)
+#      `.`
+#      (Either `p1.openshiftapps` or `dc.paas.redhat`)
+#      `.com`
 CONS_RE="console-openshift-console\.apps\.mpp[\w\-\.]{0,20}\.(p1\.openshiftapps|dc\.paas\.redhat)\.com"
 
 # copy working files to temp dir


### PR DESCRIPTION
## What I did

1. add a short bash script to git's pre-commit hook
   the script scans the docs and elements dirs on each commit and scans staged files for internal links. Pavlos Psomiadis provided the regexp's


## Testing Instructions

1. add an internal link to a file (see `docs: fix internal link`) commit 
2. try to commit it, it should fail

## Notes to Reviewers