### PR TITLE
docs: spacer table reduce font size, switch to outline to adjust fit

### DIFF
--- a/docs/scss/components/_spacer-tokens-table.scss
+++ b/docs/scss/components/_spacer-tokens-table.scss
@@ -15,13 +15,13 @@
   samp {
     width: var(--samp-width);
     aspect-ratio: 1 / 1;
-    border: var(--rh-border-width-sm, 1px) dashed var(--samp-color, var(--rh-color-surface-darkest, #151515));
+    outline: var(--rh-border-width-sm, 1px) dashed var(--samp-color, var(--rh-color-surface-darkest, #151515));
     color: var(--samp-color, var(--rh-color-text-primary-on-light, #151515));
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
-    aspect-ratio: 1;
+    font-size: var(--rh-font-size-body-text-xs, 0.75rem);
   }
 
   samp span {


### PR DESCRIPTION
## What I did

1. Reduces font size for spacer samples
2. Switched to outline from border to output more exact spacer size

## Testing Instructions

1. View deploy preview

## Notes to Reviewers
