### PR TITLE
fix(alert): Adding logic to check for empty actions for margin-top

### DIFF
--- a/.changeset/long-colts-prove.md
+++ b/.changeset/long-colts-prove.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Fixing an issue with rh-alert where the margin-top would still exist on the footer when no actions were slotted.

--- a/.changeset/long-colts-prove.md
+++ b/.changeset/long-colts-prove.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-Fixing an issue with rh-alert where the margin-top would still exist on the footer when no actions were slotted.
+`<rh-alert>` fixed empty footer actions container still taking up blockwise space.

--- a/elements/rh-alert/rh-alert.css
+++ b/elements/rh-alert/rh-alert.css
@@ -123,7 +123,7 @@ header ::slotted(:is(h1,h2,h3,h4,h5,h6)) {
   margin-bottom: var(--rh-space-lg, 16px);
 }
 
-footer {
+footer.hasActions {
   margin-top: var(--rh-space-lg, 16px);
 }
 

--- a/elements/rh-alert/rh-alert.ts
+++ b/elements/rh-alert/rh-alert.ts
@@ -1,5 +1,8 @@
+import { SlotController } from '@patternfly/pfe-core/controllers/slot-controller.js';
+
 import { LitElement, html, svg } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 import { ComposedEvent } from '@patternfly/pfe-core';
 
@@ -67,6 +70,10 @@ export class RhAlert extends LitElement {
 
   @property({ reflect: true, type: Boolean }) dismissable = false;
 
+  #slots = new SlotController(this, {
+    slots: ['header', null, 'actions']
+  });
+
   #closeHandler() {
     const event = new AlertCloseEvent();
     if (this.dispatchEvent(event)) {
@@ -76,6 +83,7 @@ export class RhAlert extends LitElement {
   }
 
   render() {
+    const hasActions = this.#slots.hasSlotted('actions');
     return html`
       <div id="container" role="alert" aria-hidden="false">
         <div id="left-column">
@@ -96,7 +104,7 @@ export class RhAlert extends LitElement {
           <div id="description">
             <slot></slot>
           </div>
-          <footer>
+          <footer class="${classMap({ hasActions })}">
             <slot name="actions"></slot>
           </footer>
         </div>


### PR DESCRIPTION
## What I did

1.  Added a slot check for the Shadow DOM styles so the footer only gets the `margin-top` style when actions have been slotted in from the host. 

## Related Issue

#656 


## Testing Instructions

1. Go to the demo
3. Remove the actions from one of the alert elements
4. Inspect the Shadow DOM of that element, you should not see a `margin-top` on an empty footer now
5. You should still see the `margin-top` on the footers with actions slotted in.