### PR TITLE
docs: don't bundle rhds before build

### DIFF
--- a/docs/_plugins/rhds.cjs
+++ b/docs/_plugins/rhds.cjs
@@ -271,12 +271,6 @@ module.exports = function(eleventyConfig, { tagsToAlphabetize }) {
     eleventyConfig.addGlobalData('pfeconfig', config);
   });
 
-  /** generate a bundle that packs all of rhds with all dependencies into a single large js file */
-  eleventyConfig.on('eleventy.before', async function() {
-    const { bundle } = await import('../../scripts/bundle.js');
-    await bundle({ outfile: '_site/assets/rhds.min.js' });
-  });
-
   /** custom-elements.json */
   eleventyConfig.on('eleventy.before', async function({ runMode }) {
     if (runMode === 'watch') {

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -23,6 +23,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.watchIgnores.add('docs/assets/redhat/');
   eleventyConfig.watchIgnores.add('**/*.spec.ts');
   eleventyConfig.watchIgnores.add('**/*.d.ts');
+  eleventyConfig.watchIgnores.add('**/*.js.map');
   eleventyConfig.watchIgnores.add('elements/*/test/');
   eleventyConfig.watchIgnores.add('lib/elements/*/test/');
   eleventyConfig.addPassthroughCopy('docs/public/red-hat-outfit.css');


### PR DESCRIPTION
closes #962

... hopefully?

## What I did

1. stop bundling rhds on each 11ty build
2. exclude `.js.map` from 11ty watch
