### PR TITLE
docs: combine repeated code tab shortcodes into single shortcode

### DIFF
--- a/docs/_plugins/shortcodes.cjs
+++ b/docs/_plugins/shortcodes.cjs
@@ -8,6 +8,7 @@ const Section = require('./shortcodes/section.cjs');
 const Demo = require('./shortcodes/demo.cjs');
 const SpacerTokensTable = require('./shortcodes/spacerTokensTable.cjs');
 const TokensTable = require('./shortcodes/tokensTable.cjs');
+const renderCodeDocs = require('./shortcodes/renderCodeDocs.cjs');
 
 /** @typedef {import('@patternfly/pfe-tools/11ty/DocsPage').DocsPage} DocsPage */
 
@@ -29,4 +30,5 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(Demo);
   eleventyConfig.addPlugin(SpacerTokensTable);
   eleventyConfig.addPlugin(TokensTable);
+  eleventyConfig.addPlugin(renderCodeDocs);
 };

--- a/docs/_plugins/shortcodes/renderCodeDocs.cjs
+++ b/docs/_plugins/shortcodes/renderCodeDocs.cjs
@@ -1,0 +1,43 @@
+import('@patternfly/pfe-tools/11ty/DocsPage.js');
+
+/** @typedef {import('@patternfly/pfe-tools/11ty/DocsPage').DocsPage} DocsPage */
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPairedShortcode('renderCodeDocs',
+    function renderCodeDocs(content, kwargs = {}) {
+    /**
+     * NB: since the data for this shortcode is no a POJO,
+     * but a DocsPage instance, 11ty assigns it to this.ctx._
+     * @see https://github.com/11ty/eleventy/blob/bf7c0c0cce1b2cb01561f57fdd33db001df4cb7e/src/Plugins/RenderPlugin.js#L89-L93
+     * @type {DocsPage}
+     */
+      const docsPage = this.ctx._;
+
+      const slugify = eleventyConfig.getFilter('slugify');
+
+      const level = kwargs.level ?? 2;
+      const subHeadings = level + 1;
+      const component = kwargs.for ?? docsPage.tagName;
+      const hideDescription = kwargs.hideDescription ?? false;
+      const headerTag = `h${level}`;
+
+      return /* html */`
+        <copy-permalink class="${headerTag}">
+          <${headerTag}>
+            <a class="heading-anchor" href="#${slugify(component)}">
+              ${component}
+            </a>
+          </${headerTag}>
+        </copy-permalink>
+        ${hideDescription ? `` : `<p>${docsPage.manifest.getDescription(component)}</p>`}
+        ${docsPage.renderSlots('', { 'level': subHeadings, 'for': component })}
+        ${docsPage.renderAttributes('', { 'level': subHeadings, 'for': component })}
+        ${docsPage.renderMethods('', { 'level': subHeadings, 'for': component })}
+        ${docsPage.renderEvents('', { 'level': subHeadings, 'for': component })}
+        ${docsPage.renderCssParts('', { 'level': subHeadings, 'for': component })}
+        ${docsPage.renderCssCustomProperties('', { 'level': subHeadings, 'for': component })}
+        ${content}
+      `.trim();
+    }
+  );
+};
+

--- a/elements/rh-accordion/docs/30-code.md
+++ b/elements/rh-accordion/docs/30-code.md
@@ -25,51 +25,11 @@
 ```
 {% endband %}
  
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}
 
-## `rh-accordion`
+{% renderCodeDocs for='rh-accordion-header' %}{% endrenderCodeDocs %}
 
-{% renderSlots for='rh-accordion', level=3%}{% endrenderSlots %}
+{% renderCodeDocs for='rh-accordion-panel' %}{% endrenderCodeDocs %}
 
-{% renderAttributes for='rh-accordion', level=3%}{% endrenderAttributes %}
-
-{% renderMethods for='rh-accordion', level=3%}{% endrenderMethods %}
-
-{% renderEvents for='rh-accordion', level=3%}{% endrenderEvents %}
-
-{% renderCssParts for='rh-accordion', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-accordion', level=3%}{% endrenderCssCustomProperties %} 
-
- 
-
-## `rh-accordion-header`
-
-{% renderSlots for='rh-accordion-header', level=3%}{% endrenderSlots %}
-
-{% renderAttributes for='rh-accordion-header', level=3%}{% endrenderAttributes %}
-
-{% renderMethods for='rh-accordion-header', level=3%}{% endrenderMethods %}
-
-{% renderEvents for='rh-accordion-header', level=3%}{% endrenderEvents %}
-
-{% renderCssParts for='rh-accordion-header', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-accordion-header', level=3%}{% endrenderCssCustomProperties %} 
-
- 
-
-## `rh-accordion-panel`
-
-{% renderSlots for='rh-accordion-panel', level=3%}{% endrenderSlots %}
-
-{% renderAttributes for='rh-accordion-panel', level=3%}{% endrenderAttributes %}
-
-{% renderMethods for='rh-accordion-panel', level=3%}{% endrenderMethods %}
-
-{% renderEvents for='rh-accordion-panel', level=3%}{% endrenderEvents %}
-
-{% renderCssParts for='rh-accordion-panel', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-accordion-panel', level=3%}{% endrenderCssCustomProperties %} 
 
 

--- a/elements/rh-alert/docs/30-code.md
+++ b/elements/rh-alert/docs/30-code.md
@@ -1,14 +1,3 @@
 {% renderInstallation %}{% endrenderInstallation %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderCssParts %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties %}{% endrenderCssCustomProperties %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-audio-player/docs/40-code.md
+++ b/elements/rh-audio-player/docs/40-code.md
@@ -6,52 +6,11 @@
 View the demo in a new tab
 {% endcta %}
 
-## `rh-audio-player`
-{% renderSlots  for="rh-audio-player" %}{% endrenderSlots %}
+{% renderCodeDocs for='rh-audio-player', hideDescription=true %}{% endrenderCodeDocs %}
 
-{% renderAttributes for="rh-audio-player" %}{% endrenderAttributes %}
+{% renderCodeDocs for='rh-audio-player-about' %}{% endrenderCodeDocs %}
 
-{% renderMethods for="rh-audio-player" %}{% endrenderMethods %}
+{% renderCodeDocs for='rh-audio-player-subscribe' %}{% endrenderCodeDocs %}
 
-{% renderEvents for="rh-audio-player" %}{% endrenderEvents %}
+{% renderCodeDocs for='rh-transcript' %}{% endrenderCodeDocs %}
 
-{% renderCssCustomProperties for="rh-audio-player" %}{% endrenderCssCustomProperties %}
-
-{% renderCssParts for="rh-audio-player" %}{% endrenderCssParts %}
-
-## `rh-audio-player-about`
-{% renderSlots  for="rh-audio-player-about" %}{% endrenderSlots %}
-
-{% renderAttributes for="rh-audio-player-about" %}{% endrenderAttributes %}
-
-{% renderMethods for="rh-audio-player-about" %}{% endrenderMethods %}
-
-{% renderEvents for="rh-audio-player-about" %}{% endrenderEvents %}
-
-{% renderCssCustomProperties for="rh-audio-player-about" %}{% endrenderCssCustomProperties %}
-
-## `rh-audio-player-subscribe`
-{% renderSlots  for="rh-audio-player-subscribe" %}{% endrenderSlots %}
-
-{% renderAttributes for="rh-audio-player-subscribe" %}{% endrenderAttributes %}
-
-{% renderMethods for="rh-audio-player-subscribe" %}{% endrenderMethods %}
-
-{% renderEvents for="rh-audio-player-subscribe" %}{% endrenderEvents %}
-
-{% renderCssCustomProperties for="rh-audio-player-subscribe" %}{% endrenderCssCustomProperties %}
-
-{% renderCssParts for="rh-audio-player-subscribe" %}{% endrenderCssParts %}
-
-## `rh-transcript`
-{% renderSlots  for="rh-transcript" %}{% endrenderSlots %}
-
-{% renderAttributes for="rh-transcript" %}{% endrenderAttributes %}
-
-{% renderMethods for="rh-transcript" %}{% endrenderMethods %}
-
-{% renderEvents for="rh-transcript" %}{% endrenderEvents %}
-
-{% renderCssCustomProperties for="rh-transcript" %}{% endrenderCssCustomProperties %}
-
-{% renderCssParts for="rh-transcript" %}{% endrenderCssParts %}

--- a/elements/rh-avatar/docs/30-code.md
+++ b/elements/rh-avatar/docs/30-code.md
@@ -6,14 +6,4 @@
   ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-avatar', level=3 %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-avatar', level=3 %}{% endrenderCssCustomProperties %}
+{% renderCodeDocs for='rh-avatar', hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-badge/docs/30-code.md
+++ b/elements/rh-badge/docs/30-code.md
@@ -6,14 +6,4 @@
 ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-badge', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-badge', level=3%}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-blockquote/docs/30-code.md
+++ b/elements/rh-blockquote/docs/30-code.md
@@ -1,0 +1,3 @@
+{% renderInstallation %}{% endrenderInstallation %}
+
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-button/docs/30-code.md
+++ b/elements/rh-button/docs/30-code.md
@@ -6,14 +6,4 @@
 View the demo in a new tab
   {% endcta %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-button', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-button', level=3%}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-card/docs/30-code.md
+++ b/elements/rh-card/docs/30-code.md
@@ -1,13 +1,3 @@
 {% renderInstallation %}{% endrenderInstallation %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-card', level=3 %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-card', level=3 %}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-cta/docs/30-code.md
+++ b/elements/rh-cta/docs/30-code.md
@@ -8,14 +8,4 @@
   ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-cta', level=3 %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-cta', level=3 %}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-dialog/docs/30-code.md
+++ b/elements/rh-dialog/docs/30-code.md
@@ -12,14 +12,4 @@
 ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-dialog', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-dialog', level=3%}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-footer/docs/30-code.md
+++ b/elements/rh-footer/docs/30-code.md
@@ -5,86 +5,15 @@
 Lightdom CSS is required to ensure a reduced [Cumulative Layout Shift (CLS)](https://web.dev/cls/) experience before the component has fully initialized.
 {% endrenderInstallation %}
 
-## &lt;rh-footer&gt;
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}
 
-    {% renderSlots for='rh-footer', level=3 %}{% endrenderSlots %}
+{% renderCodeDocs for='rh-footer-universal' %}{% endrenderCodeDocs %}
 
-    {% renderAttributes for='rh-footer', level=3 %}{% endrenderAttributes %}
+{% renderCodeDocs for='rh-footer-block' %}{% endrenderCodeDocs %}
 
-    {% renderMethods for='rh-footer', level=3 %}{% endrenderMethods %}
+{% renderCodeDocs for='rh-footer-copyright' %}{% endrenderCodeDocs %}
 
-    {% renderEvents for='rh-footer', level=3 %}{% endrenderEvents %}
+{% renderCodeDocs for='rh-footer-links' %}{% endrenderCodeDocs %}
 
-    {% renderCssParts for='rh-footer', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-footer', level=3 %}{% endrenderCssCustomProperties %}
-
-## &lt;rh-footer-universal&gt;
-
-    {% renderSlots for='rh-footer-universal', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-footer-universal', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-footer-universal', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-footer-universal', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-footer-universal', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-footer-universal', level=3 %}{% endrenderCssCustomProperties %}
-
-## &lt;rh-footer-block&gt;
-
-    {% renderSlots for='rh-footer-block', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-footer-block', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-footer-block', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-footer-block', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-footer-block', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-footer-block', level=3 %}{% endrenderCssCustomProperties %}
-
-## &lt;rh-footer-copyright&gt;
-
-    {% renderSlots for='rh-footer-copyright', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-footer-copyright', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-footer-copyright', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-footer-copyright', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-footer-copyright', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-footer-copyright', level=3 %}{% endrenderCssCustomProperties %}
-
-## &lt;rh-footer-links&gt;
-
-    {% renderSlots for='rh-footer-links', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-footer-links', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-footer-links', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-footer-links', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-footer-links', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-footer-links', level=3 %}{% endrenderCssCustomProperties %}
-
-## &lt;rh-footer-social-link&gt;
-
-    {% renderSlots for='rh-footer-social-link', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-footer-social-link', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-footer-social-link', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-footer-social-link', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-footer-social-link', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-footer-social-link', level=3 %}{% endrenderCssCustomProperties %}   
+{% renderCodeDocs for='rh-footer-social-link' %}{% endrenderCodeDocs %}
+ 

--- a/elements/rh-navigation-secondary/docs/30-code.md
+++ b/elements/rh-navigation-secondary/docs/30-code.md
@@ -5,62 +5,11 @@
 Lightdom CSS is required to ensure a reduced [Cumulative Layout Shift (CLS)](https://web.dev/cls/) experience before the component has fully initialized.
 {% endrenderInstallation %}
 
-## &lt;rh-navigation-secondary&gt;
 
-    {% renderSlots for='rh-navigation-secondary', level=3 %}{% endrenderSlots %}
+{% renderCodeDocs for='rh-navigation-secondary', hideDescription=true %}{% endrenderCodeDocs %}
 
-    {% renderAttributes for='rh-navigation-secondary', level=3 %}{% endrenderAttributes %}
+{% renderCodeDocs for='rh-navigation-secondary-dropdown' %}{% endrenderCodeDocs %}
 
-    {% renderMethods for='rh-navigation-secondary', level=3 %}{% endrenderMethods %}
+{% renderCodeDocs for='rh-navigation-secondary-menu' %}{% endrenderCodeDocs %}
 
-    {% renderEvents for='rh-navigation-secondary', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-navigation-secondary', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-navigation-secondary', level=3 %}{% endrenderCssCustomProperties %}
-
-## &lt;rh-navigation-secondary-dropdown&gt;
-  
-    {% renderSlots for='rh-navigation-secondary-dropdown', level=3 %}{% endrenderSlots %}
-  
-    {% renderAttributes for='rh-navigation-secondary-dropdown', level=3 %}{% endrenderAttributes %}
-  
-    {% renderMethods for='rh-navigation-secondary-dropdown', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-navigation-secondary-dropdown', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-navigation-secondary-dropdown', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-navigation-secondary-dropdown', level=3 %}{% endrenderCssCustomProperties %}
-    
-
-## &lt;rh-navigation-secondary-menu&gt;
-  
-    {% renderSlots for='rh-navigation-secondary-menu', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-navigation-secondary-menu', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-navigation-secondary-menu', level=3 %}{% endrenderMethods %}
-
-    {% renderEvents for='rh-navigation-secondary-menu', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-navigation-secondary-menu', level=3 %}{% endrenderCssParts %}
-  
-    {% renderCssCustomProperties for='rh-navigation-secondary-menu', level=3 %}{% endrenderCssCustomProperties %}
-    
-
-## &lt;rh-navigation-secondary-menu-section&gt;
-  
-    {% renderSlots for='rh-navigation-secondary-menu-section', level=3 %}{% endrenderSlots %}
-
-    {% renderAttributes for='rh-navigation-secondary-menu-section', level=3 %}{% endrenderAttributes %}
-
-    {% renderMethods for='rh-navigation-secondary-menu-section', level=3 %}{% endrenderMethods %}
-   
-    {% renderEvents for='rh-navigation-secondary-menu-section', level=3 %}{% endrenderEvents %}
-
-    {% renderCssParts for='rh-navigation-secondary-menu-section', level=3 %}{% endrenderCssParts %}
-
-    {% renderCssCustomProperties for='rh-navigation-secondary-menu-section', level=3 %}{% endrenderCssCustomProperties %}
-    
-
+{% renderCodeDocs for='rh-navigation-secondary-menu-section' %}{% endrenderCodeDocs %}

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
@@ -31,7 +31,8 @@ export class SecondaryNavDropdownExpandEvent extends ComposedEvent {
 import styles from './rh-navigation-secondary-dropdown.css';
 
 /**
- * @summary A wrapper component to upgrade a top level nav link to include dropdown functionality
+ * Upgrades a top level nav link to include dropdown functionality
+ * @summary Upgrades a top level nav link to include dropdown functionality
  *
  * @slot link   - Link for dropdown, expects `<a>` element
  * @slot menu   - Menu for dropdown, expects `<rh-navigation-secondary-menu>` element

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-menu-section.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-menu-section.ts
@@ -9,7 +9,8 @@ import { isHeadingElement } from '../../lib/functions.js';
 import styles from './rh-navigation-secondary-menu-section.css';
 
 /**
- * @summary 'A menu section which auto upgrades header and sibling link list accessibility attributes'
+ * A menu section which auto upgrades accessibility for headers and sibling list
+ * @summary 'A menu section which auto upgrades accessibility for headers and sibling list'
  *
  * @slot header     - Adds a header tag to section, expects `<h1> | <h2> | <h3> | <h4> | <h5> | <h6>` element
  * @slot links      - Adds a ul tag to section, expects `<ul> | <ol>` element

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-menu.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-menu.ts
@@ -12,7 +12,8 @@ import { ScreenSizeController } from '../../lib/ScreenSizeController.js';
 import styles from './rh-navigation-secondary-menu.css';
 
 /**
- * @summary 'A pop up menu for secondary nav, available in full-width and fixed-with sizes'
+ * Dropdown menu for secondary nav, available in full-width and fixed-with sizes
+ * @summary 'Dropdown menu for secondary nav, available in full-width and fixed-with sizes'
  *
  * @slot                  - Optional `<rh-navigation-secondary-menu-section>` elements or content following [design guidelines](../guidelines/#expandable-tray)
  * @csspart container     - container - `<div>` element, wrapper for menus

--- a/elements/rh-pagination/docs/30-code.md
+++ b/elements/rh-pagination/docs/30-code.md
@@ -14,14 +14,4 @@
 ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-pagination', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-pagination', level=3%}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-spinner/docs/30-code.md
+++ b/elements/rh-spinner/docs/30-code.md
@@ -17,14 +17,4 @@
 ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-spinner', level=3%}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-spinner', level=3%}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-stat/docs/30-code.md
+++ b/elements/rh-stat/docs/30-code.md
@@ -9,14 +9,4 @@
 ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-stat', level=3 %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-stat', level=3 %}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-subnav/docs/30-code.md
+++ b/elements/rh-subnav/docs/30-code.md
@@ -7,14 +7,4 @@ Lightdom CSS is required to ensure a reduced [Cumulative Layout Shift
 initialized.
 {% endrenderInstallation %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties  %}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-tabs/docs/30-code.md
+++ b/elements/rh-tabs/docs/30-code.md
@@ -1,5 +1,4 @@
-{% renderInstallation %}
-{% endrenderInstallation %}
+{% renderInstallation %}{% endrenderInstallation %}
 
 ## Usage
   ```html
@@ -15,43 +14,8 @@
   </rh-tabs>
   ```
 
-## &lt;rh-tabs&gt;
-  {% renderSlots for='rh-tabs', level=3%}{% endrenderSlots %}
+{% renderCodeDocs for='rh-tabs', hideDescription=true %}{% endrenderCodeDocs %}
 
-  {% renderAttributes for='rh-tabs', level=3%}{% endrenderAttributes %}
+{% renderCodeDocs for='rh-tab' %}{% endrenderCodeDocs %}
 
-  {% renderMethods for='rh-tabs', level=3%}{% endrenderMethods %}
-
-  {% renderEvents for='rh-tabs', level=3%}{% endrenderEvents %}
-
-  {% renderCssParts for='rh-tabs', level=3%}{% endrenderCssParts %}
-
-  {% renderCssCustomProperties for='rh-tabs', level=3%}{% endrenderCssCustomProperties %}
-
-## &lt;rh-tab&gt;
-  {% renderSlots for='rh-tab', level=3%}{% endrenderSlots %}
-
-  {% renderAttributes for='rh-tab', level=3%}{% endrenderAttributes %}
-
-  {% renderMethods for='rh-tab', level=3%}{% endrenderMethods %}
-
-  {% renderEvents for='rh-tab', level=3%}{% endrenderEvents %}
-
-  {% renderCssParts for='rh-tab', level=3%}{% endrenderCssParts %}
-
-  {% renderCssCustomProperties for='rh-tab', level=3%}{% endrenderCssCustomProperties %}
-
-
-## &lt;rh-tab-panel&gt;
-  {% renderSlots for='rh-tab-panel', level=3%}{% endrenderSlots %}
-
-  {% renderAttributes for='rh-tab-panel', level=3%}{% endrenderAttributes %}
-
-  {% renderMethods for='rh-tab-panel', level=3%}{% endrenderMethods %}
-
-  {% renderEvents for='rh-tab-panel', level=3%}{% endrenderEvents %}
-
-  {% renderCssParts for='rh-tab-panel', level=3%}{% endrenderCssParts %}
-
-  {% renderCssCustomProperties for='rh-tab-panel', level=3%}{% endrenderCssCustomProperties %}
-
+{% renderCodeDocs for='rh-tab-panel' %}{% endrenderCodeDocs %}

--- a/elements/rh-tag/docs/30-code.md
+++ b/elements/rh-tag/docs/30-code.md
@@ -6,14 +6,4 @@
 ```
 {% endband %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
-
-{% renderCssParts for='rh-tag', level=3 %}{% endrenderCssParts %}
-
-{% renderCssCustomProperties for='rh-tag', level=3 %}{% endrenderCssCustomProperties %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-tooltip/docs/30-code.md
+++ b/elements/rh-tooltip/docs/30-code.md
@@ -6,10 +6,4 @@
 View the demo in a new tab
   {% endcta %}
 
-{% renderSlots %}{% endrenderSlots %}
-
-{% renderAttributes %}{% endrenderAttributes %}
-
-{% renderMethods %}{% endrenderMethods %}
-
-{% renderEvents %}{% endrenderEvents %}
+{% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}


### PR DESCRIPTION
## What I did

1. Combined repeated shortcodes on the code tab to a single shortcode `renderCodeDocs`
2. Adds ability to hide and show description under component tag header `hideDescription`

Closes #1052
Closes #1073


## Testing Instructions

1. View deploy preview for each component look for regressions in information not shown or incorrect information shown.

## Notes to Reviewers
