### PR TITLE
fix(spinner): remove `on` attribute

### DIFF
--- a/.changeset/honest-hornets-tap.md
+++ b/.changeset/honest-hornets-tap.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Made `on` attribute of rh-spinner private

--- a/elements/rh-spinner/rh-spinner.css
+++ b/elements/rh-spinner/rh-spinner.css
@@ -72,11 +72,11 @@ circle.track {
   font-size: var(--rh-font-size-body-text-sm, 0.875rem);
 }
 
-:host([on="dark"]) circle.dash {
+circle.dash.dark {
   stroke: var(--rh-color-blue-200, #73bcf7);
 }
 
-:host([on="dark"]) circle.track {
+circle.track.dark {
   stroke: var(--rh-color-black-700, #3c3f42);
 }
 

--- a/elements/rh-spinner/rh-spinner.ts
+++ b/elements/rh-spinner/rh-spinner.ts
@@ -7,6 +7,7 @@ import type { ColorPalette, ColorTheme } from '../../lib/context/color.js';
 import { BaseSpinner } from '@patternfly/pfe-spinner/BaseSpinner.js';
 
 import styles from './rh-spinner.css';
+import { classMap } from 'lit/directives/class-map.js';
 
 export type SpinnerSize = (
   | 'sm'
@@ -36,8 +37,7 @@ export class RhSpinner extends BaseSpinner {
   /**
    * Sets color theme based on parent context
    */
-  @colorContextConsumer()
-  @property({ reflect: true }) on?: ColorTheme;
+  @colorContextConsumer({ attribute: false }) private on?: ColorTheme;
 
   /**
    * Preset sizes for the spinner
@@ -45,10 +45,11 @@ export class RhSpinner extends BaseSpinner {
   @property({ reflect: true }) size: SpinnerSize = 'lg';
 
   render() {
+    const { on = 'light' } = this;
     return html`
       <svg role="status" viewBox="0 0 100 100" aria-live="polite">
-        <circle class="track" cx="50" cy="50" r="40" fill="none" vector-effect="non-scaling-stroke" />
-        <circle class="dash" cx="50" cy="50" r="40" fill="none" vector-effect="non-scaling-stroke" />
+        <circle class="track ${classMap({ [on]: !!this.on })}" cx="50" cy="50" r="40" fill="none" vector-effect="non-scaling-stroke" />
+        <circle class="dash ${classMap({ [on]: !!this.on })}" cx="50" cy="50" r="40" fill="none" vector-effect="non-scaling-stroke" />
       </svg>
       <slot></slot>
     `;


### PR DESCRIPTION
## What I did

1. remove public `on` attribute from rh-spinner


## Testing Instructions

1. put spinner on different contexts
2. make sure it looks good
3. make sure it doesn't have an `on` attr
4. toggle `on` attr with different values and make sure setting `on` attribute has no effect.

## Notes to Reviewers
