### PR TITLE
docs: add permalink/copy to repo status table header & use SVG for check

### DIFF
--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -17,9 +17,10 @@ function repoStatus({ heading = 'Repo status', type = 'Pattern' } = {}) {
   } else {
     return /* html*/`
 
-<section class="section section--palette-default container">
-  <a id="Component status"></a>
-  <h2 id="component-status" class="section-title pfe-jump-links-panel__section">${heading}</h2>
+<section class="section section--palette-default container">  
+  
+  ${`## ${heading} {.section-title .pfe-jump-links-panel__section} `}
+  
   <p>Learn more about our various code repos by visiting <a href="https://ux.redhat.com/about/how-we-build/" target="_blank">this page</a>.</p>
   <div class="component-status-table-container">
     <table class="component-status-table">

--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -21,11 +21,10 @@ function repoStatus({ heading = 'Repo status', type = 'Pattern', level = 2 } = {
   } else {
     return /* html*/`
 
-<section class="section section--palette-default container">  
+<section class="section section--palette-default container">
+
   ${`${headingLevel} ${heading} {.section-title .pfe-jump-links-panel__section}`}
-  
-  ${`## ${heading} {.section-title .pfe-jump-links-panel__section} `}
-  
+    
   <p>Learn more about our various code repos by visiting <a href="https://ux.redhat.com/about/how-we-build/" target="_blank">this page</a>.</p>
   <div class="component-status-table-container">
     <table class="component-status-table">

--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -4,7 +4,8 @@ const fs = require('fs');
  * Reads component status data from global data (see above) and outputs a table for each component
  * @this {EleventyContext}
  */
-function repoStatus({ heading = 'Repo status', type = 'Pattern' } = {}) {
+function repoStatus({ heading = 'Repo status', type = 'Pattern', level = 2 } = {}) {
+  const headingLevel = Array.from({ length: level }, () => '#').join('');
   const checkSVG = fs.readFileSync('node_modules/@patternfly/icons/fas/check.svg', 'utf8');
   /** @type {string[][]} */
   const docsPage = this.ctx._;
@@ -21,6 +22,7 @@ function repoStatus({ heading = 'Repo status', type = 'Pattern' } = {}) {
     return /* html*/`
 
 <section class="section section--palette-default container">  
+  ${`${headingLevel} ${heading} {.section-title .pfe-jump-links-panel__section}`}
   
   ${`## ${heading} {.section-title .pfe-jump-links-panel__section} `}
   

--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -1,8 +1,11 @@
+const fs = require('fs');
+
 /**
  * Reads component status data from global data (see above) and outputs a table for each component
  * @this {EleventyContext}
  */
 function repoStatus({ heading = 'Repo status', type = 'Pattern' } = {}) {
+  const checkSVG = fs.readFileSync('node_modules/@patternfly/icons/fas/check.svg', 'utf8');
   /** @type {string[][]} */
   const docsPage = this.ctx._;
   const allStatuses = this.ctx.repoStatus ?? docsPage?.repoStatus ?? [];
@@ -32,7 +35,7 @@ function repoStatus({ heading = 'Repo status', type = 'Pattern' } = {}) {
       <tbody>${bodyRows.map(([, rowHeader, ...columns]) => `
         <tr>
           <th>${rowHeader}</th>
-          ${columns.map(x => `<td>${x === 'x' ? '&check;' : ''}</td>`.trim()).join('\n').trim()}
+          ${columns.map(x => `<td>${x === 'x' ? `${checkSVG}` : ''}</td>`.trim()).join('\n').trim()}
         </tr>`.trim()).join('\n').trim()}
       </tbody>
     </table>

--- a/docs/scss/components/_component-status-table.scss
+++ b/docs/scss/components/_component-status-table.scss
@@ -37,6 +37,12 @@
     &:last-child {
       border-right: 0;
     }
+
+    svg {
+      height: var(--rh-size-icon-01, 16px);
+      width: var(--rh-size-icon-01, 16px);
+      fill: var(--rh-color-text-primary-on-light, #151515);
+    }
   }
 
   @media (max-width: 1000px) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@11ty/eleventy-img": "^3.1.0",
         "@patternfly/elements": "^2.2.1",
+        "@patternfly/icons": "^1.0.2",
         "@rhds/tokens": "^1.1.2",
         "image-size": "^1.0.2",
         "lit": "^2.7.3",

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
   "dependencies": {
     "@11ty/eleventy-img": "^3.1.0",
     "@patternfly/elements": "^2.2.1",
+    "@patternfly/icons": "^1.0.2",
     "@rhds/tokens": "^1.1.2",
     "image-size": "^1.0.2",
     "lit": "^2.7.3",


### PR DESCRIPTION
Closes #424

## What I did

1. Using markdown for repo status table header so that it automatically adds the permalink/copy functionality
2. Removed some markup and the heading element ID that I don't see being used anywhere


## Testing Instructions

1. Verify that the permalink/copy functionality appears and works on the `Repo status` heading.
2. Verify that you now see SVG checks now instead of the HTML entities