### PR TITLE
fix(subnav): add font-size initial to lightdom styles

### DIFF
--- a/elements/rh-subnav/rh-subnav-lightdom.css
+++ b/elements/rh-subnav/rh-subnav-lightdom.css
@@ -1,3 +1,7 @@
+rh-subnav {
+  font-size: initial;
+}
+
 rh-subnav:not(:defined) {
   display: flex;
   background-color: var(--rh-context-background-color, #f5f5f5);


### PR DESCRIPTION
## What I did

1. Adds `font-size: initial` to lightdom styles.


## Testing Instructions

1. View the deploy preview, and ensure the correct font size.

## Notes to Reviewers
Font size should be `16px` for `rh-subnav` links on `ux.`