### PR TITLE
fix(navigation-secondary): realign color-palette with surface tokens

### DIFF
--- a/.changeset/eleven-hounds-cry.md
+++ b/.changeset/eleven-hounds-cry.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`rh-navigation-secondary`: Realigned `color-palette` default to new surface token values`

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -21,7 +21,7 @@ import { ScreenSizeController } from '../../lib/ScreenSizeController.js';
 import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
 
 export type NavPalette = Extract<ColorPalette, (
-  | 'light'
+  | 'lighter'
   | 'dark'
 )>;
 
@@ -106,7 +106,7 @@ export class RhNavigationSecondary extends LitElement {
 
 
   @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'light';
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
 
   /**
    * If the host color-palette="light", the cta color context should be on="light"

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -109,7 +109,7 @@ export class RhNavigationSecondary extends LitElement {
   @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
 
   /**
-   * If the host color-palette="light", the cta color context should be on="light"
+   * If the host color-palette="lighter", the cta color context should be on="lighter"
    * by default.  However when the host color-palette="dark", the cta context should be
    * dark when in desktop mode, but light when in mobile compact mode because the cta shifts
    * to a white background in the mobile compact nav. This state property is set on firstUpdated()

--- a/elements/rh-navigation-secondary/test/rh-navigation-secondary.spec.ts
+++ b/elements/rh-navigation-secondary/test/rh-navigation-secondary.spec.ts
@@ -43,8 +43,8 @@ describe('<rh-navigation-secondary>', async function() {
     expect(element.hasAttribute('role')).to.be.false;
   });
 
-  it('should by default set color-palette="light"', async function() {
-    expect(element.getAttribute('color-palette') === 'light').to.be.true;
+  it('should by default set color-palette="lighter"', async function() {
+    expect(element.getAttribute('color-palette') === 'lighter').to.be.true;
   });
 
   it('should have an overlay set to hidden after upgrade', async function() {


### PR DESCRIPTION
## What I did

1. Realigned `color-palette` default to new surface token values


## Testing Instructions

1. View [Deploy Preview,](https://deploy-preview-878--red-hat-design-system.netlify.app/elements/navigation-secondary/demo/) navigation-secondary background should match `--rh-color-surface-lighter` value of #f2f2f2


