### PR TITLE
Docs: fixing elementDocs "elements" sorting in the side panel

### DIFF
--- a/docs/_includes/component/header.njk
+++ b/docs/_includes/component/header.njk
@@ -122,7 +122,7 @@
               <li class="site-navigation__sub-menu__item">
                 {{ menuLink('All elements', '/elements/', 'site-navigation__sub-menu__link') }}
               </li>
-              {%- for tagName, docs in collections.elementDocs | groupby('tagName') -%}
+              {%- for tagName, docs in collections.elementDocs | reverse | groupby('tagName') -%}
                 {%- set slug = docs[0].slug -%}
                 {%- set href = '/elements/' + slug + '/' -%}
                 <li class="site-navigation__sub-menu__item">


### PR DESCRIPTION
## What I did

1.  Added a `reverse` function to the `elementDocs` collection to fix the sorting issue in the side panel


## Testing Instructions

1.  Check out the Deploy Preview and verify the elements are showing in the correct order