### PR TITLE
docs: remove margin from feedback section

### DIFF
--- a/docs/_includes/feedback.html
+++ b/docs/_includes/feedback.html
@@ -1,4 +1,4 @@
-<section class="multi-column--min-300-wide section section--palette-default container">
+<section class="multi-column--min-300-wide section section--palette-default container feedback">
   {% section %}
     <h2>Feedback</h2>
     <p>

--- a/docs/scss/styles.scss
+++ b/docs/scss/styles.scss
@@ -26,3 +26,7 @@ section.api.band {
   margin-block-end: var(--rh-space-4xl, 64px);
   padding-inline: 0;
 }
+
+.section.feedback {
+  margin-block-end: 0;
+}


### PR DESCRIPTION
## What I did

1. Removed margin from feedback and foundations section wrapper.

Closes #944 