### PR TITLE
fix: replace "postinstall" to "prepare"

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "clean": "git clean -fX -e node_modules",
     "clean:nuke": "git clean -fX",
     "lint": "wireit",
-    "postinstall": "wireit",
+    "prepare": "wireit",
     "patch": "patch-package",
     "husky": "husky install",
     "prepack": "npx pinst --disable",
@@ -167,7 +167,7 @@
         "build"
       ]
     },
-    "postinstall": {
+    "prepare": {
       "dependencies": [
         "patch",
         "husky"


### PR DESCRIPTION
The `prepare` scripts only works for dev

https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts

fix #981

## What I did

1. replace "postinstall" to "prepare"


## Testing Instructions

1.

## Notes to Reviewers
