### PR TITLE
fix(alert): remove `rem` values from icon height, width

### DIFF
--- a/.changeset/rude-carpets-switch.md
+++ b/.changeset/rude-carpets-switch.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-alert>`: used design tokens for icon dimensions

--- a/elements/rh-alert/rh-alert.css
+++ b/elements/rh-alert/rh-alert.css
@@ -96,8 +96,8 @@ header ::slotted(:is(h1,h2,h3,h4,h5,h6)) {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--rh-font-size-body-text-2xl, 1.5rem);
-  height: var(--rh-font-size-body-text-2xl, 1.5rem);
+  width: var(--rh-size-icon-02, 24px);
+  height: var(--rh-size-icon-02, 24px);
   color: var(--_icon-color);
 }
 


### PR DESCRIPTION
#655 

CSS update to the `rh-alert` element to replace the `1.5rem` value token that was used for the height / width and replace it with `var(--rh-size-icon-02, 24px)`.  