### PR TITLE
fix(footer): copyright spans whole row

### DIFF
--- a/.changeset/rh-footer-copyright-row.md
+++ b/.changeset/rh-footer-copyright-row.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-footer-universal>`: improves layout of copyright statement

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -103,3 +103,7 @@ rh-footer:not(:defined) > *:not([slot="logo"], :is(rh-footer-universal, rh-globa
   width: 100%;
   min-height: 176px;
 }
+
+rh-footer-universal rh-footer-copyright {
+  grid-column: -1/1;
+}

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -333,3 +333,7 @@ rh-accordion-header:not([expanded])::part(container) {
 rh-accordion-header:hover {
   --_after-background-color: var(--_accent-color);
 }
+
+::slotted(rh-footer-copyright) {
+  grid-column: -1/1;
+}


### PR DESCRIPTION
Closes #562 
## What I did

1. span the copyright statement across all grid columns
## Testing Instructions
https://deploy-preview-805--red-hat-design-system.netlify.app/elements/footer/demo/ at responsive widths, copyright should span the full width
