### PR TITLE
fix: remove husky from postinstall for users

### DIFF
--- a/.changeset/eight-garlics-grow.md
+++ b/.changeset/eight-garlics-grow.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Removed postinstall husky script from users

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "lint": "wireit",
     "postinstall": "wireit",
     "patch": "patch-package",
-    "husky": "husky install"
+    "husky": "husky install",
+    "prepack": "npx pinst --disable",
+    "postpack": "npx pinst --enable"
   },
   "wireit": {
     "start": {


### PR DESCRIPTION
## What I did

1. remove husky step from postinstall when it's just users doing `npm i @rhds/elements`

