### PR TITLE
docs: fix spacing and typography 

### DIFF
--- a/docs/index.njk
+++ b/docs/index.njk
@@ -3,7 +3,7 @@ layout: layout-home.njk
 title: Home
 ---
 
-<div class="container">
+<div class="container l-main__content">
   <div class="centered">
     <div class="margin-top--12">
       <h1 class="section-headline">Red&nbsp;Hat design system</h1>

--- a/docs/scss/_base/_base.scss
+++ b/docs/scss/_base/_base.scss
@@ -57,7 +57,7 @@ h2,
 h3,
 h4 {
   font-family: 'RedHatDisplay', 'Overpass', Helvetica, sans-serif;
-  line-height: 1.4;
+  line-height: 1.3;
   font-weight: 400;
 }
 

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -56,7 +56,7 @@
     margin-bottom: 16px;
 
     @include breakpoint(romeo) {
-      /*font-size: 24px;*/
+      font-size: 24px;
       margin-top: 64px;
     }
   }
@@ -71,6 +71,7 @@
     margin: 32px 0 16px;
     font-size: 18px;
     line-height: 25px;
+    
     @include breakpoint(lima) {
       font-size: 20px;
       line-height: 26px;

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -895,7 +895,7 @@ pfe-jump-links-nav {
 .feature-box {
   border: 1px solid #d2d2d2;
   padding: 64px 24px;
-  border-radius: 3px;
+  border-radius: 8px;
   margin: 80px 0;
 
   @include breakpoint(tango) {
@@ -1121,7 +1121,7 @@ pfe-jump-links-nav {
   &--item {
     border: 1px solid #d2d2d2;
     padding: 32px;
-    border-radius: 3px;
+    border-radius: 8px;
     display: block;
     grid-template-columns: 1fr 4fr;
 

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -56,18 +56,19 @@
     margin-bottom: 16px;
 
     @include breakpoint(romeo) {
-      font-size: 24px;
+      /*font-size: 24px;*/
       margin-top: 64px;
     }
   }
 
-  h2 + h3 {
-    margin-top: 24px;
+  h2 + h3,
+  h2 + h4 {
+    margin-top: 32px;
   }
 
   h4 {
     font-weight: 500;
-    margin: 64px 0 8px;
+    margin: 64px 0 16px;
     font-size: 18px;
     line-height: 25px;
     @include breakpoint(lima) {
@@ -82,6 +83,8 @@
 
   p {
     max-width: 1000px;
+    margin-top: 16px;
+    margin-bottom: 16px;
 
     a {
       text-decoration: none;
@@ -240,7 +243,6 @@
 
   .example {
     margin-bottom: 0;
-
   }
 
   .example + .example {
@@ -1032,6 +1034,12 @@ pfe-jump-links-nav {
 
 // Alert styles
 
+rh-alert {
+  margin-top: 32px;
+  margin-bottom: 32px;
+}
+
+// Delete the alert styles below after making sure all alerts are converted to rh-alert element
 .alert {
   position: fixed;
   bottom: 0;

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -68,7 +68,7 @@
 
   h4 {
     font-weight: 500;
-    margin: 64px 0 16px;
+    margin: 32px 0 16px;
     font-size: 18px;
     line-height: 25px;
     @include breakpoint(lima) {

--- a/docs/scss/components/_example.scss
+++ b/docs/scss/components/_example.scss
@@ -70,20 +70,20 @@ rh-alert + .example {
 .example--palette-light {
   background: #ffffff;
   border: 1px solid #d2d2d2;
-  border-radius: 3px;
+  border-radius: 8px;
 }
 
 .example--palette-lightest {
   background: transparent;
   border: 1px solid #d2d2d2;
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 64px;
   padding-bottom: 64px;
 }
 
 .example--palette-darkest {
   background: #151515;
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 64px;
   padding-bottom: 64px;
 }
@@ -96,25 +96,25 @@ rh-alert + .example {
   background-position-x: 8px;
   background-position-y: 8px;
   border: 1px solid #ee0000;
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 64px;
   padding-bottom: 64px;
 }
 
 .example--palette-medium {
   background: #f0f0f0;
-  border-radius: 3px;
+  border-radius: 8px;
 }
 
 .example--palette-dark {
   background: #15151580;
-  border-radius: 3px;
+  border-radius: 8px;
 }
 
 .example--palette-descriptive {
   background: transparent;
   border: 1px solid #d2d2d2;
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 32px;
   padding-bottom: 32px;
   margin-bottom: 24px;
@@ -130,7 +130,7 @@ rh-alert + .example {
   background: #0066cc;
 
   /* border: 1px solid #d2d2d2; */
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 32px;
   padding-bottom: 32px;
   margin-bottom: 24px;
@@ -145,7 +145,7 @@ rh-alert + .example {
   background: rgba(0, 0, 0, 0.65);
 
   /* border: 1px solid #d2d2d2; */
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 32px;
   padding-bottom: 32px;
   margin-bottom: 24px;
@@ -159,7 +159,7 @@ rh-alert + .example {
 .example--palette-descriptive-gray {
   background: rgba(0, 0, 0, 0.25);
   border: 1px solid #d2d2d2;
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 32px;
   padding-bottom: 32px;
   margin-bottom: 24px;
@@ -172,7 +172,7 @@ rh-alert + .example {
 
 .example--palette-descriptive-light-gray {
   background: #f0f0f0;
-  border-radius: 3px;
+  border-radius: 8px;
   padding-top: 32px;
   padding-bottom: 32px;
   margin-bottom: 24px;

--- a/docs/scss/components/_example.scss
+++ b/docs/scss/components/_example.scss
@@ -81,15 +81,11 @@ rh-alert + .example {
   background: transparent;
   border: 1px solid #d2d2d2;
   border-radius: 8px;
-  padding-top: 64px;
-  padding-bottom: 64px;
 }
 
 .example--palette-darkest {
   background: #151515;
   border-radius: 8px;
-  padding-top: 64px;
-  padding-bottom: 64px;
 }
 
 .example--palette-wrong {
@@ -101,8 +97,6 @@ rh-alert + .example {
   background-position-y: 8px;
   border: 1px solid #ee0000;
   border-radius: 8px;
-  padding-top: 64px;
-  padding-bottom: 64px;
 }
 
 .example--palette-medium {

--- a/docs/scss/components/_example.scss
+++ b/docs/scss/components/_example.scss
@@ -40,6 +40,10 @@ rh-alert + .example {
     }
   }
 
+  + table {
+    margin-top: -48px;
+  }
+
   img:only-child {
     display: block;
     margin: 0 auto;

--- a/docs/scss/components/_header.scss
+++ b/docs/scss/components/_header.scss
@@ -7,7 +7,7 @@
   padding-top: 32px;
   padding-bottom: 32px;
   @include breakpoint(tango) {
-    padding-top: 64px;
+    padding-top: 80px;
     padding-bottom: 64px;
   }
 


### PR DESCRIPTION
## What I did

I changed spacing between headings, body paragraphs, and other layout elements. Some of the spacing will still look funky until the proper `<section>` tags and heading levels are implemented or cleaned up on individual element and pattern pages.

## Testing Instructions

In the deploy preview:
- The content on the Accordion and CTA pages have good examples to check spacing and heading styles.
- Check the homepage to make sure body copy is the right size.
- Check that the border radius for cards or example containers are 8px.

## Notes to Reviewers
CLoses #919