### PR TITLE
docs: sort elementDocs alphabetically by slug

### DIFF
--- a/docs/_includes/component/header.njk
+++ b/docs/_includes/component/header.njk
@@ -122,7 +122,7 @@
               <li class="site-navigation__sub-menu__item">
                 {{ menuLink('All elements', '/elements/', 'site-navigation__sub-menu__link') }}
               </li>
-              {%- for tagName, docs in collections.elementDocs | reverse | groupby('tagName') -%}
+              {%- for tagName, docs in collections.elementDocs | groupby('tagName') -%}
                 {%- set fst = docs[0] -%}
                 {%- set slug = fst.slug -%}
                 {%- set href = '/elements/' + slug + '/' -%}

--- a/docs/_plugins/rhds.cjs
+++ b/docs/_plugins/rhds.cjs
@@ -124,6 +124,14 @@ function getFilesToCopy() {
   }));
 }
 
+function alphabeticallyBySlug(a, b) {
+  return (
+      a.slug < b.slug ? -1
+    : a.slug > b.slug ? 1
+    : 0
+  );
+}
+
 /** @param {import('@11ty/eleventy/src/UserConfig')} eleventyConfig */
 module.exports = function(eleventyConfig, { tagsToAlphabetize }) {
   eleventyConfig.addPlugin(RHDSAlphabetizeTagsPlugin, { tagsToAlphabetize });
@@ -218,7 +226,8 @@ module.exports = function(eleventyConfig, { tagsToAlphabetize }) {
             .sort()
             .map(x => getProps(x, config));
           return { docsPage, tabs, ...props };
-        });
+        })
+        .sort(alphabeticallyBySlug);
     } catch (e) {
       // it's important to surface this
       // eslint-disable-next-line no-console

--- a/docs/elements/index.md
+++ b/docs/elements/index.md
@@ -22,7 +22,7 @@ summaries:
 {% endsection %}
 
 <div class="multi-column--min-400-wide margin-top--10">
-{%- for tagName, docs in collections.elementDocs | reverse | groupby('tagName') -%}
+{%- for tagName, docs in collections.elementDocs | groupby('tagName') -%}
   {%- set doc = docs[0] -%}
   {%- set slug = doc.slug -%}
   {%- set linkTitle = doc.alias or (slug | deslugify) -%}


### PR DESCRIPTION
## What I did

1. We're using the `elementDocs` collection when generating the side nav, but it's not created/sorted with the other collections used in the `RHDSAlphabetizeTagsPlugin`. Before returning, I'm sorting `elementDocs` by the slug since it takes a component's alias into consideration. 

## Testing Instructions

1. Run the docs with `npm run start` locally and verify that the elements are listing in alphabetical order in the side navigation under `Elements`.
