### PR TITLE
docs: fix card grids

### DIFF
--- a/docs/get-started/design-system-kit.njk
+++ b/docs/get-started/design-system-kit.njk
@@ -9,6 +9,7 @@ includeComponent:
 ---
 
 <script type="module">
+  import '@rhds/elements/rh-alert/rh-alert.js';
   import '@rhds/elements/rh-button/rh-button.js';
   import '@rhds/elements/rh-card/rh-card.js';
   import '@rhds/elements/rh-dialog/rh-dialog.js';

--- a/docs/get-started/design-system-kit.njk
+++ b/docs/get-started/design-system-kit.njk
@@ -173,9 +173,14 @@ includeComponent:
     <li>If you think something needs to be updated, describe which asset and what the updates are</li>
   </ul>
 
-  {% alert state="warning", title="Warning" %}
-    When changes to a component are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that component in XD</a> in order to see the changes.
-  {% endalert %}
+  <rh-alert state="warning">
+    <h3 slot="header">Warning</h3>
+    <p>
+      When changes to a component are made, you must
+      <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that component in XD</a>
+      in order to see the changes.
+    </p>
+  </rh-alert>
 
 {%- endcall %}
 

--- a/docs/get-started/design-system-kit.njk
+++ b/docs/get-started/design-system-kit.njk
@@ -172,8 +172,9 @@ includeComponent:
     <li>If you think something needs to be updated, describe which asset and what the updates are</li>
   </ul>
 
-  <!-- Warning alert -->
-  <p style="background-color: #fdf7e7; border-top: 2px solid #f0ab00; padding: 16px 16px 16px 24px; font-size: 14px; letter-spacing: 0.2px;"><span style="color:#795600"><strong>Warning</strong></span><br />When changes to a component are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that component in XD</a> in order to see the changes.</p>
+  {% alert state="warning", title="Warning" %}
+    When changes to a component are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that component in XD</a> in order to see the changes.
+  {% endalert %}
 
 {%- endcall %}
 

--- a/docs/get-started/design-system-kit.njk
+++ b/docs/get-started/design-system-kit.njk
@@ -8,6 +8,12 @@ includeComponent:
   - pfe-modal
 ---
 
+<script type="module">
+  import '@rhds/elements/rh-button/rh-button.js';
+  import '@rhds/elements/rh-card/rh-card.js';
+  import '@rhds/elements/rh-dialog/rh-dialog.js';
+</script>
+
 <!-- Body -->
 
 {% import 'component/get-started.njk' as getstarted %}
@@ -30,83 +36,72 @@ includeComponent:
 
   <p>If necessary, complete any XD trainings before requesting an invite to access the design system kit library.</p>
 
-  <div class="list-box">
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>1</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Request an invite</h4>
-        <p><a href="mailto:digital-design-system@redhat.com">Contact us</a> about what you are working on and then we will send you an invite to access the library.</p>
-      </div>
-    </div>
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>2</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Sync the library</h4>
-        <p>Once you accept the invite, a library of components will sync in XD. There are a lot, so this might take some time.</p>
-      </div>
-    </div>
+  <div class="card-grid">
+    <rh-card>
+      <div slot="header" class="number">1</div>
+      <h3 slot="header">Request an invite</h3>
+      <p>
+        <a href="mailto:digital-design-system@redhat.com">Contact us</a>
+        about what you are working on and then we will send you an invite to access the library.
+      </p>
+    </rh-card>
 
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>3</span>
-      </div>
-      <div class="list-box--item-description">
+    <rh-card>
+      <div slot="header" class="number">2</div>
+      <h3 slot="header">Sync the library</h3>
+      <p>
+        Once you accept the invite, a library of components will sync in XD.
+        There are a lot, so this might take some time.
+      </p>
+    </rh-card>
 
-        <!-- Start modal content -->
+    <rh-card>
+      <div slot="header" class="number">3</div>
+      <h3 slot="header">Load the library</h3>
+      <p>
+        When syncing is done, the library will appear in the Libraries
+        panel. Selecting this library will load all of the assets.
+      </p>
+      <rh-button id="connect-kit-trigger" slot="footer">About the Libraries panel</rh-button>
+      <rh-dialog id="connect-kit" trigger="connect-kit-trigger">
+        <h3 slot="header">Load the library</h3>
+        <p>When the design system kit library is done syncing, it should appear in the <em>Libraries</em> panel in XD. You can view the Libraries panel by pressing <strong>Shift+Command+Y</strong> (or <strong>Shift+Control+Y</strong> on Windows). Clicking on the library will load all of the colors, character styles, and components for you to work with.</p>
+        <div style="text-align:center;">
+          <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-1.png' | url }}" alt="Library name" style="padding-top: 40px; padding-bottom: 12px; max-width: 432px; text-align: center; margin: 0 auto;">
+        </div>
+        <p>If you do not see the library, click on the <em>Manage libraries</em> link in the Libraries panel. The library might be turned off for you. To turn it on, toggle the switch as pictured below. It does take some time for XD to sync our libraries, so be patient. Remember that our libraries require access to Adobe Creative Cloud through a Red Hat account.</p>
+        <div style="text-align:center;">
+          <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-2.png' | url }}" alt="Turn on library" style="padding-top: 40px; padding-bottom: 12px; max-width: 610px; text-align: center; margin: 0 auto;">
+        </div>
+        <p>Still need assistance? No problem, just <a href="mailto:digital-design-system@redhat.com">contact us</a> and we will make sure you get connected.</p>
+      </rh-dialog>
+    </rh-card>
 
-        <rh-dialog id="connect-kit" trigger="connect-kit-trigger">
-          <h3 slot="header">Load the library</h3>
-          <p>When the design system kit library is done syncing, it should appear in the <em>Libraries</em> panel in XD. You can view the Libraries panel by pressing <strong>Shift+Command+Y</strong> (or <strong>Shift+Control+Y</strong> on Windows). Clicking on the library will load all of the colors, character styles, and components for you to work with.</p>
-          <div style="text-align:center;">
-            <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-1.png' | url }}" alt="Library name" style="padding-top: 40px; padding-bottom: 12px; max-width: 432px; text-align: center; margin: 0 auto;">
-          </div>
-          <p>If you do not see the library, click on the <em>Manage libraries</em> link in the Libraries panel. The library might be turned off for you. To turn it on, toggle the switch as pictured below. It does take some time for XD to sync our libraries, so be patient. Remember that our libraries require access to Adobe Creative Cloud through a Red Hat account.</p>
-          <div style="text-align:center;">
-            <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-2.png' | url }}" alt="Turn on library" style="padding-top: 40px; padding-bottom: 12px; max-width: 610px; text-align: center; margin: 0 auto;">
-          </div>
-          <p>Still need assistance? No problem, just <a href="mailto:digital-design-system@redhat.com">contact us</a> and we will make sure you get connected.</p>
-        </rh-dialog>
+    <rh-card>
+      <div slot="header" class="number">4</div>
+      <h3 slot="header">Browse around</h3>
+      <p>
+        Take some time to familiarize yourself with our
+        <a href="../../get-started">libraries</a>,
+        <a href="../../foundations">foundations</a>, and
+        <a href="/elements">components</a> by browsing around.
+      </p>
+    </rh-card>
 
-        <!-- End modal content -->
+    <rh-card>
+      <div slot="header" class="number">5</div>
+      <h3 slot="header">Read the documentation</h3>
+      <p>
+        Read the documentation on this website if you need to educate yourself about using our components.
+      </p>
+    </rh-card>
 
-        <h4>Load the library</h4>
-        <p>When syncing is done, the library will appear in the <a class="modal-launch" id="connect-kit-trigger">Libraries</a> panel. Selecting this library will load all of the assets.</p>
-      </div>
-    </div>
-
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>4</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Browse around</h4>
-        <p>Take some time to familiarize yourself with our <a href="../../get-started">libraries</a>, <a href="../../foundations">foundations</a>, and <a href="/elements">components</a> by browsing around.</p>
-      </div>
-    </div>
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>5</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Read the documentation</h4>
-        <p>Read the documentation on this website if you need to educate yourself about using our components.</p>
-      </div>
-    </div>
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>6</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Create experiences</h4>
-        <p>Create designs and experiences by dragging and dropping components and using other features like <a href="https://www.adobe.com/products/xd/learn/get-started-xd-prototype.html">prototyping</a>.</p>
-      </div>
-    </div>
+    <rh-card>
+      <div slot="header" class="number">6</div>
+      <h3 slot="header">Create experiences</h3>
+      <p>Create designs and experiences by dragging and dropping components and using other features like <a href="https://www.adobe.com/products/xd/learn/get-started-xd-prototype.html">prototyping</a>.</p>
+    </rh-card>
   </div>
-
 {%- endcall %}
 
 {% call getstarted.section("Working in XD") -%}

--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -7,6 +7,7 @@ tags:
 ---
 
 <script type="module">
+  import '@rhds/elements/rh-alert/rh-alert.js';
   import '@rhds/elements/rh-button/rh-button.js';
   import '@rhds/elements/rh-card/rh-card.js';
   import '@rhds/elements/rh-dialog/rh-dialog.js';
@@ -188,8 +189,6 @@ tags:
   {% alert state="warning", title="Warning" %}
     When changes to an FTS pattern are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that pattern in XD</a> in order to see the changes.
   {% endalert %}
-  <!-- Warning alert -->
-  <p style="background-color: #fdf7e7; border-top: 2px solid #f0ab00; padding: 16px 16px 16px 24px; font-size: 14px; letter-spacing: 0.2px;"></p>
 
 {%- endcall %}
 

--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -186,9 +186,14 @@ tags:
     <li>If you think something needs to be updated, describe which asset and what the updates are</li>
   </ul>
 
-  {% alert state="warning", title="Warning" %}
-    When changes to an FTS pattern are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that pattern in XD</a> in order to see the changes.
-  {% endalert %}
+  <rh-alert state="warning">
+    <h3 slot="header">Warning</h3>
+    <p>
+      When changes to an FTS pattern are made, you must
+      <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that pattern in XD</a>
+      in order to see the changes.
+    </p>
+  </rh-alert>
 
 {%- endcall %}
 

--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -4,10 +4,13 @@ title: FTS starter kit
 order: 2
 tags:
   - getstarted
-includeComponent:
-  - pfe-modal
 ---
 
+<script type="module">
+  import '@rhds/elements/rh-button/rh-button.js';
+  import '@rhds/elements/rh-card/rh-card.js';
+  import '@rhds/elements/rh-dialog/rh-dialog.js';
+</script>
 <!-- Body -->
 
 {% import 'component/get-started.njk' as getstarted %}
@@ -50,63 +53,48 @@ includeComponent:
 
   <p>If necessary, complete any Drupal or XD trainings before requesting an invite to access the FTS starter kit library.</p>
 
-  <div class="list-box">
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>1</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Request an invite</h4>
-        <p><a href="mailto:digital-design-system@redhat.com">Contact us</a> about what you are working on and then we will send you an invite to access the library.</p>
-      </div>
-    </div>
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>2</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Sync the library</h4>
-        <p>Once you accept the invite, a library of patterns will sync in XD. There are a lot, so this might take some time.</p>
-      </div>
-    </div>
+  <div class="card-grid">
+    <rh-card>
+      <div slot="header" class="number">1</div>
+      <h3 slot="header" data-number="1">Request an invite</h3>
+      <p>
+        <a href="mailto:digital-design-system@redhat.com">Contact us</a> 
+        about what you are working on and then we will send you an invite to access the library.
+      </p>
+    </rh-card>
 
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>3</span>
-      </div>
-      <div class="list-box--item-description">
+    <rh-card>
+      <div slot="header" class="number">2</div>
+      <h3 slot="header">Sync the library</h3>
+      <p>
+        Once you accept the invite, a library of patterns will sync in XD. There are a lot, so this might take some time.
+      </p>
+    </rh-card>
 
-        <!-- Start modal content -->
+    <rh-card>
+      <div slot="header" class="number">3</div>
+      <h3 slot="header">Load the library</h3>
+      <p>When syncing is done, the library will appear in the Libraries panel. Selecting this library will load all of the patterns.</p>
+      <rh-button id="connect-kit-trigger" slot="footer">About the Libraries panel</rh-button>
+      <rh-dialog id="connect-kit" trigger="connect-kit-trigger">
+        <h3 slot="header">Load the library</h3>
+        <p>When the FTS starter kit library is done syncing, it should appear in the <em>Libraries</em> panel in XD. You can view the Libraries panel by pressing <strong>Shift+Command+Y</strong> (or <strong>Shift+Control+Y</strong> on Windows). Clicking on the library will load all of the FTS patterns for you to work with.</p>
+        <div style="text-align:center;">
+          <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-3.png' | url }}" alt="Library name" style="padding-top: 40px; padding-bottom: 12px; max-width: 326px; text-align: center; margin: 0 auto;">
+        </div>
+        <p>If you do not see the library, click on the <em>Manage libraries</em> link in the Libraries panel. The library might be turned off for you. To turn it on, toggle the switch as pictured below. It does take some time for XD to sync our libraries, so be patient. Remember that our libraries require access to Adobe Creative Cloud through a Red Hat account.</p>
+        <div style="text-align:center;">
+          <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-4.png' | url }}" alt="Turn on library" style="padding-top: 40px; padding-bottom: 12px; max-width: 466px; text-align: center; margin: 0 auto;">
+        </div>
+        <p>Still need assistance? No problem, just <a href="mailto:digital-design-system@redhat.com">contact us</a> and we will make sure you get connected.</p>
+      </rh-dialog>
+    </rh-card>
 
-        <rh-dialog id="connect-kit" trigger="connect-kit-trigger">
-          <h3 slot="header">Load the library</h3>
-          <p>When the FTS starter kit library is done syncing, it should appear in the <em>Libraries</em> panel in XD. You can view the Libraries panel by pressing <strong>Shift+Command+Y</strong> (or <strong>Shift+Control+Y</strong> on Windows). Clicking on the library will load all of the FTS patterns for you to work with.</p>
-          <div style="text-align:center;">
-            <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-3.png' | url }}" alt="Library name" style="padding-top: 40px; padding-bottom: 12px; max-width: 326px; text-align: center; margin: 0 auto;">
-          </div>
-          <p>If you do not see the library, click on the <em>Manage libraries</em> link in the Libraries panel. The library might be turned off for you. To turn it on, toggle the switch as pictured below. It does take some time for XD to sync our libraries, so be patient. Remember that our libraries require access to Adobe Creative Cloud through a Red Hat account.</p>
-          <div style="text-align:center;">
-            <img src="{{ '/assets/get-started/dialog/get-started-dialog-image-4.png' | url }}" alt="Turn on library" style="padding-top: 40px; padding-bottom: 12px; max-width: 466px; text-align: center; margin: 0 auto;">
-          </div>
-          <p>Still need assistance? No problem, just <a href="mailto:digital-design-system@redhat.com">contact us</a> and we will make sure you get connected.</p>
-        </rh-dialog>
-
-        <!-- End modal content -->
-
-        <h4>Load the library</h4>
-        <p>When syncing is done, the library will appear in the <a class="modal-launch" id="connect-kit-trigger">Libraries</a> panel. Selecting this library will load all of the patterns.</p>
-      </div>
-    </div>
-
-    <div class="list-box--item">
-      <div class="list-box--item-number">
-        <span>4</span>
-      </div>
-      <div class="list-box--item-description">
-        <h4>Create pages and experiences</h4>
-        <p>Use these patterns to create designs and experiences that look consistent when building them in Drupal.</p>
-      </div>
-    </div>
+    <rh-card>
+      <div slot="header" class="number">4</div>
+      <h3 slot="header">Create pages and experiences</h3>
+      <p>Use these patterns to create designs and experiences that look consistent when building them in Drupal.</p>
+    </rh-card>
   </div>
 
 {%- endcall %}

--- a/docs/get-started/fts-starter-kit.njk
+++ b/docs/get-started/fts-starter-kit.njk
@@ -185,8 +185,11 @@ tags:
     <li>If you think something needs to be updated, describe which asset and what the updates are</li>
   </ul>
 
+  {% alert state="warning", title="Warning" %}
+    When changes to an FTS pattern are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that pattern in XD</a> in order to see the changes.
+  {% endalert %}
   <!-- Warning alert -->
-  <p style="background-color: #fdf7e7; border-top: 2px solid #f0ab00; padding: 16px 16px 16px 24px; font-size: 14px; letter-spacing: 0.2px;"><span style="color:#795600"><strong>Warning</strong></span><br />When changes to an FTS pattern are made, you must <a href="https://helpx.adobe.com/xd/help/work-with-components-xd.html">update that pattern in XD</a> in order to see the changes.</p>
+  <p style="background-color: #fdf7e7; border-top: 2px solid #f0ab00; padding: 16px 16px 16px 24px; font-size: 14px; letter-spacing: 0.2px;"></p>
 
 {%- endcall %}
 

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -1142,16 +1142,16 @@ rh-alert {
       &.number {
         justify-content: center;
         text-align: center;
-        margin-bottom: 16px;
-        background-color: #f5f5f5;
+        margin-bottom: var(--rh-space-lg);
+        background-color: var(--rh-color-surface-lighter);
         border-radius: 50%;
         width: var(--number-size);
         height: var(--number-size);
         font-size: 28px;
         display: block;
         padding: 10px;
-        color: #e00;
-        font-weight: 600;
+        color: var(--rh-color-brand-red-on-light);
+        font-weight: var(--rh-font-weight-heading-bold);
         text-align: center;
         line-height: 37px;
         margin-inline-end: var(--rh-space-4xl);

--- a/docs/scss/_utility.scss
+++ b/docs/scss/_utility.scss
@@ -1123,55 +1123,42 @@ rh-alert {
 
 // Step boxes
 
-.list-box {
+.card-grid {
+  --number-size: 56px;
   display: grid;
   grid-template-columns: 1fr;
-  grid-gap: 64px;
-  margin-top: 32px;
+  gap: var(--rh-space-4xl);
+  margin-block-start: var(--rh-space-2xl);
 
   @include breakpoint(papa) {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));;
   }
 
-  &--item {
-    border: 1px solid #d2d2d2;
-    padding: 32px;
-    border-radius: 8px;
-    display: block;
-    grid-template-columns: 1fr 4fr;
-
-    @include breakpoint(papa) {
-      display: grid;
-    }
-
-    h4 {
-      margin: 16px 0;
-    }
-
-    p {
-      margin-bottom: 0;
-    }
-
-    &-number {
-      justify-content: center;
-      text-align: center;
-      margin-bottom: 16px;
-    }
-
-    span {
-      background-color: #f5f5f5;
-      border-radius: 50%;
-      width: 56px;
-      height: 56px;
-      font-size: 28px;
-      display: block;
-      padding: 10px;
-      color: #e00;
-      font-weight: 600;
-      text-align: center;
-      line-height: 37px;
+  & rh-card {
+    & [slot="header"] {
+      &:is(h2, h3, h4, h5, h6) {
+        margin: var(--rh-space-xl) 0;
+      }
+      &.number {
+        justify-content: center;
+        text-align: center;
+        margin-bottom: 16px;
+        background-color: #f5f5f5;
+        border-radius: 50%;
+        width: var(--number-size);
+        height: var(--number-size);
+        font-size: 28px;
+        display: block;
+        padding: 10px;
+        color: #e00;
+        font-weight: 600;
+        text-align: center;
+        line-height: 37px;
+        margin-inline-end: var(--rh-space-4xl);
+      }
     }
   }
+
 }
 
 // Adding style for modal launch


### PR DESCRIPTION
fixes #1159

## What I did

1. replace bespoke patterns with cards
2. simplify selectors and scss
3. use tokens where possible
4. replace link-to-open-dialog with card action button

https://deploy-preview-1182--red-hat-design-system.netlify.app/get-started/fts-starter-kit/
https://deploy-preview-1182--red-hat-design-system.netlify.app/get-started/design-system-kit/

## Notes

This isn't a pixel perfect refactor. first, we're fixing the broken layout, second, the dialog was not imported and thus broken, third, the colours and spaces were not tokens from the design system, and last, links should not be used to trigger a dialog (cc @nikkimk can you gut check me on that last one? there aren't any guidelines on triggering elements in the docs pages for dialog).
