### PR TITLE
docs(footer): add rh-footer-universal to ux site

### DIFF
--- a/docs/_includes/component/footer.njk
+++ b/docs/_includes/component/footer.njk
@@ -13,21 +13,30 @@
     </div>
   </section> #}
 
-  <footer class="main-footer">
-    <img style="max-width: 135px;" src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg" alt="Red Hat" />
-    <p>Copyright &copy; 2021-{{ page.date.getFullYear() }} Red Hat, Inc.</p>
-    <div class="main-footer--list">
-      <ul>
-        <li><a href="https://www.redhat.com/en/about/privacy-policy">Privacy statement</a></li>
-        <li><a href="https://www.redhat.com/en/about/terms-use">Terms of use</a></li>
-        <li><a href="https://www.redhat.com/en/about/all-policies-guidelines">All policies and guidelines</a></li>
-      </ul>
-    </div>
-
-    <a id="netlify-badge" href="https://www.netlify.com" target="_blank" rel="noreferrer noopener">
-      <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify">
-    </a>
-  </footer>
+<rh-footer-universal>
+  <h3 slot="links-primary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
+  <ul slot="links-primary" data-analytics-region="page-footer-bottom-primary">
+    <li><a href="https://redhat.com/en/about/company" data-analytics-category="Footer|Corporate" data-analytics-text="About Red Hat">About Red Hat</a></li>
+    <li><a href="https://redhat.com/en/jobs" data-analytics-category="Footer|Corporate" data-analytics-text="Jobs">Jobs</a></li>
+    <li><a href="https://redhat.com/en/events" data-analytics-category="Footer|Corporate" data-analytics-text="Events">Events</a></li>
+    <li><a href="https://redhat.com/en/about/office-locations" data-analytics-category="Footer|Corporate" data-analytics-text="Locations">Locations</a></li>
+    <li><a href="https://redhat.com/en/contact" data-analytics-category="Footer|Corporate" data-analytics-text="Contact Red Hat">Contact Red Hat</a></li>
+    <li><a href="https://redhat.com/en/blog" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Blog">Red Hat Blog</a></li>
+    <li><a href="https://redhat.com/en/about/our-culture/diversity-equity-inclusion" data-analytics-category="Footer|Corporate" data-analytics-text="Diversity equity and inclusion">Diversity, equity, and inclusion</a></li>
+    <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
+    <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
+  </ul>
+  <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+  <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
+  <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
+    <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>
+    <li><a href="https://redhat.com/en/about/terms-use" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Terms of use">Terms of use</a></li>
+    <li><a href="https://redhat.com/en/about/all-policies-guidelines" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="All policies and guidelines">All policies and guidelines</a></li>
+    <li><a href="https://redhat.com/en/about/digital-accessibility" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Digital accessibility" class="active">Digital accessibility</a></li>
+    <!-- If your website supports trustarc include this item to add Cookie Preferences to your site. -->
+    <!-- <li><span id="teconsent"> </span></li> -->
+  </ul>
+</rh-footer-universal>
 
 <div class="back-to-top">
     <a href="#top" class="back-to-top-link">

--- a/docs/_includes/layout-base.njk
+++ b/docs/_includes/layout-base.njk
@@ -24,6 +24,7 @@
   <link rel="stylesheet" href="{{ '/assets/prism.css' | url }}" >
   <link rel="stylesheet" href="{{ '/assets/pfe.min.css' | url }}">
   <link rel="stylesheet" href="{{ '/assets/rhds.min.css' | url }}">
+  <link rel="stylesheet" href="{{ '/assets/packages/@rhds/elements/elements/rh-footer/rh-footer-lightdom.css' | url }}">
 
   {% sassFile false %}
   {% for stylesheet in stylesheets %}

--- a/docs/_includes/layout-home.njk
+++ b/docs/_includes/layout-home.njk
@@ -5,7 +5,9 @@ layout: layout-base.njk
 {% include 'component/header.njk' %}
 
 <main class="l-main">
-  {{ content | safe }}
+  <div class="l-main__content">
+    {{ content | safe }}
+  </div>
 
   {% include 'component/footer.njk' %}
 </main>

--- a/docs/scss/_layout.scss
+++ b/docs/scss/_layout.scss
@@ -66,7 +66,7 @@ body {
 }
 
 .l-main__content {
-  // overflow: hidden;
+  padding-block-end: var(--rh-space-4xl, 64px);
 }
 
 .main-footer {


### PR DESCRIPTION
## What I did

1. Replacing the footer on the UX site with the `rh-footer-universal`
2. Adding a bit of padding between the main content and footer. var(--rh-space-4xl, 64px)


## Testing Instructions

1.

## Notes to reviewers

I'm just using raw HTML because the content will nearly never change and it is super easy to copy and paste from the [footer README](https://github.com/RedHat-UX/red-hat-design-system/blob/main/elements/rh-footer/README.md).