### PR TITLE
docs: set container max-width to 1000px;

### DIFF
--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -31,7 +31,7 @@
 .header,
 .section,
 .container {
-  max-width: 1000px;
+  max-width: 1160px;
   padding-left: 32px;
   padding-right: 32px;
   @include breakpoint(tango) {

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -31,7 +31,7 @@
 .header,
 .section,
 .container {
-  max-width: 65rem;
+  max-width: 1000px;
   padding-left: 32px;
   padding-right: 32px;
   @include breakpoint(tango) {


### PR DESCRIPTION
## What I did

1. Changed container max-width CSS from 65rem to 1000px;


## Testing Instructions

From a large desktop window, view the following pages from the DP and verify that `.container`, `.header` and `.section` are consistently a max-width 1000px: 

- [ ] [Tokens overview](https://deploy-preview-1132--red-hat-design-system.netlify.app/tokens/)
- [ ] [Tokens icon](https://deploy-preview-1132--red-hat-design-system.netlify.app/tokens/icon/)
- [ ] [All elements](https://deploy-preview-1132--red-hat-design-system.netlify.app/elements/) 
- [ ] [Audio player](https://deploy-preview-1132--red-hat-design-system.netlify.app/elements/audio-player/)

## Notes to Reviewers
Max-width was initially 65em, but we (a call between @zeroedin and me) had to changed it to 65rem because it was inconsistent in some of the tokens pages.  I'm assuming this was what broke. Setting it to 1000px should keep it consistent across the site.