### PR TITLE
fix(accordion): adding right-to-left (rtl) styles

### DIFF
--- a/.changeset/two-wolves-push.md
+++ b/.changeset/two-wolves-push.md
@@ -2,6 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`rh-accordion` is being updated to fix the styling for right-to-left texts.  We are using logical properties to determine the position of the border on the header and panel elements.  We are also including a check inside the component for the nearest element that sets direction and applying these styles for the header icon rotation. 
-
-This will improve the user experience with languages that write from right to left.
+`<rh-accordion>`: fixed styles for RTL languages.

--- a/.changeset/two-wolves-push.md
+++ b/.changeset/two-wolves-push.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Updating right-to-left styles for rh-accordion for the border and the rotation of the header icon.

--- a/.changeset/two-wolves-push.md
+++ b/.changeset/two-wolves-push.md
@@ -2,4 +2,6 @@
 "@rhds/elements": patch
 ---
 
-Updating right-to-left styles for rh-accordion for the border and the rotation of the header icon.
+`rh-accordion` is being updated to fix the styling for right-to-left texts.  We are using logical properties to determine the position of the border on the header and panel elements.  We are also including a check inside the component for the nearest element that sets direction and applying these styles for the header icon rotation. 
+
+This will improve the user experience with languages that write from right to left.

--- a/elements/rh-accordion/demo/right-to-left.html
+++ b/elements/rh-accordion/demo/right-to-left.html
@@ -6,10 +6,10 @@
 
 <section dir="rtl" lang="he" id="rtl">
   <rh-accordion>
-    <rh-accordion-header>
+    <rh-accordion-header expanded>
       <h3>תוכנה חופשית</h3>
     </rh-accordion-header>
-    <rh-accordion-panel expanded>
+    <rh-accordion-panel>
       <p> ”תוכנה חופשית“ זה עניין של חירות, לא של מחיר. כדי להבין את העקרון, צריך לחשוב על ”חופש“ כמו ב”חופש הביטו“ ולא כמו ב”בירה חופשי“. </p>
 
       <rh-cta><a href="#">קראו עוד</a></rh-cta>

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -10,6 +10,7 @@
   --_font-size: var(--rh-font-size-body-text-md, 1rem);
   --_after-background-color: transparent;
   --_expanded-background-color: var(--rh-color-text-brand-on-light, #ee0000);
+  --_isRTL: -1;
 }
 
 #heading {
@@ -25,6 +26,10 @@
   --_active-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_expanded-background-color: var(--rh-color-brand-red-on-dark, #ff3333);
   --_border-inline-end-color: var(--rh-color-black-600, #6a6e73);
+}
+
+.rtl {
+  --_isRTL: 1;
 }
 
 :host([large]) {
@@ -93,7 +98,7 @@ span {
 }
 
 #button[aria-expanded="true"] #icon {
-  rotate: -180deg;
+  rotate: calc(var(--_isRTL, -1) * 180deg);
 }
 
 #button:hover,
@@ -111,4 +116,9 @@ span {
 #button:focus span,
 #button:active span {
   font-weight: var(--rh-font-weight-heading-bold, 700);
+}
+
+.toggle:after {
+  inset-block: 0;
+  inset-inline-start: 0;
 }

--- a/elements/rh-accordion/rh-accordion-header.ts
+++ b/elements/rh-accordion/rh-accordion-header.ts
@@ -32,11 +32,11 @@ import styles from './rh-accordion-header.css';
 export class RhAccordionHeader extends BaseAccordionHeader {
   static readonly version = '{{version}}';
 
+  static readonly styles = [...BaseAccordionHeader.styles, styles];
+
   @property({ reflect: true }) icon = 'angle-down';
 
   @property({ reflect: true, type: Boolean }) expanded = false;
-
-  static readonly styles = [...BaseAccordionHeader.styles, styles];
 
   #dir = new DirController(this);
 

--- a/elements/rh-accordion/rh-accordion-header.ts
+++ b/elements/rh-accordion/rh-accordion-header.ts
@@ -5,6 +5,7 @@ import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { colorContextConsumer } from '../../lib/context/color.js';
+import { DirController } from '../../lib/DirController.js';
 
 import { BaseAccordionHeader } from '@patternfly/pfe-accordion/BaseAccordionHeader.js';
 
@@ -37,12 +38,15 @@ export class RhAccordionHeader extends BaseAccordionHeader {
 
   static readonly styles = [...BaseAccordionHeader.styles, styles];
 
+  #dir = new DirController(this);
+
   @colorContextConsumer() private on?: ColorTheme;
 
   override render(): TemplateResult {
     const { on = '' } = this;
+    const rtl = this.#dir.dir === 'rtl';
     return html`
-      <div id="container" class="${classMap({ [on]: !!on })}">${super.render()}</div>
+      <div id="container" class="${classMap({ [on]: !!on, rtl })}">${super.render()}</div>
     `;
   }
 

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -77,6 +77,8 @@
 .body:after {
   width: var(--_panel-body--before--Width, var(--rh-border-width-lg, 3px));
   background-color: var(--_panel-body--before-background-color, transparent);
+  inset-block: 0;
+  inset-inline-start: 0;
 }
 
 .content {

--- a/elements/rh-accordion/rh-accordion.css
+++ b/elements/rh-accordion/rh-accordion.css
@@ -8,6 +8,7 @@
 :host([on="dark"]) {
   --_border-color: var(--rh-color-black-600, #6a6e73);
 }
+
 #container { display: contents; }
 
 ::slotted(rh-accordion-header:first-child) {

--- a/elements/rh-accordion/rh-accordion.ts
+++ b/elements/rh-accordion/rh-accordion.ts
@@ -1,18 +1,18 @@
 import type { TemplateResult } from 'lit';
 import type { ColorPalette, ColorTheme } from '../../lib/context/color.js';
 
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { customElement, property } from 'lit/decorators.js';
+
 import { colorContextConsumer, colorContextProvider } from '../../lib/context/color.js';
 
 import { observed } from '@patternfly/pfe-core/decorators/observed.js';
-import { customElement, property } from 'lit/decorators.js';
 
 import styles from './rh-accordion.css';
 import { BaseAccordion } from '@patternfly/pfe-accordion/BaseAccordion.js';
 import './rh-accordion-header.js';
 import './rh-accordion-panel.js';
-import { html } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
-
 
 /**
  * Accordions toggle the visibility of sections of content.


### PR DESCRIPTION
## What I did

1.  Added logical properties to .toggle:after for the red border on the accordion elements
2. Added --_isRTL to handle whether or not the rotation of the icon needs to happen clockwise (applicable for right-to-left text) or counter-clockwise (applicable for left-to-right text)

## Testing Instructions

- [ ] Go to the deploy link right-to-left demo
- [ ] Check that the following styles are correct
  - [ ] Text orientation
  - [ ] Red border position
  - [ ] Icon rotation on expand  