### PR TITLE
fix: Corrected href for footer logo links

### DIFF
--- a/.changeset/clever-moose-invent.md
+++ b/.changeset/clever-moose-invent.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-footer>` Corrected href for footer logo links.  They were incorrectly pointing
+to the `href="/en"` url. They have been changed to `href="/"`.

--- a/elements/rh-footer/RhFooter.ts
+++ b/elements/rh-footer/RhFooter.ts
@@ -104,7 +104,7 @@ export class RhFooter extends LitElement {
                 <slot name="header-primary">
                   <div class="logo" part="logo">
                     <slot name="logo">
-                      <a href="/en">
+                      <a href="/">
                         <img alt="Red Hat" src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg"/>
                       </a>
                     </slot>

--- a/elements/rh-footer/demo/proxy.html
+++ b/elements/rh-footer/demo/proxy.html
@@ -18,7 +18,7 @@
 </script>
 <template id="rh-footer-spandx-template">
     <rh-footer>
-    <a slot="logo" href="/en">
+    <a slot="logo" href="/">
       <img src="https://via.placeholder.com/170x40" alt="Red Hat logo" loading="lazy" />
     </a>
     <rh-footer-social-link slot="social-links" icon="linkedin">

--- a/elements/rh-footer/rh-global-footer.ts
+++ b/elements/rh-footer/rh-global-footer.ts
@@ -59,7 +59,7 @@ export class RhGlobalFooter extends LitElement {
             <slot name="logo">
               <a class="global-logo-anchor"
                   part="logo-anchor"
-                  href="/en"
+                  href="/"
                   alt="Visit Red Hat">
                 <svg title="Red Hat logo"
                     class="global-logo-image"

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -8,7 +8,7 @@ import '../rh-footer.js';
 
 const KITCHEN_SINK = html`
   <rh-footer>
-    <a slot="logo" href="/en">
+    <a slot="logo" href="/">
       <img src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg" alt="Red Hat logo"
         loading="lazy" />
     </a>


### PR DESCRIPTION
## What I did

1. Changed all instances of `href="/en"` to `href="/"` in our rh-footer components and in our docs.


## Testing Instructions

1.

## Notes to Reviewers
