### PR TITLE
fix(subnav): lightdom styles

### DIFF
--- a/.changeset/giant-cobras-tease.md
+++ b/.changeset/giant-cobras-tease.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-subnav>`:
+  - Added `rh-subnav-lightdom.css` to reduce layout shift before element is defined

--- a/.changeset/giant-cobras-tease.md
+++ b/.changeset/giant-cobras-tease.md
@@ -2,5 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-subnav>`:
-  - Added `rh-subnav-lightdom.css` to reduce layout shift before element is defined
+`<rh-subnav>`: Added `rh-subnav-lightdom.css` to reduce layout shift before element is defined

--- a/elements/rh-subnav/demo/color-context.html
+++ b/elements/rh-subnav/demo/color-context.html
@@ -1,5 +1,6 @@
 
 <link rel="stylesheet" href="demo.css">
+<link rel="stylesheet" href="../rh-subnav-lightdom.css">
 <script type="module" src="rh-subnav.js"></script>
 <script type="module" src="color-context.js"></script>
 

--- a/elements/rh-subnav/demo/rh-subnav.html
+++ b/elements/rh-subnav/demo/rh-subnav.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="demo.css"/>
+<link rel="stylesheet" href="../rh-subnav-lightdom.css">
 <script type="module" src="rh-subnav.js"></script>
 
 <div class="example">

--- a/elements/rh-subnav/rh-subnav-lightdom.css
+++ b/elements/rh-subnav/rh-subnav-lightdom.css
@@ -1,0 +1,28 @@
+rh-subnav:not(:defined) {
+  display: flex;
+  background-color: var(--rh-context-background-color, #f5f5f5);
+}
+
+rh-subnav:not(:defined) a {
+  display: block !important;
+  white-space: nowrap !important;
+  padding: var(--rh-space-lg, 16px) var(--rh-space-2xl, 32px) !important;
+  text-decoration: none !important;
+  color: var(--rh-color-text-secondary-on-light, #6a6e73) !important;
+  position: relative !important;
+}
+
+rh-subnav:not(:defined) a:after {
+  content: "" !important;
+  position: absolute !important;
+  top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  border-block-end: var(--rh-border-width-lg, 3px) solid transparent !important;
+}
+
+rh-subnav:not(:defined) a[active]:after {
+  border-block-end-color: var(--rh-color-brand-red-on-light, #ee0000) !important;
+}


### PR DESCRIPTION
## What I did

1. Added `rh-subnav-lightdom.css` to reduce layout shift before the element is defined

Closes #777 

## Testing Instructions

1. View the [deploy preview demo](https://deploy-preview-781--red-hat-design-system.netlify.app/components/subnav/demo/) on a slow 3G network. 

## Notes to Reviewers

Simulate a slow 3G network in the networks tab of the browser inspector.  Should be little to no layout shift as the page loads.  
