### PR TITLE
fix(cta): make inner border visible in focus and active states

### DIFF
--- a/.changeset/tall-knives-kick.md
+++ b/.changeset/tall-knives-kick.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-cta>`: made inner border visible in focus and active states

--- a/elements/rh-cta/rh-cta.css
+++ b/elements/rh-cta/rh-cta.css
@@ -52,7 +52,7 @@
 
 /** Inner border */
 #container:after {
-  --_offset: 1px;
+  --_offset: 2px;
 
   content: "";
   display: block;
@@ -62,7 +62,6 @@
   position: absolute;
   top: var(--_offset);
   left: var(--_offset);
-  z-index: -1;
   border-width: var(--rh-border-width-sm, 1px);
   border-radius: 2px;
   outline: none;
@@ -109,9 +108,13 @@ svg {
       var(--rh-cta-focus-background-color)
     );
 
-  --rh-cta-inner-border-color: var(--rh-cta-focus-inner-border-color);
   --rh-cta-color: var(--rh-cta-focus-color);
   --rh-cta-text-decoration: var(--rh-cta-focus-text-decoration);
+}
+
+:host(:is(:focus, :focus-within)) #container:after {
+  border-style: solid;
+  border-color: var(--rh-cta-focus-inner-border-color);
 }
 
 /*****************************************************************************
@@ -124,7 +127,6 @@ svg {
   background-color: var(--rh-cta-hover-background-color);
 
   --rh-cta-text-decoration: var(--rh-cta-hover-text-decoration);
-  --rh-cta-inner-border-color: var(--rh-cta-hover-inner-border-color);
 }
 
 :host(:hover) #container svg {
@@ -141,8 +143,6 @@ svg {
 
 :host(:active) {
   background-color: var(--rh-cta-active-background-color);
-
-  --rh-cta-inner-border-color: var(--rh-cta-active-inner-border-color) !important;
 }
 
 :host(:active) #container {
@@ -152,6 +152,12 @@ svg {
       var(--rh-cta-active-background-color)
     );
 }
+
+:host(:active) #container:after {
+  border-style: solid;
+  border-color: var(--rh-cta-active-inner-border-color) !important;
+}
+
 
 /*****************************************************************************
  * VARIANTS                                                                  *
@@ -197,8 +203,8 @@ svg {
   /* --rh-color-border-interactive-on-light with 10% opacity */
   --rh-cta-focus-container-background-color: #0066cc1a;
   --rh-cta-focus-border-color: transparent;
-  --rh-cta-focus-color: var(--rh-color-interactive-blue-darker, #0066cc);
   --rh-cta-focus-inner-border-color: transparent;
+  --rh-cta-focus-color: var(--rh-color-interactive-blue-darker, #0066cc);
   --rh-cta-focus-text-decoration: none;
 
   /* --rh-color-border-interactive-on-light with 10% opacity */


### PR DESCRIPTION
## What I did

1. Made inner border for primary, secondary, and brick variants visible on hover and focus


## Testing Instructions

1. View [deploy preview](https://deploy-preview-839--red-hat-design-system.netlify.app/components/call-to-action/demo/) and tab through or click CTAs to check that it shows the inner border

## Notes to Reviewers
Closes issue #838 
