### PR TITLE
feat: contain focus outline to the width of the link text

### DIFF
--- a/.changeset/little-cheetahs-talk.md
+++ b/.changeset/little-cheetahs-talk.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-footer>`: contain focus outline to the width of the link text

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -57,6 +57,7 @@ rh-footer [slot^="links"] a {
   display: block;
   color: var(--rh-color-text-primary-on-dark, #ffffff) !important;
   font-size: var(--rh-footer-link-font-size, var(--rh-font-size-body-text-sm, 0.875rem));
+  width: fit-content;
 }
 
 :is(rh-footer-universal, rh-global-footer) [slot^="links"] a {


### PR DESCRIPTION
## What I did

1. The flexbox setting on the parent `ul` container was forcing the link width to be 100% of its container.  I'm using fit-content to reduce it to just take up the width of the text inside the link.


## Testing Instructions

1.  Visit
2. Using `tab` move the focus state to the primary links of the footer.
3. Verify that it only outlines around the width of the link text.

