### PR TITLE
fix(audio-player): tooltip duplication

### DIFF
--- a/elements/rh-audio-player/rh-audio-player.ts
+++ b/elements/rh-audio-player/rh-audio-player.ts
@@ -1071,7 +1071,6 @@ export class RhAudioPlayer extends LitElement {
     this.#unsetTabindexFromMenuItems();
     window.removeEventListener('click', this.#onWindowClick);
     await this.#menufloat.hide();
-    this.shadowRoot?.getElementById('menu-button')?.focus();
   }
 
   #onTranscriptDownload() {

--- a/elements/rh-audio-player/rh-audio-player.ts
+++ b/elements/rh-audio-player/rh-audio-player.ts
@@ -590,7 +590,7 @@ export class RhAudioPlayer extends LitElement {
                     aria-label="${this.#translation.get('menu')}"
                     aria-controls="menu"
                     aria-haspopup="true"
-                    @click="${() => this.#menuOpen = !this.#menuOpen}">
+                    @click="${this.#onMenuToggle}">
               ${RhAudioPlayer.icons.menuKebab}
             </button>
             <span slot="content">${this.#translation.get('menu')}</span>
@@ -917,6 +917,15 @@ export class RhAudioPlayer extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * handles toggling the "More options" menu button
+   */
+  #onMenuToggle(event: Event) {
+    event.preventDefault();
+    this.#menuOpen = !this.#menuOpen;
+    event.stopPropagation();
+  }
+
   /** updates panel text */
   #onPanelChange() {
     this.#updateMenuLabels();
@@ -1039,12 +1048,6 @@ export class RhAudioPlayer extends LitElement {
 
   async #positionMenu() {
     await this.updateComplete;
-    const menu = this.shadowRoot?.getElementById('menu') as RhMenu;
-    const button = this.shadowRoot?.getElementById('menu-button') as HTMLElement;
-    if (!menu || !button) { return; }
-    if (this.#lastActiveMenuItem) {
-      menu.activateItem(this.#lastActiveMenuItem);
-    }
     const placement = 'bottom-start';
     const mainAxis = 0;
     const offset = { mainAxis: mainAxis, alignmentAxis: 0 };
@@ -1053,9 +1056,13 @@ export class RhAudioPlayer extends LitElement {
 
   async #showMenu() {
     const menu = this.shadowRoot?.getElementById('menu') as RhMenu;
+    const button = this.shadowRoot?.getElementById('menu-button') as HTMLElement;
+    if (!menu || !button) { return; }
     await this.#positionMenu();
     await this.updateComplete;
-    menu.activateItem(menu.activeItem as HTMLElement);
+    if (this.#lastActiveMenuItem) {
+      menu.activateItem(this.#lastActiveMenuItem);
+    }
     window.addEventListener('click', this.#onWindowClick);
   }
 


### PR DESCRIPTION
## What I did

1. Removed unnecessary focus() on menu button when menu is closed

## Testing Instructions

1. Go to the [Prevent concurrent playback demo from the DP](https://deploy-preview-1107--red-hat-design-system.netlify.app/elements/audio-player/demo/prevent-concurrent-playback/).
2. Click the **More options** menu button (kebab icon) on the _**first**_ player.
3. Click the **More options** menu button (kebab icon) on the _**second**_ player.
4. Verify that the **More options** tooltip appears only on the _**first**_ player.
5. For good measure, try clicking and using the keyboard to jump between various buttons on the players, opening and closing the menus.
6. Verify that the focus and tooltips behave as expected.

## Notes to Reviewers
