### PR TITLE
fix(global-footer): correct logo href

### DIFF
--- a/.changeset/fair-schools-deliver.md
+++ b/.changeset/fair-schools-deliver.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+<rh-global-footer>: corrected the href for the global-footer logo to point to rhdc

--- a/elements/rh-footer/rh-global-footer.ts
+++ b/elements/rh-footer/rh-global-footer.ts
@@ -59,7 +59,7 @@ export class RhGlobalFooter extends LitElement {
             <slot name="logo">
               <a class="global-logo-anchor"
                   part="logo-anchor"
-                  href="/"
+                  href="https://redhat.com"
                   alt="Visit Red Hat">
                 <svg title="Red Hat logo"
                     class="global-logo-image"

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -251,6 +251,13 @@ describe('<rh-footer>', function() {
       });
     });
 
+    describe('global-footer behaviors', function() {
+      it('logo anchor tag should always link to redhat.com', async function() {
+        const globalElement = await fixture<RhGlobalFooter>(GLOBAL_FOOTER);
+        expect(globalElement.shadowRoot?.querySelector('slot[name="logo"] a')?.getAttribute('href')).to.equal('https://redhat.com');
+      });
+    });
+
     describe('global-footer links stack correctly.', function() {
       let globalElement: HTMLElement;
       let primaryLinks: HTMLElement;


### PR DESCRIPTION
## What I did

1. The fedora logo in `rh-global-footer` should always point to the Red Hat homepage no matter what site it's on.  I updated the logo url in the shadowroot to no longer be relative but absolute instead.
2. Added a test to check the logo slot for the absolute link to RHDC.


## Testing Instructions

1. Go to https://deploy-preview-730--red-hat-design-system.netlify.app/components/footer/demo/
2. Click on the gray Fedora in the universal footer (rh-global-footer)
3. Verify that you were redirected to the Red Hat .com homepage (https://redhat.com)

