### PR TITLE
docs: remove abspath hack in import map

### DIFF
--- a/CONTRIBUTING_DEV.md
+++ b/CONTRIBUTING_DEV.md
@@ -54,3 +54,16 @@ npm start
 ```
 
 This starts a local dev server at http://localhost:8000 and the 11ty dev server for the docs site at http://localhost:8080
+
+To run *only* the components dev server, first run the build, then run the dev 
+server:
+```bash
+npm run build
+npx wds --open --watch
+```
+
+To run *only* the docs dev server, first run the build, then 11ty
+```bash
+npm run build
+npx eleventy --serve --incremental
+```

--- a/docs/_plugins/importMap.cjs
+++ b/docs/_plugins/importMap.cjs
@@ -63,27 +63,12 @@ module.exports = function(eleventyConfig, {
     generator.importMap.set('@rhds/elements/lib/', '/assets/packages/@rhds/elements/lib/');
 
     // Node modules
-    // HACK: at @jspm/generator 1.0.4 it became apparently necessary to use a relative path here
-    generator.importMap.replace(
-      pathToFileURL(join(cwd, 'node_modules/')).href,
-      './assets/packages/',
-    );
+    generator.importMap.replace(pathToFileURL(join(cwd, 'node_modules/')).href, '/assets/packages/');
+
+    // for some reason, `@lrnwebcomponents/code-sample` shows up in the import map under cwd scope
+    generator.importMap.replace(`${pathToFileURL(cwd).href}/`, '/assets/packages/');
 
     const json = generator.importMap.flatten().combineSubpaths().toJSON();
-
-    // HACK: convert the relative path from above to the abspath it always knew it wanted to be
-    if (json.imports) {
-      for (const [k, v] of Object.entries(json.imports)) {
-        json.imports[k] = v.replace('./assets', '/assets');
-      }
-    }
-    if (json.scopes) {
-      for (const [scope, map] of Object.entries(json.scopes)) {
-        for (const [k, v] of Object.entries(map)) {
-          json.scopes[scope][k] = v.replace('./assets', '/assets');
-        }
-      }
-    }
 
     // HACK: extract the scoped imports to the main map, since they're all local
     // this might not be necessary if we flatten to a single lit version


### PR DESCRIPTION
## What I did

1. investigated the problem in the import map related to abspaths and found it had something to do with `@lrnwebcomponents/code-sample`
2. alias that package specifically, and remove the previous hack


## Testing Instructions

1. check demo pages, including nested demos 
    - cta demo https://deploy-preview-756--red-hat-design-system.netlify.app/components/call-to-action/demo/
    - cta nested demo https://deploy-preview-756--red-hat-design-system.netlify.app/components/call-to-action/demo/analytics/

## Notes to Reviewers
