### PR TITLE
fix(accordion): remove overflow from headers

### DIFF
--- a/.changeset/silver-jars-wait.md
+++ b/.changeset/silver-jars-wait.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-accordion>`: prevented unwanted scrollbars from appearing in headers

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -91,7 +91,6 @@
 
 span {
   max-width: calc(100% - var(--rh-space-xl, 24px));
-  overflow: auto;
   text-overflow: unset;
   white-space: normal;
   text-align: start;


### PR DESCRIPTION
## What I did

1. Removing overflow on `span` element from `rh-accordion-header` as it's causing visual error on mobile screens for `rh-footer`.
