### PR TITLE
fix(footer): accordion styles at mobile screen sizes

### DIFF
--- a/.changeset/spotty-moose-draw.md
+++ b/.changeset/spotty-moose-draw.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-<rh-footer>`: fixed accordion styles to support rh-accordion
+`<rh-footer>`: fixed accordion styles to support rh-accordion

--- a/.changeset/spotty-moose-draw.md
+++ b/.changeset/spotty-moose-draw.md
@@ -2,4 +2,8 @@
 "@rhds/elements": patch
 ---
 
-`<rh-footer>`: fixed accordion styles at mobile screen sizes
+`<rh-accordion>`: fixed double border on expanded state
+
+`<rh-footer>`: fixed accordion styles at mobile screen sizes ([#707][issue])
+
+[issue]: https://github.com/RedHat-UX/red-hat-design-system/issues/707

--- a/.changeset/spotty-moose-draw.md
+++ b/.changeset/spotty-moose-draw.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-footer>`: fixed accordion styles to support rh-accordion
+`<rh-footer>`: fixed accordion styles at mobile screen sizes

--- a/.changeset/spotty-moose-draw.md
+++ b/.changeset/spotty-moose-draw.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-asdf
+<rh-footer>`: fixed accordion styles to support rh-accordion

--- a/.changeset/spotty-moose-draw.md
+++ b/.changeset/spotty-moose-draw.md
@@ -3,7 +3,3 @@
 ---
 
 `<rh-accordion>`: fixed double border on expanded state
-
-`<rh-footer>`: fixed accordion styles at mobile screen sizes ([#707][issue])
-
-[issue]: https://github.com/RedHat-UX/red-hat-design-system/issues/707

--- a/.changeset/spotty-moose-draw.md
+++ b/.changeset/spotty-moose-draw.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+asdf

--- a/.changeset/spotty-moose-sculpt.md
+++ b/.changeset/spotty-moose-sculpt.md
@@ -1,0 +1,7 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-footer>`: fixed accordion styles at mobile screen sizes ([#707][issue])
+
+[issue]: https://github.com/RedHat-UX/red-hat-design-system/issues/707

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -24,7 +24,7 @@
   --_background-color: var(--rh-color-surface-darkest, #151515);
   --_active-background-color: var(--rh-color-surface-darkest, #151515);
   --_active-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
-  --_expanded-background-color: var(--rh-color-brand-red-on-dark, #ff3333);
+  --_expanded-background-color: var(--rh-color-brand-red-on-dark, #ff442b);
   --_border-inline-end-color: var(--rh-color-black-600, #6a6e73);
 }
 
@@ -69,7 +69,7 @@
     var(--_padding-inline-end)
     var(--_padding-block-end)
     var(--_padding-inline-start);
-  font-family: var(--rh-font-family-body-text, RedHatText, "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Overpass, Helvetica, Arial, sans-serif);
+  font-family: var(--rh-font-family-body-text, RedHatText, "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif);
   font-size: var(--_font-size, var(--rh-font-size-body-text-md, 1rem));
   font-weight: var(--rh-font-weight-heading-medium, 500);
   color: var(--_text-color);

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -41,7 +41,7 @@
 }
 
 :host([expanded]) {
-  border-inline-end: 2px solid var(--_border-inline-end-color, #d2d2d2);
+  border-inline-end: 1px solid var(--_border-inline-end-color, #d2d2d2);
 }
 
 :host(.animating) #button,

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -41,7 +41,7 @@
 }
 
 :host([expanded]) {
-  border-inline-end: 1px solid var(--_border-inline-end-color, #d2d2d2);
+  border-inline-end: var(--rh-border-width-sm, 1px) solid var(--_border-inline-end-color, #d2d2d2);
 }
 
 :host(.animating) #button,

--- a/elements/rh-accordion/rh-accordion-header.ts
+++ b/elements/rh-accordion/rh-accordion-header.ts
@@ -47,7 +47,7 @@ export class RhAccordionHeader extends BaseAccordionHeader {
     const { on = '' } = this;
     const rtl = this.#dir.dir === 'rtl';
     return html`
-      <div id="container" class="${classMap({ [on]: !!on, rtl })}">${super.render()}</div>
+      <div id="container" class="${classMap({ [on]: !!on, rtl })}" part="container">${super.render()}</div>
     `;
   }
 

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -56,7 +56,7 @@
   position: unset;
 }
 
-#container {
+#rhds-container {
   border-inline-end:
     1px solid var(
       --_panel-border-inline-end-color,

--- a/elements/rh-accordion/rh-accordion-panel.ts
+++ b/elements/rh-accordion/rh-accordion-panel.ts
@@ -30,7 +30,7 @@ export class RhAccordionPanel extends BaseAccordionPanel {
   override render() {
     const { on = '' } = this;
     return html`
-      <div class="${classMap({ [on]: !!on })}">${super.render()}</div>
+      <div id="rhds-container" class="${classMap({ [on]: !!on })}">${super.render()}</div>
     `;
   }
 }

--- a/elements/rh-accordion/rh-accordion-panel.ts
+++ b/elements/rh-accordion/rh-accordion-panel.ts
@@ -30,7 +30,7 @@ export class RhAccordionPanel extends BaseAccordionPanel {
   override render() {
     const { on = '' } = this;
     return html`
-      <div id="container" class="${classMap({ [on]: !!on })}">${super.render()}</div>
+      <div class="${classMap({ [on]: !!on })}">${super.render()}</div>
     `;
   }
 }

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -319,3 +319,17 @@ footer,
     ) !important;
   color: var(--rh-color-white, #ffffff) !important;
 }
+
+/* @todo We should consider rolling this into the rh-accordion design spec */
+rh-accordion-header[expanded] {
+  --_border-inline-end-color: var(--_border-color);
+}
+
+rh-accordion-header:not([expanded])::part(container) {
+  --_background-color: var(--rh-color-surface-darker, #212427);
+  --_active-background-color: var(--rh-color-surface-darker, #212427);
+}
+
+rh-accordion-header:hover {
+  --_after-background-color: var(--_accent-color);
+}


### PR DESCRIPTION
## What I did

1.  Added a shadow part on the rh-accordion-header container so we can override private CSS props
2. Added overrides to rh-accordion-header private CSS props to fix visual regressions switching from pfe-accordion to rh-accordion.
3. Removed a duplicate `id="container"` which was causing double border


## Testing Instructions

1. Go to https://deploy-preview-742--red-hat-design-system.netlify.app/components/footer/demo/
2. Shrink the screen size until the footer accordion is visible.
4. Ensure that there are no unwanted regressions to the UI of the accordion.

## Notes to Reviewers

There are two intentional regressions
 1. The dropdown animation is now matching rh-accordion dropdown functionality
 2. The size of the accordion headers coming from the rh-accordion spec

## Screenshots

![Screenshot 2023-02-20 at 2 07 57 PM](https://user-images.githubusercontent.com/3428964/220183740-bdfcd988-cbbf-41f3-93de-cfb55f9ff930.png)
![Screenshot 2023-02-20 at 2 08 08 PM](https://user-images.githubusercontent.com/3428964/220183750-92c6a380-f706-42cf-a3d2-4cca47091770.png)


