### PR TITLE
fix: change semantic token for the border when accordions are expanded

### DIFF
--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -9,7 +9,7 @@
   --_active-background-color: var(--_rhds-background-color, #f2f2f2);
   --_font-size: var(--rh-font-size-body-text-md, 1rem);
   --_after-background-color: transparent;
-  --_expanded-background-color: var(--rh-color-text-brand-on-light, #ee0000);
+  --_expanded-background-color: var(--rh-color-accent-brand-on-light, #ee0000);
   --_isRTL: -1;
 }
 
@@ -24,7 +24,7 @@
   --_background-color: var(--rh-color-surface-darkest, #151515);
   --_active-background-color: var(--rh-color-surface-darkest, #151515);
   --_active-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
-  --_expanded-background-color: var(--rh-color-brand-red-on-dark, #ff442b);
+  --_expanded-background-color: var(--rh-color-accent-brand-on-dark, #ff442b);
   --_border-inline-end-color: var(--rh-color-border-subtle-on-dark, #707070);
 }
 

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -4,7 +4,7 @@
   --_background-color: var(--rh-color-surface-white, #ffffff);
   --_panel-color: var(--rh-color-surface-darkest, #151515);
   --_panel-font-size: var(--rh-font-size-body-text-md, 1rem);
-  --_panel-content-body-accent-color: var(--rh-color-border-danger-on-light, #ee0000);
+  --_panel-content-body-accent-color: var(--rh-color-accent-brand-on-light, #ee0000);
   --_panel-body-padding-block-start: var(--rh-space-lg, 16px);
   --_panel-body-padding-inline-end: var(--rh-space-xl, 24px);
   --_panel-body-padding-block-end: var(--rh-space-lg, 16px);
@@ -14,7 +14,7 @@
 .dark {
   --_background-color: var(--rh-color-surface-darkest, #151515);
   --_panel-color: var(--rh-color-text-primary-on-dark, #ffffff);
-  --_panel-content-body-accent-color: var(--rh-color-brand-on-dark, #ff442b);
+  --_panel-content-body-accent-color: var(--rh-color-accent-brand-on-dark, #ff442b);
   --_panel-border-inline-end-color: var(--rh-color-border-subtle-on-dark, #707070);
 }
 


### PR DESCRIPTION
## What I did

Changed semantic token for the red border when accordions are expanded in rh-accordion-panel.css and rh-accordion-header.css. They previously used tokens from the brand red group or a danger border token.


## Testing Instructions

Check that the border for the expanded accordion panel and header use either `var(--rh-color-accent-brand-on-light, #ee0000)` or `var(--rh-color-accent-brand-on-dark, #ff442b)` in the deploy preview.

## Notes to Reviewers
Closes #876 