### PR TITLE
fix(tooltip): dark context

### DIFF
--- a/.changeset/six-needles-study.md
+++ b/.changeset/six-needles-study.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tooltip>`: fixed tooltips on dark contexts

--- a/elements/rh-tooltip/rh-tooltip.ts
+++ b/elements/rh-tooltip/rh-tooltip.ts
@@ -22,13 +22,13 @@ export class RhTooltip extends BaseTooltip {
   static readonly styles = [...BaseTooltip.styles, styles];
 
   @colorContextConsumer()
-  private on: ColorTheme = 'light';
+  private on?: ColorTheme;
 
   @property() position: Placement = 'top';
   @property() content?: string;
 
   override render() {
-    const { on } = this;
+    const { on = '' } = this;
     return html`
       <div id="container" class="${classMap({ [on]: !!on })}">
         ${super.render()}


### PR DESCRIPTION
Noticed that the dark mode theme was not showing up for rh-tooltip after #693, fixing this issue. 

## What I did

1.  Changed the color context to not default to `light` for rh-tooltip
2. Added the empty string backup for the on property.


## Testing Instructions
1. [Go to the deploy preview demo for rh-tooltip ](https://deploy-preview-713--red-hat-design-system.netlify.app/components/tooltip/demo/)
2. Verify the dark mode theme looks correct