### PR TITLE
docs(footer): split out all subcomponents on code tab

### DIFF
--- a/elements/rh-footer/docs/30-code.md
+++ b/elements/rh-footer/docs/30-code.md
@@ -49,17 +49,17 @@ Lightdom CSS is required to ensure a reduced [Cumulative Layout Shift (CLS)](htt
 
 ## &lt;rh-footer-copyright&gt;
 
-    {% renderSlots for='rh-footer-block', level=3 %}{% endrenderSlots %}
+    {% renderSlots for='rh-footer-copyright', level=3 %}{% endrenderSlots %}
 
-    {% renderAttributes for='rh-footer-block', level=3 %}{% endrenderAttributes %}
+    {% renderAttributes for='rh-footer-copyright', level=3 %}{% endrenderAttributes %}
 
-    {% renderMethods for='rh-footer-block', level=3 %}{% endrenderMethods %}
+    {% renderMethods for='rh-footer-copyright', level=3 %}{% endrenderMethods %}
 
-    {% renderEvents for='rh-footer-block', level=3 %}{% endrenderEvents %}
+    {% renderEvents for='rh-footer-copyright', level=3 %}{% endrenderEvents %}
 
-    {% renderCssParts for='rh-footer-block', level=3 %}{% endrenderCssParts %}
+    {% renderCssParts for='rh-footer-copyright', level=3 %}{% endrenderCssParts %}
 
-    {% renderCssCustomProperties for='rh-footer-block', level=3 %}{% endrenderCssCustomProperties %}
+    {% renderCssCustomProperties for='rh-footer-copyright', level=3 %}{% endrenderCssCustomProperties %}
 
 ## &lt;rh-footer-links&gt;
 

--- a/elements/rh-footer/docs/30-code.md
+++ b/elements/rh-footer/docs/30-code.md
@@ -1,20 +1,90 @@
-{% renderInstallation %}{% endrenderInstallation %}
+{% renderInstallation %}
+~~~html
+<link rel="stylesheet" href="https://redhatstatic.com/dx/v1-alpha/@rhds/elements@1.0.2/rh-footer/rh-footer-lightdom.css">
+~~~
+Lightdom CSS is required to ensure a reduced [Cumulative Layout Shift (CLS)](https://web.dev/cls/) experience before the component has fully initialized.
+{% endrenderInstallation %}
 
-## Usage
-  {% playground tagName=tagName %}{% endplayground %}
-  {% cta href="./demo/", target="_blank" %}
-View the demo in a new tab
-  {% endcta %}
+## &lt;rh-footer&gt;
 
-{% renderSlots %}{% endrenderSlots %}
+    {% renderSlots for='rh-footer', level=3 %}{% endrenderSlots %}
 
-{% renderAttributes %}{% endrenderAttributes %}
+    {% renderAttributes for='rh-footer', level=3 %}{% endrenderAttributes %}
 
-{% renderMethods %}{% endrenderMethods %}
+    {% renderMethods for='rh-footer', level=3 %}{% endrenderMethods %}
 
-{% renderEvents %}{% endrenderEvents %}
+    {% renderEvents for='rh-footer', level=3 %}{% endrenderEvents %}
 
-{% renderCssParts for='rh-footer', level=3%}{% endrenderCssParts %}
+    {% renderCssParts for='rh-footer', level=3 %}{% endrenderCssParts %}
 
-{% renderCssCustomProperties for='rh-footer', level=3%}{% endrenderCssCustomProperties %}
+    {% renderCssCustomProperties for='rh-footer', level=3 %}{% endrenderCssCustomProperties %}
 
+## &lt;rh-footer-universal&gt;
+
+    {% renderSlots for='rh-footer-universal', level=3 %}{% endrenderSlots %}
+
+    {% renderAttributes for='rh-footer-universal', level=3 %}{% endrenderAttributes %}
+
+    {% renderMethods for='rh-footer-universal', level=3 %}{% endrenderMethods %}
+
+    {% renderEvents for='rh-footer-universal', level=3 %}{% endrenderEvents %}
+
+    {% renderCssParts for='rh-footer-universal', level=3 %}{% endrenderCssParts %}
+
+    {% renderCssCustomProperties for='rh-footer-universal', level=3 %}{% endrenderCssCustomProperties %}
+
+## &lt;rh-footer-block&gt;
+
+    {% renderSlots for='rh-footer-block', level=3 %}{% endrenderSlots %}
+
+    {% renderAttributes for='rh-footer-block', level=3 %}{% endrenderAttributes %}
+
+    {% renderMethods for='rh-footer-block', level=3 %}{% endrenderMethods %}
+
+    {% renderEvents for='rh-footer-block', level=3 %}{% endrenderEvents %}
+
+    {% renderCssParts for='rh-footer-block', level=3 %}{% endrenderCssParts %}
+
+    {% renderCssCustomProperties for='rh-footer-block', level=3 %}{% endrenderCssCustomProperties %}
+
+## &lt;rh-footer-copyright&gt;
+
+    {% renderSlots for='rh-footer-block', level=3 %}{% endrenderSlots %}
+
+    {% renderAttributes for='rh-footer-block', level=3 %}{% endrenderAttributes %}
+
+    {% renderMethods for='rh-footer-block', level=3 %}{% endrenderMethods %}
+
+    {% renderEvents for='rh-footer-block', level=3 %}{% endrenderEvents %}
+
+    {% renderCssParts for='rh-footer-block', level=3 %}{% endrenderCssParts %}
+
+    {% renderCssCustomProperties for='rh-footer-block', level=3 %}{% endrenderCssCustomProperties %}
+
+## &lt;rh-footer-links&gt;
+
+    {% renderSlots for='rh-footer-links', level=3 %}{% endrenderSlots %}
+
+    {% renderAttributes for='rh-footer-links', level=3 %}{% endrenderAttributes %}
+
+    {% renderMethods for='rh-footer-links', level=3 %}{% endrenderMethods %}
+
+    {% renderEvents for='rh-footer-links', level=3 %}{% endrenderEvents %}
+
+    {% renderCssParts for='rh-footer-links', level=3 %}{% endrenderCssParts %}
+
+    {% renderCssCustomProperties for='rh-footer-links', level=3 %}{% endrenderCssCustomProperties %}
+
+## &lt;rh-footer-social-link&gt;
+
+    {% renderSlots for='rh-footer-social-link', level=3 %}{% endrenderSlots %}
+
+    {% renderAttributes for='rh-footer-social-link', level=3 %}{% endrenderAttributes %}
+
+    {% renderMethods for='rh-footer-social-link', level=3 %}{% endrenderMethods %}
+
+    {% renderEvents for='rh-footer-social-link', level=3 %}{% endrenderEvents %}
+
+    {% renderCssParts for='rh-footer-social-link', level=3 %}{% endrenderCssParts %}
+
+    {% renderCssCustomProperties for='rh-footer-social-link', level=3 %}{% endrenderCssCustomProperties %}   


### PR DESCRIPTION
## What I did

1. Split out subcomponents on code tab into their own sections containing each section of shortcode, `slots`, `attributes`, `methods`, `events`, `cssparts`, and `csscusomtproperties`. 

Closes #948

## Testing Instructions

1. View deploy preview

## Notes to Reviewers

Now that some of these sub components APIs are exposed we should consider adding more detail to the JSDoc around css parts and slots on these components either as part of this PR or as a new issue. 
