### PR TITLE
docs: correct subscribe slot

### DIFF
--- a/.changeset/popular-crews-relate.md
+++ b/.changeset/popular-crews-relate.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-audio-player>`: corrected subscribe slot documentation.

--- a/elements/rh-audio-player/rh-audio-player.ts
+++ b/elements/rh-audio-player/rh-audio-player.ts
@@ -34,7 +34,7 @@ import { RhTooltip } from '../rh-tooltip/rh-tooltip.js';
  * @slot title - optional, title of episode
  * @slot media - html `audio` element
  * @slot about - optional `rh-audio-player-about` panel with attribution
- * @slot about - optional `rh-audio-player-subscribe` panel with links to subscribe
+ * @slot subscribe - optional `rh-audio-player-subscribe` panel with links to subscribe
  * @slot transcript - optional `rh-transcript` panel with `rh-cue` elements
  * @cssprop --rh-audio-player-background-color - color of player background - {@default var(--rh-color-surface-lightest, #ffffff)}
  * @cssprop --rh-audio-player-icon-background-color {@default var(--rh-audio-player-background-color)}


### PR DESCRIPTION
## What I did

1. Fixed name of subscribe slot on audio-player


## Testing Instructions

1. Go to https://deploy-preview-1168--red-hat-design-system.netlify.app/elements/audio-player/code/#slots
2. Verify that there is now a slot named 'subscribe'

## Screenshots

![Screenshot 2023-07-26 at 7 17 40 AM](https://github.com/RedHat-UX/red-hat-design-system/assets/3428964/e820b71d-7dcc-42e0-bf0d-c69319fa78db)

