### PR TITLE
docs(example): fixes example img CSS

### DIFF
--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -115,7 +115,8 @@
   }
 
   img {
-    width: var(--inline-img-max-width, 100%);
+    width: auto;
+    max-width: var(--inline-img-max-width, 100%);
     max-height: var(--inline-img-max-height, auto);
   }
 

--- a/docs/scss/components/_example.scss
+++ b/docs/scss/components/_example.scss
@@ -118,7 +118,8 @@ rh-alert + .example {
   margin-bottom: 24px;
 
   img {
-    width: var(--inline-img-max-width, 100%);
+    width: auto;
+    max-width: var(--inline-img-max-width, 100%);
     max-height: var(--inline-img-max-height, auto);
   }
 
@@ -134,7 +135,8 @@ rh-alert + .example {
   margin-bottom: 24px;
 
   img {
-    width: var(--inline-img-max-width, 100%);
+    width: auto;
+    max-width: var(--inline-img-max-width, 100%);
     max-height: var(--inline-img-max-height, auto);
   }
 }
@@ -149,7 +151,8 @@ rh-alert + .example {
   margin-bottom: 24px;
 
   img {
-    width: var(--inline-img-max-width, 100%);
+    width: auto;
+    max-width: var(--inline-img-max-width, 100%);
     max-height: var(--inline-img-max-height, auto);
   }
 }
@@ -163,7 +166,8 @@ rh-alert + .example {
   margin-bottom: 24px;
 
   img {
-    width: var(--inline-img-max-width, 100%);
+    width: auto;
+    max-width: var(--inline-img-max-width, 100%);
     max-height: var(--inline-img-max-height, auto);
   }
 }
@@ -176,7 +180,8 @@ rh-alert + .example {
   margin-bottom: 24px;
 
   img {
-    width: var(--inline-img-max-width, 100%);
+    width: auto;
+    max-width: var(--inline-img-max-width, 100%);
     max-height: var(--inline-img-max-height, auto);
   }
 }


### PR DESCRIPTION
## What I did

1. Moved example `img` references to `var(--inline-img-max-width, 100%)` from `width` to `max-width`.
2. Set example `img` references width to `auto`.


## Testing Instructions

1. Check [DP](https://deploy-preview-980--red-hat-design-system.netlify.app) for issues with image size.

## Notes to Reviewers
