### PR TITLE
refactor: remove context tokens

### DIFF
--- a/.changeset/remove-context-tokens.md
+++ b/.changeset/remove-context-tokens.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": major
+---
+
+**Color Context**: Removed deprecated context tokens

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -13,7 +13,7 @@
 
 .dark {
   --_background-color: var(--rh-color-surface-darkest, #151515);
-  --_panel-color: var(--rh-context-dark-color-text, #ffffff);
+  --_panel-color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_panel-content-body-accent-color: var(--rh-color-brand-on-dark, #ff442b);
   --_panel-border-inline-end-color: var(--rh-color-border-subtle-on-dark, #6a6e73);
 }

--- a/elements/rh-avatar/rh-avatar.css
+++ b/elements/rh-avatar/rh-avatar.css
@@ -9,7 +9,7 @@
 
 #container {
   display: grid;
-  color: var(--rh-context-light-color-text-muted, #6a6e73);
+  color: var(--rh-color-text-secondary-on-light, #6a6e73);
 
   --_colors: var(--rh-avatar-colors,
   var(--rh-color-blue-200, #73bcf7)
@@ -77,7 +77,7 @@ slot {
 .dark ::slotted(a:hover) { color: var(--rh-color-interactive-blue-lightest, #bee1f4); }
 
 #container.dark {
-  color: var(--rh-context-dark-color-text-muted, #d2d2d2);
+  color: var(--rh-color-text-secondary-on-dark, #d2d2d2);
 
   --_colors: var(--rh-avatar-colors,
   var(--rh-color-blue-400, #0066cc)

--- a/elements/rh-badge/rh-badge.css
+++ b/elements/rh-badge/rh-badge.css
@@ -1,5 +1,5 @@
 :host {
-  --_color: var(--rh-context-light-color-text, #151515);
+  --_color: var(--rh-color-text-primary-on-light, #151515);
   --_background-color: var(--rh-color-black-200, #f0f0f0);
 
   background-color: var(--_background-color);
@@ -15,12 +15,12 @@
 }
 
 :host([state="info"]) {
-  --_color: var(--rh-context-dark-color-text, #ffffff);
+  --_color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_background-color: var(--rh-color-blue-400, #0066cc);
 }
 
 :host([state="success"]) {
-  --_color: var(--rh-context-dark-color-text, #ffffff);
+  --_color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_background-color: var(--rh-color-green-500, #3e8635);
 }
 
@@ -30,11 +30,11 @@
 }
 
 :host([state="important"]) {
-  --_color: var(--rh-context-dark-color-text, #ffffff);
+  --_color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_background-color: var(--rh-color-red-600, #be0000);
 }
 
 :host([state="critical"]) {
-  --_color: var(--rh-context-dark-color-text, #ffffff);
+  --_color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_background-color: var(--rh-color-red-700, #8f0000);
 }

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -79,7 +79,7 @@
   --_link-hover-background-color: transparent;
 
   /* CLOSE */
-  --_close-color: var(--rh-context-light-color-text-muted, #6a6e73);
+  --_close-color: var(--rh-color-text-secondary-on-light, #6a6e73);
   --_close-background-color: transparent;
   --_close-active-color: var(--rh-color-black-900, #151515);
   --_close-active-background-color: transparent;
@@ -234,7 +234,7 @@ button {
 
 button:after {
   position: absolute;
-  inset: 0 0 0 0;
+  inset: 0;
   content: "";
   border-style: solid;
   border-color: var(--_border-color);
@@ -477,7 +477,7 @@ button[disabled] {
   pointer-events: none;
   cursor: default;
 
-  --_color: var(--rh-context-light-color-text-muted, #6a6e73);
+  --_color: var(--rh-color-text-secondary-on-light, #6a6e73);
   --_background-color: var(--rh-color-black-300, #d2d2d2);
 }
 

--- a/elements/rh-context-provider/rh-context-provider.css
+++ b/elements/rh-context-provider/rh-context-provider.css
@@ -1,5 +1,5 @@
 :host {
   display: block;
-  background-color: var(--rh-context-background-color);
-  color: var(--rh-context-text);
+  background-color: var(--_context-background-color);
+  color: var(--_context-text);
 }

--- a/elements/rh-cta/rh-cta.css
+++ b/elements/rh-cta/rh-cta.css
@@ -43,7 +43,7 @@
   border-radius: var(--rh-border-radius-default, 3px);
   border-width: var(--rh-border-width-sm, 1px);
 
-  --rh-context-background-color: var(--rh-cta-background-color) !important;
+  --_context-background-color: var(--rh-cta-background-color) !important;
   --_arrow-size: 13px;
 }
 
@@ -192,14 +192,14 @@ svg {
   --rh-cta-hover-background-color: transparent;
   --rh-cta-hover-border-color: transparent;
   --rh-cta-hover-inner-border-color: transparent;
-  --rh-cta-hover-color: var(--rh-context-color-link-hover, #004080);
+  --rh-cta-hover-color: var(--rh-color-interactive-blue-darkest, #004080);
   --rh-cta-hover-text-decoration: none;
   --rh-cta-focus-background-color: transparent;
 
   /* --rh-color-border-interactive-on-light with 10% opacity */
   --rh-cta-focus-container-background-color: #0066cc1a;
   --rh-cta-focus-border-color: transparent;
-  --rh-cta-focus-color: var(--rh-context-light-color-focus, #0066cc);
+  --rh-cta-focus-color: var(--rh-color-interactive-blue-darker, #0066cc);
   --rh-cta-focus-inner-border-color: transparent;
   --rh-cta-focus-text-decoration: none;
 

--- a/elements/rh-footer/docs/20-guidelines.md
+++ b/elements/rh-footer/docs/20-guidelines.md
@@ -2,7 +2,7 @@ The footer is divided into two parts, the **modular** footer and **universal**
 footer. Most of the content in the modular footer can be customized whereas the 
 content in the universal footer is the same across all websites.
 
-![Footer component anatomy]({{ '/assets/footer/footer-anatomy.png' | url }}) 
+![Footer component anatomy][anatomy] 
 
 #### Website logo
 
@@ -37,7 +37,7 @@ websites.
 
 #### Default
 
-![Footer component interaction state - default]({{ '/assets/footer/footer-interaction-state-default.png' | url }})
+![Footer component interaction state - default][interaction-default]
 
 | Interaction State | Element                    | Text Styling                                         |
 | ----------------- | -------------------------- | ---------------------------------------------------- |
@@ -49,15 +49,15 @@ websites.
 
 #### Hover
 
-![Footer component interaction state - hover]({{ '/assets/footer/footer-interaction-state-hover.png' | url }}) 
+![Footer component interaction state - hover][interaction-hover] 
 
-| Interaction State        | Element                    | Text Styling                         |
-| -----------------        | -------------------------  | ------------------------------------ |
-| Hover, Focus, and Active | Social media link          | `--rh-color-black-400`               |
-| Hover, Focus, and Active | Modular nav link           | `--rh-color-white` / Underline       |
-| Hover, Focus, and Active | Call to action             | `--rh-context-dark-text-link-hover`  |
-| Hover, Focus, and Active | Red Hat fedora icon        | `--rh-color-black-400`               |
-| Hover, Focus, and Active | Universal nav & legal link | `--rh-color-white`  / Underline      |
+| Interaction State        | Element                    | Text Styling                           |
+| -----------------        | -------------------------  | ------------------------------------   |
+| Hover, Focus, and Active | Social media link          | `--rh-color-black-400`                 |
+| Hover, Focus, and Active | Modular nav link           | `--rh-color-white` / Underline         |
+| Hover, Focus, and Active | Call to action             | `--rh-color-interactive-blue-lighter`  |
+| Hover, Focus, and Active | Red Hat fedora icon        | `--rh-color-black-400`                 |
+| Hover, Focus, and Active | Universal nav & legal link | `--rh-color-white`  / Underline        |
 
 #### Focus
 
@@ -141,4 +141,7 @@ us](mailto:digital-design-system@redhat.com).
 To learn how to use our other components in your designs, visit the 
 [Components]({{ '/components/' | url }}) section.
 
-
+[anatomy]: {{ '/assets/footer/footer-anatomy.png' | url }}
+[interaction-default]: {{ '/assets/footer/footer-interaction-state-default.png' 
+| url }}
+[interaction-hover]: {{ '/assets/footer/footer-interaction-state-hover.png' | url }}

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -43,11 +43,11 @@
 
 :is(rh-secondary-nav-menu, rh-navigation-secondary-menu) a {
   text-decoration: none;
-  color: var(--rh-context-light-color-text-link, #0066cc);
+  color: var(--rh-color-interactive-blue-darker, #0066cc);
 }
 
 :is(rh-secondary-nav-menu, rh-navigation-secondary-menu) a:hover {
-  color: var(--rh-context-light-color-text-link-hover, #004080) !important;
+  color: var(--rh-color-interactive-blue-darkest, #004080) !important;
   text-decoration: none !important;
 }
 

--- a/elements/rh-subnav/rh-subnav-lightdom.css
+++ b/elements/rh-subnav/rh-subnav-lightdom.css
@@ -1,6 +1,6 @@
 rh-subnav:not(:defined) {
   display: flex;
-  background-color: var(--rh-context-background-color, #f5f5f5);
+  background-color: var(--_context-background-color, #f5f5f5);
 }
 
 rh-subnav:not(:defined) a {

--- a/elements/rh-subnav/rh-subnav.css
+++ b/elements/rh-subnav/rh-subnav.css
@@ -4,33 +4,33 @@
 
 [part="container"] {
   display: flex;
-  background-color: var(--rh-context-background-color, #f5f5f5);
+  background-color: var(--_context-background-color, #f5f5f5);
 }
 
 [part="container"]:not(.dark),
 .light {
   --_subnav-link-text-color: var(--rh-color-text-secondary-on-light, #6a6e73);
-  --_subnav-link-hover-text-color: var(--rh-context-light-color-text, #151515);
+  --_subnav-link-hover-text-color: var(--rh-color-text-primary-on-light, #151515);
   --_subnav-link-hover-border-end-color: var(--rh-color-border-subtle-on-light, #d2d2d2);
   --_subnav-link-active-border-end-color: var(--rh-color-brand-red-on-light, #ee0000);
   --_subnav-link-visited-text-color: var(--rh-color-text-secondary-on-light, #6a6e73);
   --_subnav-link-focus-outline-color: var(--rh-color-border-interactive-on-light, #0066cc);
   --_subnav-next-prev-button-text-color: var(--rh-color-text-secondary-on-light, #6a6e73);
   --_subnav-next-prev-disabled-text-color: var(--rh-color-border-subtle-on-light, #d2d2d2);
-  --_subnav-next-prev-hover-text-color: var(--rh-context-light-color-text, #151515);
+  --_subnav-next-prev-hover-text-color: var(--rh-color-text-primary-on-light, #151515);
   --_subnav-next-prev-border-color: var(--rh-color-border-subtle-on-light, #d2d2d2);
 }
 
 .dark {
   --_subnav-link-text-color: var(--rh-color-text-secondary-on-dark, #d2d2d2);
-  --_subnav-link-hover-text-color: var(--rh-context-dark-color-text, #ffffff);
+  --_subnav-link-hover-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_subnav-link-hover-border-end-color: var(--rh-color-border-subtle-on-dark, #6a6e73);
   --_subnav-link-active-border-end-color: var(--rh-color-brand-red-on-dark, #ff442b);
   --_subnav-link-visited-text-color: var(--rh-color-text-secondary-on-dark, #d2d2d2);
   --_subnav-link-focus-outline-color: var(--rh-color-border-interactive-on-dark, #73bcf7);
   --_subnav-next-prev-button-text-color: var(--rh-color-text-secondary-on-dark, #d2d2d2);
   --_subnav-next-prev-disabled-text-color: var(--rh-color-border-subtle-on-dark, #6a6e73);
-  --_subnav-next-prev-hover-text-color: var(--rh-context-dark-color-text, #ffffff);
+  --_subnav-next-prev-hover-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_subnav-next-prev-border-color: var(--rh-color-border-subtle-on-dark, #6a6e73);
 }
 

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -126,7 +126,7 @@ button:after {
 /* Active Box (Not Vertical) */
 :host([active][box]:not([vertical])) button:after {
   border-block-start: var(--rh-border-width-lg, 3px) solid var(--_active-tab-border-color);
-  border-block-end: var(--rh-border-width-sm, 1px) solid var(--rh-context-background-color);
+  border-block-end: var(--rh-border-width-sm, 1px) solid var(--_context-background-color);
 }
 
 /* Active Vertical */
@@ -143,7 +143,7 @@ button:after {
 /* Box Vertical Active */
 :host([box][vertical][active]) button:before {
   border-inline-start: var(--rh-border-width-lg, 3px) solid var(--_active-tab-border-color);
-  border-inline-end: var(--rh-border-width-sm, 1px) solid var(--rh-context-background-color);
+  border-inline-end: var(--rh-border-width-sm, 1px) solid var(--_context-background-color);
 }
 
 :host([box][vertical]:not([active])) button:before {

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -6,7 +6,7 @@
   --_arrow-color: var(--rh-color-accent-base-on-light, #0066cc);
   --_overflow-button-text-color: var(--rh-color-text-secondary-on-light, #6a6e73);
   --_overflow-button-disabled-text-color: #d2d2d2;
-  --_overflow-button-hover-text-color: var(--rh-context-light-color-text, #151515);
+  --_overflow-button-hover-text-color: var(--rh-color-text-primary-on-light, #151515);
 }
 
 #rhds-container.dark {
@@ -14,7 +14,7 @@
   --_arrow-color: var(--rh-color-accent-base-on-dark, #73bcf7);
   --_overflow-button-text-color: var(--rh-color-text-secondary-on-dark, #d2d2d2);
   --_overflow-button-disabled-text-color: #6a6e73;
-  --_overflow-button-hover-text-color: var(--rh-context-dark-color-text, #ffffff);
+  --_overflow-button-hover-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
 }
 
 [part="tabs-container"]:before {
@@ -95,7 +95,7 @@
 #nextTab {
   padding-block: 0;
   padding-inline: var(--rh-space-xl, 24px);
-  background-color: var(--rh-context-background-color);
+  background-color: var(--_context-background-color);
   color: var(--_overflow-button-text-color);
   position: relative;
   z-index: 2;

--- a/lib/context/color/context-color.css
+++ b/lib/context/color/context-color.css
@@ -7,13 +7,11 @@
 :host(:is([color-palette^="dark"])) {
   --context: dark;
   --_context-text: var(--rh-color-text-primary-on-dark, #ffffff);
-  --_context-text-muted: var(--rh-color-text-secondary-on-dark, #d2d2d2);
 }
 
 :host(:is([color-palette^="light"],[color-palette="base"])) {
   --context: light;
   --_context-text: var(--rh-color-text-primary-on-light, #151515);
-  --_context-text-muted: var(--rh-color-text-secondary-on-light, #6a6e73);
 }
 
 :host(:is([color-palette="lightest"])) {

--- a/lib/context/color/context-color.css
+++ b/lib/context/color/context-color.css
@@ -1,69 +1,45 @@
 /**
  * It's important for `color-palette` to take precedence over `on`
  * when setting `--context`, because a `dark` card that's on a `light`
- * background must create a new `dark` context for its descendents
+ * background must create a new `dark` context for its descendants
  */
 
 :host(:is([color-palette^="dark"])) {
   --context: dark;
-  --rh-context-text: var(--rh-context-dark-color-text, #ffffff);
-  --rh-context-text-muted: var(--rh-context-dark-color-text-muted, #d2d2d2);
-  --rh-context-link: var(--rh-context-dark-color-text-link, #73bcf7);
-  --rh-context-link-hover: var(--rh-context-dark-color-text-link-hover, #bee1f4);
-  --rh-context-link-focus: var(--rh-context-dark-color-text-link-focus, #bee1f4);
-  --rh-context-link-visited: var(--rh-context-dark-color-text-link-visited, #a18fff);
-  --rh-context-link-visited-hover: var(--rh-context-dark-color-text-link-visited-hover, #cbc1ff);
-
-  /*
-  --rh-context-link-decoration: var(--rh-theme--link-decoration--on-dark, none);
-  --rh-context-link-decoration-hover: var(--rh-theme--link-decoration-hover--on-dark, underline);
-  --rh-context-link-decoration-focus: var(--rh-theme--link-decoration-focus--on-dark, underline);
-  --rh-context-link-decoration--visited: var(--rh-theme--link-decoration--visited--on-dark, none);
-  */
+  --_context-text: var(--rh-color-text-primary-on-dark, #ffffff);
+  --_context-text-muted: var(--rh-color-text-secondary-on-dark, #d2d2d2);
 }
 
 :host(:is([color-palette^="light"],[color-palette="base"])) {
   --context: light;
-  --rh-context-text: var(--rh-context-light-color-text, #151515);
-  --rh-context-text-muted: var(--rh-context-light-color-text-muted, #6a6e73);
-  --rh-context-link: var(--rh-context-light-color-text-link, #0066cc);
-  --rh-context-link-hover: var(--rh-context-light-color-text-link-hover, #004080);
-  --rh-context-link-focus: var(--rh-context-light-color-text-link-focus, #004080);
-  --rh-context-link-visited: var(--rh-context-light-color-text-link-visited, #6753ac);
-  --rh-context-link-visited-hover: var(--rh-context-light-color-text-link-visited-hover, #1f0066);
-
-  /*
-  --rh-context-link-decoration: var(--rh-theme--link-decoration, none);
-  --rh-context-link-decoration-hover: var(--rh-theme--link-decoration-hover, underline);
-  --rh-context-link-decoration-focus: var(--rh-theme--link-decoration-focus, underline);
-  --rh-context-link-decoration--visited: var(--rh-theme--link-decoration--visited, none);
-  */
+  --_context-text: var(--rh-color-text-primary-on-light, #151515);
+  --_context-text-muted: var(--rh-color-text-secondary-on-light, #6a6e73);
 }
 
 :host(:is([color-palette="lightest"])) {
-  --rh-context-background-color: var(--rh-color-surface-lightest, #ffffff);
+  --_context-background-color: var(--rh-color-surface-lightest, #ffffff);
 }
 
 :host(:is([color-palette="lighter"])) {
-  --rh-context-background-color: var(--rh-color-surface-lighter, #f5f5f5);
+  --_context-background-color: var(--rh-color-surface-lighter, #f5f5f5);
 }
 
 :host(:is([color-palette="light"])) {
-  --rh-context-background-color: var(--rh-color-surface-light, #f0f0f0);
+  --_context-background-color: var(--rh-color-surface-light, #f0f0f0);
 }
 
 :host(:is([color-palette="base"])) {
-  --rh-context-background-color: var(--rh-color-surface-lightest, #ffffff);
+  --_context-background-color: var(--rh-color-surface-lightest, #ffffff);
 }
 
 :host(:is([color-palette="dark"])) {
-  --rh-context-background-color: var(--rh-color-surface-dark, #3c3f42);
+  --_context-background-color: var(--rh-color-surface-dark, #3c3f42);
 }
 
 :host(:is([color-palette="darker"])) {
-  --rh-context-background-color: var(--rh-color-surface-darker, #212427);
+  --_context-background-color: var(--rh-color-surface-darker, #212427);
 }
 
 :host(:is([color-palette="darkest"])) {
-  --rh-context-background-color: var(--rh-color-surface-darkest, #151515);
+  --_context-background-color: var(--rh-color-surface-darkest, #151515);
 }


### PR DESCRIPTION
Depends on https://github.com/RedHat-UX/red-hat-design-tokens/pull/82
Closes #810 
## What I did

1. remove all references to `--rh-context-*` tokens
2. replace the `--rh-context-text` and `--rh-context-background` tokens with "private" `--_context-*` vars

## Testing Instructions
DPs:

- [x] [accordion](https://deploy-preview-817--red-hat-design-system.netlify.app/components/accordion/demo/color-context/)
- [x] [avatar](https://deploy-preview-817--red-hat-design-system.netlify.app/components/avatar/demo/color-context/)
- [x] [badge](https://deploy-preview-817--red-hat-design-system.netlify.app/components/badge/demo/)
- [x] [button](https://deploy-preview-817--red-hat-design-system.netlify.app/components/button/demo/color-context/)
- [x] [context-provider](https://deploy-preview-817--red-hat-design-system.netlify.app/components/context-provider/demo/nested-contexts/)
- [ ] [cta](https://deploy-preview-817--red-hat-design-system.netlify.app/components/call-to-action/demo/)
- [x] [navigation-secondary](https://deploy-preview-817--red-hat-design-system.netlify.app/components/navigation-secondary/demo/)
- [x] [subnav](https://deploy-preview-817--red-hat-design-system.netlify.app/components/subnav/demo/color-context/)
- [x] [tabs](https://deploy-preview-817--red-hat-design-system.netlify.app/components/tabs/demo/color-context/)




## Notes to Reviewers

The idea behind the context tokens is useful, but they were hastily implemented by yours truly without consulting the designers. Most of them were simple aliases to semantic tokens, and so have been replaced with such here in this PR. The exception to that rule are the `text` and `background` colours which were replaced with "private" css vars here in RHDS, which gives us some flexibility to determine our APIs before shipping.

