### PR TITLE
docs(alert): context provider path fix for demos

### DIFF
--- a/elements/rh-alert/demo/alternate.html
+++ b/elements/rh-alert/demo/alternate.html
@@ -44,5 +44,5 @@
 
 <script type="module">
   import '@rhds/elements/rh-alert/rh-alert.js';
-  import '@rhds/elements/lib/elements/rh-context-provider.js';
+  import '@rhds/elements/lib/elements/rh-context-provider/rh-context-provider.js';
 </script>

--- a/elements/rh-alert/demo/dismissable.html
+++ b/elements/rh-alert/demo/dismissable.html
@@ -35,5 +35,5 @@
 
 <script type="module">
   import '@rhds/elements/rh-alert/rh-alert.js';
-  import '@rhds/elements/lib/elements/rh-context-provider.js';
+  import '@rhds/elements/lib/elements/rh-context-provider/rh-context-provider.js';
 </script>

--- a/elements/rh-alert/demo/states.html
+++ b/elements/rh-alert/demo/states.html
@@ -131,5 +131,5 @@
 
 <script type="module">
   import '@rhds/elements/rh-alert/rh-alert.js';
-  import '@rhds/elements/lib/elements/rh-context-provider.js';
+  import '@rhds/elements/lib/elements/rh-context-provider/rh-context-provider.js';
 </script>

--- a/elements/rh-alert/demo/toast.html
+++ b/elements/rh-alert/demo/toast.html
@@ -43,5 +43,5 @@
 
 <script type="module">
   import '@rhds/elements/rh-alert/rh-alert.js';
-  import '@rhds/elements/lib/elements/rh-context-provider.js';
+  import '@rhds/elements/lib/elements/rh-context-provider/rh-context-provider.js';
 </script>


### PR DESCRIPTION
## Related Issue

#1047

## What I did

1.  Updated the provider paths for `rh-alert`


## Testing Instructions

Go to the following deploy previews and verify they are working: 

- [Alternate](https://deploy-preview-1048--red-hat-design-system.netlify.app/elements/alert/demo/alternate)
- [Dismissable](https://deploy-preview-1048--red-hat-design-system.netlify.app/elements/alert/demo/dismissable)
- [States](https://deploy-preview-1048--red-hat-design-system.netlify.app/elements/alert/demo/states)
- [Toast](https://deploy-preview-1048--red-hat-design-system.netlify.app/elements/alert/demo/toast)
