### PR TITLE
fix: 654 - Adding lib folder to exports in package json

### DIFF
--- a/.changeset/tender-lies-play.md
+++ b/.changeset/tender-lies-play.md
@@ -2,4 +2,8 @@
 "@rhds/elements": patch
 ---
 
-Adding the lib/ folder to the exports in package.json
+Added the `lib/` directory to the exports in `package.json`. Users can now do things like import controllers into their own projects:
+
+```js
+import { ScreenSizeController } from '@rhds/elements/lib/ScreenSizeController.js';
+```

--- a/.changeset/tender-lies-play.md
+++ b/.changeset/tender-lies-play.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Adding the lib/ folder to the exports in package.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "customElements": "custom-elements.json",
   "exports": {
     ".": "./rhds.min.js",
+    "./lib/*": "./lib/*",
     "./*": "./elements/*"
   },
   "contributors": [


### PR DESCRIPTION
In RH Product Trials we ran into an issue building where the `ScreenSizeController` exported from `@rhds/elements` gets exported as `@rhds/elements/elements/lib` due to the current export mapping.  This adds a `./lib/*` to the exports so we can bring in the ScreenSizeController and other libraries as we need from `@rhds/elements`

## Related Issue
#654 