### PR TITLE
fix(tabs): default context colors 

### DIFF
--- a/.changeset/tame-ducks-raise.md
+++ b/.changeset/tame-ducks-raise.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tabs>`: Fixed color context default values

--- a/elements/rh-tabs/demo/rh-tabs.html
+++ b/elements/rh-tabs/demo/rh-tabs.html
@@ -3,12 +3,6 @@
 
 <form>
   <fieldset>
-    <legend>Surface</legend>
-    <label><input type="radio" name="surface" value="lightest" checked> Lightest</label>
-    <label><input type="radio" name="surface" value="darkest"> Darkest</label>
-  </fieldset>
-
-  <fieldset>
     <legend>Theme</legend>
     <label><input type="radio" name="theme" value="default" checked> Default</label>
     <label><input type="radio" name="theme" value="base"> Base</label>
@@ -23,103 +17,91 @@
 
 <section>
   <h2>Default</h2>
-  <rh-context-provider color-palette="lightest">
-    <rh-tabs>
-      <rh-tab id="users" slot="tab">Users</rh-tab>
-      <rh-tab-panel>Users</rh-tab-panel>
-      <rh-tab slot="tab">Containers</rh-tab>
-      <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
-      <rh-tab slot="tab">Database</rh-tab>
-      <rh-tab-panel>Database</rh-tab-panel>
-      <rh-tab slot="tab">Servers</rh-tab>
-      <rh-tab-panel>Servers</rh-tab-panel>
-      <rh-tab slot="tab">Cloud</rh-tab>
-      <rh-tab-panel>Cloud</rh-tab-panel>
-    </rh-tabs>
-  </rh-context-provider>
+  <rh-tabs>
+    <rh-tab id="users" slot="tab">Users</rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers</rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database</rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers</rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab">Cloud</rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
 
   <h2>Centered</h2>
-  <rh-context-provider color-palette="lightest">
-    <rh-tabs centered>
-      <rh-tab id="users" slot="tab">Users</rh-tab>
-      <rh-tab-panel>Users</rh-tab-panel>
-      <rh-tab slot="tab">Containers</rh-tab>
-      <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
-      <rh-tab slot="tab">Database</rh-tab>
-      <rh-tab-panel>Database</rh-tab-panel>
-      <rh-tab slot="tab">Servers</rh-tab>
-      <rh-tab-panel>Servers</rh-tab-panel>
-      <rh-tab slot="tab">Cloud</rh-tab>
-      <rh-tab-panel>Cloud</rh-tab-panel>
-    </rh-tabs>
-  </rh-context-provider>
+  <rh-tabs centered>
+    <rh-tab id="users" slot="tab">Users</rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers</rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database</rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers</rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab">Cloud</rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
 
   <h2>Vertical</h2>
-  <rh-context-provider color-palette="lightest">
-    <rh-tabs vertical>
-      <rh-tab id="users" slot="tab">Users</rh-tab>
-      <rh-tab-panel>Users</rh-tab-panel>
-      <rh-tab slot="tab">Containers</rh-tab>
-      <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
-      <rh-tab slot="tab">Database</rh-tab>
-      <rh-tab-panel>Database</rh-tab-panel>
-      <rh-tab slot="tab">Servers</rh-tab>
-      <rh-tab-panel>Servers</rh-tab-panel>
-      <rh-tab slot="tab">Cloud</rh-tab>
-      <rh-tab-panel>Cloud</rh-tab-panel>
-    </rh-tabs>
-  </rh-context-provider>
+  <rh-tabs vertical>
+    <rh-tab id="users" slot="tab">Users</rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers</rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database</rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers</rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab">Cloud</rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
 </section>
 
 <section>
   <h2>Box Inset</h2>
-  <rh-context-provider color-palette="lightest">
-    <rh-tabs box="inset" id="inset">
-      <rh-tab id="users" slot="tab">Users</rh-tab>
-      <rh-tab-panel>Users</rh-tab-panel>
-      <rh-tab slot="tab">Containers</rh-tab>
-      <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
-      <rh-tab slot="tab">Database</rh-tab>
-      <rh-tab-panel>Database</rh-tab-panel>
-      <rh-tab slot="tab">Servers</rh-tab>
-      <rh-tab-panel>Servers</rh-tab-panel>
-      <rh-tab slot="tab">Cloud</rh-tab>
-      <rh-tab-panel>Cloud</rh-tab-panel>
-    </rh-tabs>
-  </rh-context-provider>
+  <rh-tabs box="inset" id="inset">
+    <rh-tab id="users" slot="tab">Users</rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers</rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database</rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers</rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab">Cloud</rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
 </section>
 
 <section>
   <h2>Icons and text</h2>
-  <rh-context-provider color-palette="lightest">
-    <rh-tabs>
-      <rh-tab slot="tab"> Users          <pf-icon slot="icon" icon="users" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Users</rh-tab-panel>
-      <rh-tab slot="tab"> Containers     <pf-icon slot="icon" icon="box-open" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Containers</rh-tab-panel>
-      <rh-tab slot="tab"> Database       <pf-icon slot="icon" icon="database" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Database</rh-tab-panel>
-      <rh-tab slot="tab"> Server         <pf-icon slot="icon" icon="server" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Server</rh-tab-panel>
-      <rh-tab slot="tab"> System         <pf-icon slot="icon" icon="laptop" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>System</rh-tab-panel>
-    </rh-tabs>
-  </rh-context-provider>
+  <rh-tabs>
+    <rh-tab slot="tab"> Users          <pf-icon slot="icon" icon="users" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab"> Containers     <pf-icon slot="icon" icon="box-open" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Containers</rh-tab-panel>
+    <rh-tab slot="tab"> Database       <pf-icon slot="icon" icon="database" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab"> Server         <pf-icon slot="icon" icon="server" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Server</rh-tab-panel>
+    <rh-tab slot="tab"> System         <pf-icon slot="icon" icon="laptop" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>System</rh-tab-panel>
+  </rh-tabs>
 </section>
 
 <section>
-  <rh-context-provider color-palette="lightest">
-    <rh-tabs vertical>
-      <rh-tab slot="tab"> Users          <pf-icon slot="icon" icon="users" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Users</rh-tab-panel>
-      <rh-tab slot="tab"> Containers     <pf-icon slot="icon" icon="box-open" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Containers</rh-tab-panel>
-      <rh-tab slot="tab"> Database       <pf-icon slot="icon" icon="database" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Database</rh-tab-panel>
-      <rh-tab slot="tab"> Server         <pf-icon slot="icon" icon="server" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>Server</rh-tab-panel>
-      <rh-tab slot="tab"> System         <pf-icon slot="icon" icon="laptop" set="fas" size="sm"></pf-icon></rh-tab>
-      <rh-tab-panel>System</rh-tab-panel>
-    </rh-tabs>
-  </rh-context-provider>
+  <rh-tabs vertical>
+    <rh-tab slot="tab"> Users          <pf-icon slot="icon" icon="users" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab"> Containers     <pf-icon slot="icon" icon="box-open" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Containers</rh-tab-panel>
+    <rh-tab slot="tab"> Database       <pf-icon slot="icon" icon="database" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab"> Server         <pf-icon slot="icon" icon="server" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>Server</rh-tab-panel>
+    <rh-tab slot="tab"> System         <pf-icon slot="icon" icon="laptop" set="fas" size="sm"></pf-icon></rh-tab>
+    <rh-tab-panel>System</rh-tab-panel>
+  </rh-tabs>
 </section>

--- a/elements/rh-tabs/demo/rh-tabs.js
+++ b/elements/rh-tabs/demo/rh-tabs.js
@@ -3,10 +3,7 @@ import '@rhds/elements/rh-context-provider/rh-context-provider.js';
 
 import '@patternfly/elements/pf-icon/pf-icon.js';
 
-const main = document.querySelector('body');
-
 const tabs = document.querySelectorAll('rh-tabs');
-const providers = document.querySelectorAll('rh-context-provider');
 const inset = document.querySelector('#inset');
 
 function variantToggle() {
@@ -18,12 +15,6 @@ function variantToggle() {
   });
 }
 
-function surfaceToggle(event) {
-  providers.forEach(surface => {
-    main.classList.toggle('dark', event.target.value === 'darkest');
-    surface.setAttribute('color-palette', event.target.value);
-  });
-}
 
 function themeToggle(event) {
   tabs.forEach(t => {
@@ -41,10 +32,6 @@ function insetToggle(event) {
 
 for (const input of document.querySelectorAll('input[name="variant"]')) {
   input.addEventListener('change', variantToggle);
-}
-
-for (const input of document.querySelectorAll('input[name="surface"]')) {
-  input.addEventListener('change', surfaceToggle);
 }
 
 for (const input of document.querySelectorAll('input[name="theme"]')) {

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -126,7 +126,7 @@ button:after {
 /* Active Box (Not Vertical) */
 :host([active][box]:not([vertical])) button:after {
   border-block-start: var(--rh-border-width-lg, 3px) solid var(--_active-tab-border-color);
-  border-block-end: var(--rh-border-width-sm, 1px) solid var(--_context-background-color);
+  border-block-end: var(--rh-border-width-sm, 1px) solid var(--_context-background-color, #ffffff);
 }
 
 /* Active Vertical */
@@ -143,7 +143,7 @@ button:after {
 /* Box Vertical Active */
 :host([box][vertical][active]) button:before {
   border-inline-start: var(--rh-border-width-lg, 3px) solid var(--_active-tab-border-color);
-  border-inline-end: var(--rh-border-width-sm, 1px) solid var(--_context-background-color);
+  border-inline-end: var(--rh-border-width-sm, 1px) solid var(--_context-background-color, #ffffff);
 }
 
 :host([box][vertical]:not([active])) button:before {

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -1,7 +1,7 @@
 /* stylelint-disable selector-id-pattern */
 :host {
-  background: var(--_context-background-color, var(--rh-color-surface-lightest, #ffffff));
-  color: var(--_context-text, var(--rh-color-text-primary-on-light, #151515));
+  background: var(--_context-background-color);
+  color: var(--_context-text);
 }
 
 #rhds-container {

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -1,4 +1,9 @@
 /* stylelint-disable selector-id-pattern */
+:host {
+  background: var(--_context-background-color, var(--rh-color-surface-lightest, #ffffff));
+  color: var(--_context-text, var(--rh-color-text-primary-on-light, #151515));
+}
+
 #rhds-container {
   display: contents;
 


### PR DESCRIPTION
## What I did

1. `rh-tab.css`: provided a fallback when the context background color is not available.
2. `rh-tabs.css`: set background and text color to context values when present.
3.  Remove the context provider examples from the default demo, they are available in the color-context demo if needed.

Closes #865

## Testing Instructions

1. View the [deploy preview for tabs](https://deploy-preview-866--red-hat-design-system.netlify.app/components/tabs/demo/)
2. On the default demo add `color-palette="darker"` to any tabs, it should gain the appropriate border colors, text color and background color.
3. View the [color-context demo for tabs](https://deploy-preview-866--red-hat-design-system.netlify.app/components/tabs/demo/color-context/)
4. All color-context settings should provide the correct background, text, and border colors.
