### PR TITLE
fix(navigation-secondary): correct colorPalette property

### DIFF
--- a/.changeset/color-palette-light.md
+++ b/.changeset/color-palette-light.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+**Color Context**: added missing `light` color palette option

--- a/.changeset/fair-chefs-tap.md
+++ b/.changeset/fair-chefs-tap.md
@@ -1,0 +1,7 @@
+---
+"@rhds/elements": minor
+---
+
+`rh-secondary-nav`: fixed color-palette default value to match design spec, token color values
+
+**Color Context**: added `light` option to `@colorContextProvider` `ColorPalette` type. 

--- a/.changeset/fair-chefs-tap.md
+++ b/.changeset/fair-chefs-tap.md
@@ -1,7 +1,0 @@
----
-"@rhds/elements": minor
----
-
-`rh-secondary-nav`: fixed color-palette default value to match design spec, token color values
-
-**Color Context**: added `light` option to `@colorContextProvider` `ColorPalette` type. 

--- a/.changeset/rh-navigation-secondary-default-palette.md
+++ b/.changeset/rh-navigation-secondary-default-palette.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-secondary-nav>`: match the default color-palette to design spec, use token 
+color values

--- a/elements/rh-navigation-secondary/README.md
+++ b/elements/rh-navigation-secondary/README.md
@@ -141,7 +141,7 @@ Please [open a discussion thread](https://github.com/orgs/RedHat-UX/discussions/
 | Name | Value | Description | Required | Example |
 |------|-------|-------------|----------|---------| 
 | **role** | navigation | Ensures an accessible experience before or on failed upgrade | Yes |  `<rh-navigation-secondary role="navigation">` |
-| **color-palette** | "lighter" (default),  "dark" | Sets the color theme for the navigation | No | `<rh-navigation-secondary color-palette="dark">` |
+| **color-palette** | "light" (default),  "dark" | Sets the color theme for the navigation | No | `<rh-navigation-secondary color-palette="dark">` |
 
 ### CSS Parts
 | Name | Description |

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
@@ -52,7 +52,7 @@ export class RhNavigationSecondaryDropdown extends LitElement {
   @state() expanded = false;
 
   @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: ColorPalette = 'lighter';
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: ColorPalette = 'light';
 
   connectedCallback(): void {
     super.connectedCallback();

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -21,7 +21,7 @@ import { ScreenSizeController } from '../../lib/ScreenSizeController.js';
 import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
 
 export type NavPalette = Extract<ColorPalette, (
-  | 'lighter'
+  | 'light'
   | 'dark'
 )>;
 
@@ -106,12 +106,12 @@ export class RhNavigationSecondary extends LitElement {
 
 
   @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'light';
 
   /**
-   * If the host color-palette="lighter", the cta color context should be on="light"
+   * If the host color-palette="light", the cta color context should be on="light"
    * by default.  However when the host color-palette="dark", the cta context should be
-   * on="dark" when in desktop mode, but on="light" when in mobile compact mode because the cta shifts
+   * dark when in desktop mode, but light when in mobile compact mode because the cta shifts
    * to a white background in the mobile compact nav. This state property is set on firstUpdated()
    * and __compactChanged() and is used on a wrapping `<rh-context-provider>` around the cta allowing
    * it to dynamically change with viewport changes.

--- a/elements/rh-navigation-secondary/test/rh-navigation-secondary.spec.ts
+++ b/elements/rh-navigation-secondary/test/rh-navigation-secondary.spec.ts
@@ -43,8 +43,8 @@ describe('<rh-navigation-secondary>', async function() {
     expect(element.hasAttribute('role')).to.be.false;
   });
 
-  it('should by default set color-palette="lighter"', async function() {
-    expect(element.getAttribute('color-palette') === 'lighter').to.be.true;
+  it('should by default set color-palette="light"', async function() {
+    expect(element.getAttribute('color-palette') === 'light').to.be.true;
   });
 
   it('should have an overlay set to hidden after upgrade', async function() {

--- a/lib/context/color/provider.ts
+++ b/lib/context/color/provider.ts
@@ -22,6 +22,7 @@ export type ColorPalette = (
   | 'base'
   | 'accent'
   | 'complement'
+  | 'light'
   | 'lighter'
   | 'lightest'
   | 'dark'


### PR DESCRIPTION
## What I did

1. Correct `colorPalette` property to use `light` default value to match design spec and token values
2. Added `light` to the `ColorPalette` type in the context provider

Closes #863 

## Testing Instructions

1. View [Deploy preview demo for navigation-secondary](https://deploy-preview-864--red-hat-design-system.netlify.app/elements/navigation-secondary/demo/)
2. Nav bar should be #f0f0f0 on the default demo `color-palette="light"` (default)  
3. Should fix regression issue #863


