### PR TITLE
chore: changed assignee for github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-new-component.yml
+++ b/.github/ISSUE_TEMPLATE/1-new-component.yml
@@ -8,7 +8,7 @@ labels:
   - new component
 
 assignees:
-  - methomps
+  - paigenotfound404
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2-dev-handoff.yml
+++ b/.github/ISSUE_TEMPLATE/2-dev-handoff.yml
@@ -7,7 +7,7 @@ labels:
   - ready for development
 
 assignees:
-  - methomps
+  - paigenotfound404
 
 body:
   - type: markdown

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Red Hat Design System
 
+
 [Documentation](https://ux.redhat.com), [design tokens](https://red-hat-design-tokens.netlify.app),
 and [web components](https://ux.redhat.com/components) for building uniform experiences with the 
 Red Hat brand.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Red Hat Design System
 
-
 [Documentation](https://ux.redhat.com), [design tokens](https://red-hat-design-tokens.netlify.app),
 and [web components](https://ux.redhat.com/components) for building uniform experiences with the 
 Red Hat brand.


### PR DESCRIPTION
## What I did

1. Removed @methomps as the default assignee to new component requests and design to dev handoff requests and added @paigenotfound404.

## Notes to Reviewers

This is just a chore, no changelog necessary.