### PR TITLE
fix(context): adds missing colors and demo

### DIFF
--- a/elements/rh-context-provider/demo/demo.css
+++ b/elements/rh-context-provider/demo/demo.css
@@ -1,0 +1,3 @@
+.example {
+    padding: 1rem;
+}

--- a/elements/rh-context-provider/demo/rh-context-provider.html
+++ b/elements/rh-context-provider/demo/rh-context-provider.html
@@ -1,0 +1,166 @@
+<link rel="stylesheet" href="demo.css">
+<script type="module" src="rh-context-provider.js"></script>
+
+<rh-context-provider color-palette="lightest">
+
+  <div class="example">
+    <h2>Lightest</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+
+<rh-context-provider color-palette="lighter">
+  <div class="example">
+    <h2>Lighter</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+
+<rh-context-provider color-palette="light">
+  <div class="example">
+    <h2>Light</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+
+<rh-context-provider color-palette="dark">
+  <div class="example">
+    <h2>Dark</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+
+<rh-context-provider color-palette="darker">
+  <div class="example">
+    <h2>Darker</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+
+<rh-context-provider color-palette="darkest">
+  <div class="example">
+    <h2>Darkest</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+
+
+<rh-context-provider color-palette="base">
+  <div class="example">
+    <h2>Base</h2>
+    <p>Here are some components that should be aware of their context:</p>
+
+    <rh-cta>Hello World</rh-cta>
+    <rh-spinner size="sm"></rh-spinner>
+    <rh-blockquote align="center">
+      <p>In open source, we feel strongly that to really do something well, you have to get a lot of people involved.</p>
+      <span slot="author">Linus Torvalds</span>
+      <span slot="title">Software Engineer</span>
+    </rh-blockquote>
+    <rh-stat>
+        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+            <path d="M17.37 8v10a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm7 0v7a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0Zm-14 0v12a.63.63 0 0 0 1.25 0V8a.63.63 0 0 0-1.25 0ZM31 17.89a.63.63 0 0 0-.63.62v11.87H5.62v-2.93a.63.63 0 0 0-1.25 0V31a.63.63 0 0 0 .63.62h26a.62.62 0 0 0 .62-.62V18.51a.62.62 0 0 0-.62-.62Z"/>
+            <path d="M5 21a.63.63 0 0 0 .62-.63V5.62h24.75V9a.63.63 0 0 0 1.25 0V5a.62.62 0 0 0-.62-.62H5a.63.63 0 0 0-.63.62v15.36A.63.63 0 0 0 5 21Zm27.35-9.24a.62.62 0 0 0-.87.17C28.73 16 21.5 22.93 4 23.27a.63.63 0 0 0 0 1.25c18.07-.34 25.64-7.61 28.52-11.9a.62.62 0 0 0-.17-.86Z"/>
+        </svg>
+        <span slot="statistic">Statistic Placeholder</span>
+        <span>Description Placeholder</span>
+    </rh-stat>
+  </div>
+</rh-context-provider>
+

--- a/elements/rh-context-provider/demo/rh-context-provider.js
+++ b/elements/rh-context-provider/demo/rh-context-provider.js
@@ -1,0 +1,7 @@
+import '@rhds/elements/rh-blockquote/rh-blockquote.js';
+import '@rhds/elements/rh-cta/rh-cta.js';
+import '@rhds/elements/rh-spinner/rh-spinner.js';
+import '@rhds/elements/rh-stat/rh-stat.js';
+
+import '@rhds/elements/rh-context-provider/rh-context-provider.js';
+

--- a/lib/context/color.ts
+++ b/lib/context/color.ts
@@ -19,8 +19,10 @@ export type ColorPalette = (
   | 'base'
   | 'accent'
   | 'complement'
+  | 'light'
   | 'lighter'
   | 'lightest'
+  | 'dark'
   | 'darker'
   | 'darkest'
 );

--- a/lib/context/context-color.css
+++ b/lib/context/context-color.css
@@ -8,7 +8,7 @@
  * background must create a new `dark` context for its descendents
  */
 
-:host(:is([color-palette=darker],[color-palette=darkest])) {
+:host(:is([color-palette=dark],[color-palette=darker],[color-palette=darkest])) {
   --context: dark;
   --rh-context-text: var(--rh-context-dark-color-text, #fff);
   --rh-context-text-muted: var(--rh-context-dark-color-text-muted, #d2d2d2);
@@ -54,15 +54,19 @@
 /* } */
 
 :host(:is([color-palette=lightest])) {
-  --rh-context-background-color: var(--rh-color-surface-lighest, #fff);
+  --rh-context-background-color: var(--rh-color-surface-lightest, #ffffff)
 }
 
 :host(:is([color-palette=lighter])) {
   --rh-context-background-color: var(--rh-color-surface-lighter, #f5f5f5);
 }
 
-:host(:is([color-palette=base])) {
-  --rh-context-background-color: var(--rh-color-surface-lighest, #fff);
+:host(:is([color-palette="light"])) {
+  --rh-context-background-color: var(--rh-color-surface-light, #f0f0f0);
+}
+
+:host(:is([color-palette=dark])) {
+  --rh-context-background-color: var(--rh-color-surface-dark, #3C3F42);
 }
 
 :host(:is([color-palette=darker])) {
@@ -72,6 +76,12 @@
 :host(:is([color-palette=darkest])) {
   --rh-context-background-color: var(--rh-color-surface-darkest, #151515);
 }
+
+:host(:is([color-palette=base])) {
+  --rh-context-background-color: var(--rh-color-surface-lightest, #fff);
+}
+
+
 
 /* FIXME: Saturated colors TBD */
 /* :host(:is([color-palette=complement])) { */


### PR DESCRIPTION
## What I did

1. Added `dark` and `light` as `ColorPalette` context colors
2. Added demos for `rh-context-provider` with components that should be context-aware

## Todo

- [ ] Address `rh-blockquote` not picking up the correct context.  See ~~deploy preview~~ localhost demo. (Should we fix this in this PR or open an issue and fix with a followup?)


## Dev Notes:

`rh-secondary-nav` is by default `color-palette="lighter"`.  However, it also has a dark variant `color-palette="dark"`. 
    
This was incorrectly mapped as `darker` in prior releases, and was exposed by this change to `rh-context-provider`. So when `rh-context-provider` started providing actual background colors using a container div in it's shadow root this caused the slotted cta in `rh-secondary-nav` to display the wrong (although correct by name) color background due to it being wrapped by `rh-context-provider`. 

`rh-secondary-nav` needs this `rh-context-provider` to handle the switch between secondary-nav's cta context from desktop (lighter|dark) to mobile (lightest) when the mobile menu is opened.  So, in order to fix this, we need to provide the `dark` surface token value and add it to the `ColorPalette` type which is what this PR does.

However, this brings up the question should `rh-context-provider` provide the background surface?  My original thought was it was nearly a wrapper that provides the context (and the ability to switch it) and that the components themselves would apply the correct surface colors. `rh-context-provider` was a way to inform child elements which are context aware of that change that may only exist in CSS.  At some point, I think having `rh-context-provider` provide the background color is almost like recreating `pfe-band`, but without the additional layout content.  That said, I'm not sure I have a strong opinion either way, but maybe this should be a discussion thread?

Secondary Nav Desktop Example:
```
 rh-secondary-nav color-palette="dark"
 |
 |_ rh-context-provider color-palette="dark"
    |
    |_rh-cta component gets on `dark`
```

Secondary Nav on Mobile Nav Open Example:
```
 rh-secondary-nav color-palette="dark" /* mobile nav button clicked and dropdown nav opens */
 |
 |_ rh-context-provider color-palette="lightest" /* changed in JS as CSS changes but parent context stays the same */
    |
    |_rh-cta component gets on `light`
```
