### PR TITLE
fix(menu)!: remove dropdown functionality

### DIFF
--- a/elements/rh-audio-player/rh-audio-player.css
+++ b/elements/rh-audio-player/rh-audio-player.css
@@ -313,8 +313,36 @@ rh-audio-player-range {
   --_svg-size: var(--rh-icon-size-02, 24px);
 }
 
+[part="toolbar"],
+#menu-container {
+  position: relative;
+}
+
 #menu {
   margin: 0 8px;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 10000;
+  transition: opacity 300ms cubic-bezier(0.54, 1.5, 0.38, 1.11) 0s;
+  translate: var(--_floating-content-translate);
+  max-width: calc(100vw - 10px);
+  max-height: calc(100vh - 10px);
+  width: max-content;
+  top: 0;
+  left: 0;
+  will-change: opacity;
+}
+
+#menu[aria-hidden="false"] {
+  opacity: 1;
+  pointer-events: all;
+}
+
+#menu-button {
+  display: inline-block;
+  position: relative;
+  width: max-content;
 }
 
 #menu-tooltip {

--- a/elements/rh-menu/rh-menu.css
+++ b/elements/rh-menu/rh-menu.css
@@ -1,11 +1,15 @@
 :host {
-  display: inline-flex;
+  display: contents;
 }
 
-#container {
-  display: inline;
-  position: relative;
-  width: min-content;
+slot {
+  display: inline-flex;
+  align-items: stretch;
+  flex-direction: column;
+  width: max-content;
+  border: 1px solid var(--_border-color);
+  box-shadow: var(--_box-shadow);
+  background: var(--_surface-color);
 
   --_surface-color:
     var(--rh-menu-background-color,
@@ -16,54 +20,8 @@
     var(--rh-box-shadow-md, 0 4px 6px 1px rgba(21, 21, 21, 0.25)));
 }
 
-#container.dark {
+slot.dark {
   --_surface-color: var(--rh-menu-background-color, var(--rh-color-surface-darkest, #151515));
   --_border-color: var(--rh-menu-border-color, var(--rh-color-border-subtle-on-dark, #6a6e73));
   --_box-shadow: var(--rh-menu-box-shadow, none);
-}
-
-#button {
-  display: inline-block;
-  position: relative;
-  width: max-content;
-}
-
-[part="menu"] {
-  position: absolute;
-  display: block;
-  opacity: 0;
-  pointer-events: none;
-  z-index: 10000;
-  transition: opacity 300ms cubic-bezier(0.54, 1.5, 0.38, 1.11) 0s;
-  translate: var(--_floating-content-translate);
-  max-width: calc(100vw - 10px);
-  max-height: calc(100vh - 10px);
-  width: max-content;
-  top: 0;
-  left: 0;
-  will-change: opacity;
-  border: 1px solid var(--_border-color);
-  box-shadow: var(--_box-shadow);
-  background: var(--_surface-color);
-}
-
-.open [part="menu"] {
-  opacity: 1;
-  pointer-events: all;
-}
-
-slot:not([name]) {
-  display: inline-flex;
-  align-items: stretch;
-  flex-direction: column;
-}
-
-*[hidden],
-::slotted([hidden]),
-:host([hidden]) {
-  display: none !important;
-}
-
-::slotted(rh-button:focus-within) {
-  background: red;
 }

--- a/elements/rh-menu/rh-menu.ts
+++ b/elements/rh-menu/rh-menu.ts
@@ -1,15 +1,10 @@
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
-import { property } from 'lit/decorators/property.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { styleMap } from 'lit/directives/style-map.js';
 import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
-import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 import { ComposedEvent } from '@patternfly/pfe-core';
 import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
-import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
-import { FloatingDOMController, type Placement } from '@patternfly/pfe-core/controllers/floating-dom-controller.js';
 
 import styles from './rh-menu.css';
 
@@ -24,260 +19,63 @@ export class MenuToggleEvent extends ComposedEvent {
 
 /**
  * Menu
- * @slot button - button that opens menu
- * @slot        - items for menu
+ * @slot - menu items
  * @cssprop --rh-menu-background-color - background-color for the menu - {@default var(--rh-color-surface-lightest, #ffffff)}
  * @cssprop --rh-menu-border-color - border color for menu on dark or saturated - {@default transparent));
  * @cssprop --rh-menu-box-shadow - box-shadow for the menu - {@default var(--rh-menu-box-shadow, var(--rh-box-shadow-md, 0 4px 6px 1px rgb(21 21 21 / 0.25)))}
- * @fires {RhMenuToggle} toggle - when the player menu is toggled
  */
 @customElement('rh-menu')
 export class RhMenu extends LitElement {
   static readonly styles = [styles];
 
-  /** are the menu and button disabled  */
-  @property({ type: Boolean }) disabled = false;
-
-  /** keeps menu open after a menu item has been clicked  */
-  @property({ type: Boolean }) persistent = false;
-
-  /** position of menu, relative to invoking button */
-  @property() position: Placement = 'bottom';
-
-  /** ID of the element which toggles the menu. Must be in the same root. */
-  @property() toggle?: string;
-
-  @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette?: ColorPalette;
-
   @colorContextConsumer() private on?: ColorTheme;
 
   #tabindex = new RovingTabindexController(this);
 
-  /** if mouse is hovering on menu or button  */
-  #hover = false;
-
-  /** if focus is on button or a menu items  */
-  #focus = false;
-
-  /** if menumitems have been initialized  */
-  #init = false;
-
-  /** menu button element  */
-  #menuButton?: HTMLElement;
-
-  #lastActive?:HTMLElement;
-
-  #internals = new InternalsController(this, {
-    role: 'menu',
-  });
-
-  #float = new FloatingDOMController(this, {
-    content: (): HTMLElement | undefined | null => this.shadowRoot?.getElementById('button')
-  });
-
-  get open() {
-    const { open } = this.#float;
-    return !!open;
-  }
-
-  firstUpdated() {
-    this.#initMenuButton();
-    if (!this.#init) {
-      this.#initMenuItems();
-    }
+  get activeItem() {
+    return this.#tabindex.activeItem;
   }
 
   connectedCallback() {
     super.connectedCallback();
     this.id ||= getRandomId('menu');
-    this.addEventListener('click', this.#onClick);
-    this.addEventListener('keydown', this.#onKeydown);
+    this.setAttribute('role', 'menu'); // TODO: use InternalsController.role when support/polyfill is better
+    this.#initItems();
   }
 
   render() {
-    const { on = '', hidden, disabled } = this;
-    const { alignment, anchor, open, styles } = this.#float;
+    const { on = '' } = this;
     return html`
-      <div id="container"
-           style="${styleMap(styles)}"
-           class="${classMap({
-             open,
-             [on]: !!on,
-             [anchor]: !!anchor,
-             [alignment]: !!alignment })}">
-        <slot id="button" name="button"></slot>
-        <slot id="menu"
-              part="menu"
-              aria-hidden="${String(!open) as 'true'|'false'}"
-              ?disabled=${!!disabled || !open}
-              ?hidden="${!!hidden}"
-              @focusin=${this.#onFocusin}
-              @focusout=${this.#onFocusout}
-              @mouseover=${this.#onMouseover}
-              @mouseout=${this.#onMouseout}>
-        </slot>
-      </div>
+      <slot class="${classMap({ [on]: !!on })}"></slot>
     `;
-  }
-
-  updated(changedProperties:Map<string, unknown>) {
-    if (!this.toggle && changedProperties.has('disabled')) {
-      this.#menuButton?.toggleAttribute('disabled', this.disabled);
-    }
-    if (!this.toggle && changedProperties.has('hidden')) {
-      this.#menuButton?.toggleAttribute('hidden', this.hidden);
-    }
-    if (!this.open) {
-      this.#lastActive = this.#tabindex.activeItem;
-      for (const item of this.querySelectorAll<HTMLElement>('[tabindex]:not([slot="button"])')) {
-        item.tabIndex = -1;
-      }
-    }
-  }
-
-  #findMenuButton() {
-    let toggleElement;
-    if (this.toggle) {
-      const root = this.getRootNode() as ShadowRoot | Document;
-      toggleElement = root.getElementById(this.toggle);
-    }
-    return this.#getButton(toggleElement ?? this.querySelector('[slot="button"]')) ?? undefined;
-  }
-
-  /**
-   * given button slot or toggle attr, finds menu button and sets attributes accordingly
-   */
-  #initMenuButton() {
-    this.#menuButton = this.#findMenuButton();
-    if (this.#menuButton) {
-      this.#menuButton.id ||= getRandomId('menu-button');
-      this.disabled = this.#menuButton.hasAttribute('disabled');
-      this.hidden = this.#menuButton.hasAttribute('hidden');
-      this.setAttribute('aria-labelledby', this.#menuButton.id);
-      this.#menuButton.setAttribute('aria-controls', this.id);
-      this.#menuButton.setAttribute('aria-haspopup', 'true');
-      this.#menuButton.setAttribute('aria-expanded', String(!!this.open));
-    }
-    this.requestUpdate();
   }
 
   /**
    * finds menu items and sets attributes accordingly
    */
-  #initMenuItems() {
+  #initItems() {
     const items = Array.from(this.children)
-      .map(item => this.#getButton(item))
-      .filter(x => x !== this.#menuButton && x instanceof HTMLElement);
+      .map(getItemElement)
+      .filter((x): x is HTMLElement => x instanceof HTMLElement);
     items.forEach(item => item?.setAttribute('role', 'menuitem'));
     this.#tabindex.initItems(items);
     this.requestUpdate();
   }
 
-  /**
-   * given a slotted item returns item that is not an rh-tooltip
-   */
-  #getButton(element: Element | null) {
-    return (
-        element?.localName !== 'rh-tooltip' ? element
-      : element?.querySelector(':not([slot=content])')
-    ) as HTMLElement;
+  activateItem(item: HTMLElement) {
+    this.#tabindex.updateActiveItem(item);
+    this.#tabindex.focusOnItem(item);
   }
+}
 
-  #toggle() {
-    if (this.open) {
-      this.hide(true);
-    } else {
-      this.show();
-    }
-  }
-
-  /**
-   * handles click events on button and menu
-   */
-  #onClick(event: Event) {
-    if (this.persistent) {
-      return;
-    } else if (event.composedPath().includes(this.#menuButton as EventTarget)) {
-      this.#toggle();
-    }
-  }
-
-  #onKeydown(event: KeyboardEvent) {
-    switch (event.key) {
-      case 'Escape':
-        this.hide(true);
-    }
-  }
-
-  /** sets focus state when part of button or menu has focus */
-  #onFocusin() {
-    this.#focus = true;
-    this.requestUpdate();
-  }
-
-  /** removes focus state when part of button or menu has focus */
-  #onFocusout() {
-    this.#focus = false;
-    this.requestUpdate();
-    setTimeout(this.hide.bind(this), 300);
-  }
-
-  /** sets hover state when part of button or menu is hovered */
-  #onMouseover() {
-    this.#hover = true;
-    this.requestUpdate();
-  }
-
-  /** removes hover state when part of button or menu no longer hovered */
-  #onMouseout() {
-    this.#hover = false;
-    this.requestUpdate();
-  }
-
-  #onWindowClick = (event: MouseEvent) => {
-    if (!event.composedPath().includes(this)) {
-      this.hide(true);
-      window.removeEventListener('click', this.#onWindowClick);
-    }
-  };
-
-  /**
-   * opens menu
-   */
-  async show() {
-    if (this.#lastActive) {
-      this.#tabindex.updateActiveItem(this.#lastActive);
-    }
-    await this.updateComplete;
-    const placement = this.position;
-    const button = this.shadowRoot?.getElementById('button') as HTMLElement;
-    const menu = this.shadowRoot?.querySelector('[part="menu"]') as HTMLElement;
-    const width = 0 - (button?.offsetWidth ?? 0) + (menu?.offsetWidth ?? 0);
-    const height = 0 - (button?.offsetHeight ?? 0) + (menu?.offsetHeight ?? 0);
-    const offset =
-        placement?.match(/left/) ? { mainAxis: width, alignmentAxis: 0 }
-      : placement?.match(/top/) ? { mainAxis: height, alignmentAxis: 0 }
-      : { mainAxis: 0, alignmentAxis: 0 };
-    await this.#float.show({ offset, placement });
-    await this.updateComplete;
-    await (this.#tabindex.activeItem as LitElement)?.updateComplete;
-    this.#tabindex.focusOnItem(this.#tabindex.activeItem);
-    this.#menuButton?.setAttribute('aria-expanded', String(!!this.open));
-    this.dispatchEvent(new MenuToggleEvent(this.open, this));
-    window.addEventListener('click', this.#onWindowClick);
-  }
-
-  /**
-   * closes menu
-   */
-  async hide(force?: boolean) {
-    if (!!force || (!this.#focus && !this.#hover)) {
-      await this.#float.hide();
-      this.#menuButton?.setAttribute('aria-expanded', String(!!this.open));
-      this.dispatchEvent(new MenuToggleEvent(this.open, this));
-    }
-  }
+/**
+ * Given an element, returns self, or child that is not an rh-tooltip
+ */
+function getItemElement(element: Element) {
+  return (
+      element.localName !== 'rh-tooltip' ? element
+    : element.querySelector(':not([slot=content])')
+  );
 }
 
 declare global {


### PR DESCRIPTION
## What I did

1. remove all the dropdown/button/floating-ui stuff from menu 
2. reimplemented that stuff in audio-player
3. this fixes cross-root aria problems between the button and the menu, but does not provide for `activedescendent`


## Testing Instructions

1. a11y audits and manual testing in blink, ff, and webkit

## Notes to Reviewers
the floating-ui parts of this change need to be fiddled with, they're not ready to ship yet