### PR TITLE
fix(alert): header slot will now use Red Hat Text font 

### DIFF
--- a/.changeset/ten-radios-decide.md
+++ b/.changeset/ten-radios-decide.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`rh-alert`: fixed font-family on header slot to use Red Hat Text by default.
+`<rh-alert>`: fixed font-family for header slot

--- a/.changeset/ten-radios-decide.md
+++ b/.changeset/ten-radios-decide.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`rh-alert`: fixed font-family on header slot to use Red Hat Text by default.

--- a/elements/rh-alert/rh-alert.css
+++ b/elements/rh-alert/rh-alert.css
@@ -76,10 +76,9 @@ header {
 }
 
 header ::slotted(:is(h1,h2,h3,h4,h5,h6)) {
+  font-family: var(--_font-family) !important;
   font-size: var(--rh-font-size-body-text-sm, 0.875rem) !important;
   margin: 0 !important;
-
-  font-family: var(--_font-family) !important;
 }
 
 #header-actions {

--- a/elements/rh-alert/rh-alert.css
+++ b/elements/rh-alert/rh-alert.css
@@ -79,7 +79,7 @@ header ::slotted(:is(h1,h2,h3,h4,h5,h6)) {
   font-size: var(--rh-font-size-body-text-sm, 0.875rem) !important;
   margin: 0 !important;
 
-  --rh-font-family-heading: var(--_font-family) !important;
+  font-family: var(--_font-family) !important;
 }
 
 #header-actions {


### PR DESCRIPTION
## What I did

1. Updated the CSS for the slotted elements in the header container from `  --rh-font-family-heading: var(--_font-family) !important;` to `font-family: var(--_font-family) !important;`


## Testing Instructions

1. [Go to the CTA demo](https://deploy-preview-892--red-hat-design-system.netlify.app/elements/call-to-action/)
2. Scroll down the page and confirm that the alerts on the page contain the font `RedHatText, "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif);`

## Notes to Reviewers
