### PR TITLE
docs(secondary-nav): update pfe-icons in demos

### DIFF
--- a/elements/rh-secondary-nav/demo/analytics.html
+++ b/elements/rh-secondary-nav/demo/analytics.html
@@ -22,7 +22,7 @@
               <li>
                 <a href="#" data-analytics-text="Integrations" data-analytics-category="Explore|Why Red Hat Ansible Automation Platforms">
                   Integrations
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
@@ -33,7 +33,7 @@
               <li>
                 <a href="#" data-analytics-text="What is ansible" data-analytics-category="Explore|Why Red Hat Ansible Automation Platforms">
                   What is ansible
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
@@ -73,7 +73,7 @@
               <li>
                 <a href="#" data-analytics-text="Automation mesh" data-analytics-category="Explore|Additional Features">
                   Automation mesh
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
@@ -84,25 +84,25 @@
               <li>
                 <a href="#" data-analytics-text="Automation Hub" data-analytics-category="Explore|Additional Features">
                   Automation Hub
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#" data-analytics-text="Red Hat Insights for Red Hat Ansible Automation Platform" data-analytics-category="Explore|Additional Features">
                   Red Hat Insights for Red Hat Ansible Automation Platform
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#" data-analytics-text="Automation services catalog" data-analytics-category="Explore|Additional Features">
                   Automation services catalog
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#" data-analytics-text="Ansible content tools" data-analytics-category="Explore|Additional Features">
                   Ansible content tools
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>
@@ -123,19 +123,19 @@
             <li>
               <a href="#" data-analytics-text="Infrastructure" data-analytics-category="Use cases">
                 Infrastructure
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#" data-analytics-text="Applications" data-analytics-category="Use cases">
                 Applications
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#" data-analytics-text="Networks" data-analytics-category="Use cases">
                 Networks
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
           </ul>
@@ -143,19 +143,19 @@
             <li>
               <a href="#" data-analytics-text="Containers" data-analytics-category="Use cases">
                 Containers
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#" data-analytics-text="Security" data-analytics-category="Use cases">
                 Security
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#" data-analytics-text="Cloud" data-analytics-category="Use cases">
                 Cloud
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
           </ul>

--- a/elements/rh-secondary-nav/demo/dark-variant.html
+++ b/elements/rh-secondary-nav/demo/dark-variant.html
@@ -16,14 +16,14 @@
             <li>
               <a href="#">
                 Integrations
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li><a href="#">Custom success stories</a></li>
             <li>
               <a href="#">
                 What is ansible
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li><a href="#">Why choose Red Hat for automation?</a></li>
@@ -44,14 +44,14 @@
               <li>
                 <a href="#">
                   Integrations
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Custom success stories</a></li>
               <li>
                 <a href="#">
                   What is ansible
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Why choose Red Hat for automation?</a></li>

--- a/elements/rh-secondary-nav/demo/proxy.html
+++ b/elements/rh-secondary-nav/demo/proxy.html
@@ -47,14 +47,14 @@
                 <li>
                   <a href="#">
                     Integrations
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">Custom success stories</a></li>
                 <li>
                   <a href="#">
                     What is ansible
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">Why choose Red Hat for automation?</a></li>
@@ -74,32 +74,32 @@
                 <li>
                   <a href="#">
                     Automation mesh
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">Ansible Content Collections</a></li>
                 <li>
                   <a href="#">
                     Automation Hub
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Red Hat Insights for Red Hat Ansible Automation Platform
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Automation services catalog
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Ansible content tools
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
               </ul>
@@ -117,32 +117,32 @@
                 <li>
                   <a href="#">
                     Automation mesh
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">Ansible Content Collections</a></li>
                 <li>
                   <a href="#">
                     Automation Hub
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Red Hat Insights for Red Hat Ansible Automation Platform
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Automation services catalog
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Ansible content tools
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
               </ul>
@@ -161,19 +161,19 @@
               <li>
                 <a href="#">
                   Infrastructure
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Applications
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Networks
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>
@@ -181,19 +181,19 @@
               <li>
                 <a href="#">
                   Containers
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Security
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Cloud
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>
@@ -223,14 +223,14 @@
               <li>
                 <a href="#">
                   Integrations
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Custom success stories</a></li>
               <li>
                 <a href="#">
                   What is ansible
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Why choose Red Hat for automation?</a></li>
@@ -251,14 +251,14 @@
                 <li>
                   <a href="#">
                     Integrations
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">Custom success stories</a></li>
                 <li>
                   <a href="#">
                     What is ansible
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">Why choose Red Hat for automation?</a></li>

--- a/elements/rh-secondary-nav/demo/rh-secondary-nav.html
+++ b/elements/rh-secondary-nav/demo/rh-secondary-nav.html
@@ -20,14 +20,14 @@
               <li>
                 <a href="#">
                   Integrations
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Custom success stories</a></li>
               <li>
                 <a href="#">
                   What is ansible
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon icon="icon-new-window" color="info" size="sm"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Why choose Red Hat for automation?</a></li>
@@ -47,32 +47,32 @@
               <li>
                 <a href="#">
                   Automation mesh
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Ansible Content Collections</a></li>
               <li>
                 <a href="#">
                   Automation Hub
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Red Hat Insights for Red Hat Ansible Automation Platform
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Automation services catalog
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Ansible content tools
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>
@@ -90,32 +90,32 @@
               <li>
                 <a href="#">
                   Automation mesh
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li><a href="#">Ansible Content Collections</a></li>
               <li>
                 <a href="#">
                   Automation Hub
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Red Hat Insights for Red Hat Ansible Automation Platform
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Automation services catalog
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   Ansible content tools
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>
@@ -134,19 +134,19 @@
             <li>
               <a href="#">
                 Infrastructure
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#">
                 Applications
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#">
                 Networks
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
           </ul>
@@ -154,19 +154,19 @@
             <li>
               <a href="#">
                 Containers
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#">
                 Security
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
             <li>
               <a href="#">
                 Cloud
-                <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
               </a>
             </li>
           </ul>

--- a/elements/rh-secondary-nav/demo/translation.html
+++ b/elements/rh-secondary-nav/demo/translation.html
@@ -21,14 +21,14 @@
                 <li>
                   <a href="#">
                     אינטגרציות
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">סיפורי הצלחה מותאמים אישית</a></li>
                 <li>
                   <a href="#">
                     מה זה Ansible
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">למה לבחור Red Hat לאוטומציה?</a></li>
@@ -48,32 +48,32 @@
                 <li>
                   <a href="#">
                     רשת אוטומציה
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li><a href="#">אוספי תוכן של Ansible</a></li>
                 <li>
                   <a href="#">
                     רכזת אוטומציה
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     Red Hat Insights עבור Red Hat Ansible Automation Platform
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     קטלוג שירותי אוטומציה
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
                 <li>
                   <a href="#">
                     כלי תוכן Ansible
-                    <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                    <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                   </a>
                 </li>
               </ul>
@@ -92,19 +92,19 @@
               <li>
                 <a href="#">
                   תַשׁתִית
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   יישומים
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   רשתות
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>
@@ -112,19 +112,19 @@
               <li>
                 <a href="#">
                   מיכלים
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   בִּטָחוֹן
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
               <li>
                 <a href="#">
                   ענן
-                  <pfe-icon icon="web-icon-new-window" color="info" size="sm"></pfe-icon>
+                  <pfe-icon set="patternfly" icon="arrow" size="sm" loading="idle"></pfe-icon>
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
## What I did

1. Update `<pfe-icon>` usage in demos to use `set`.

## Testing Instructions

1. check out  [deploy preivew ](https://deploy-preview-696--red-hat-design-system.netlify.app/components/secondary-nav/demo/)- icons should load in dropdown menus