### PR TITLE
docs: create example paired shortcode

### DIFF
--- a/docs/_plugins/shortcodes/example.cjs
+++ b/docs/_plugins/shortcodes/example.cjs
@@ -58,7 +58,7 @@ async function getImageHTML(opts) {
 
 /** @param {import('@11ty/eleventy/src/UserConfig')} eleventyConfig */
 module.exports = function(eleventyConfig) {
-  eleventyConfig.addShortcode('example',
+  eleventyConfig.addPairedShortcode('example',
     /**
      * Example
      * An example image or component
@@ -75,7 +75,7 @@ module.exports = function(eleventyConfig) {
      * @param {boolean}   [options.srcAbsolute=false] If true, doesn't include the page url in the img src
      * @this {EleventyContext}
      */
-    async function example({
+    async function example(content, {
       alt = '',
       src = '',
       style = '',
@@ -85,22 +85,25 @@ module.exports = function(eleventyConfig) {
       headingLevel = 3,
       srcAbsolute = src.startsWith('/'),
     } = {}) {
-      const { page } = this.ctx || {};
-      const srcHref = src && path.join('_site', !srcAbsolute ? page?.url : '', src);
-      const slugify = eleventyConfig.getFilter('slugify');
-      const imgDir = srcHref.replace(/\/[^/]+$/, '/');
-      const urlPath = imgDir.replace(/^_site/, '');
-      const outputDir = `./${imgDir}`;
-      const imageFile = src && await sizeOf(srcHref);
-      const loading = 'lazy';
-      const decoding = 'async';
+      let imageHTML;
       const classes = `example example--palette-${palette} ${wrapperClass ?? ''}`;
-      const imageHTML = src && await getImageHTML({ alt, decoding, imageFile, loading, outputDir, src, srcHref, style, urlPath });
+      const slugify = eleventyConfig.getFilter('slugify');
+      if (src) {
+        const { page } = this.ctx || {};
+        const srcHref = src && path.join('_site', !srcAbsolute ? page?.url : '', src);
+        const imgDir = srcHref.replace(/\/[^/]+$/, '/');
+        const urlPath = imgDir.replace(/^_site/, '');
+        const outputDir = `./${imgDir}`;
+        const imageFile = src && await sizeOf(srcHref);
+        const loading = 'lazy';
+        const decoding = 'async';
+        imageHTML = src && await getImageHTML({ alt, decoding, imageFile, loading, outputDir, src, srcHref, style, urlPath });
+      }
       return /* html */`
         <div ${attrMap({ style, class: classes })}>${!headline ? '' : `
           <a id="${encodeURIComponent(headline)}"></a>
           <h${headingLevel} id="${slugify(headline)}" class="example-title">${headline}</h${headingLevel}>`}
-          ${imageHTML}
+          ${src ? imageHTML : content}
         </div>`.trim();
     });
 };

--- a/docs/cheatsheet.njk
+++ b/docs/cheatsheet.njk
@@ -280,19 +280,19 @@ hasToc: true
                headline="Lightest",
                headingLevel=4,
                alt="Examples of light call to action appearance",
-               src="/elements/call-to-action/cta-theme-light.png" %}
+               src="/elements/call-to-action/cta-theme-light.png" %}{% endexample %}
 
     {% example palette="darkest",
                headline="Darkest",
                headingLevel=4,
                alt="Examples of dark call to action appearance",
-               src="/elements/call-to-action/cta-theme-dark.png" %}
+               src="/elements/call-to-action/cta-theme-dark.png" %}{% endexample %}
 
     {% example palette="wrong",
                headline="Wrong",
                headingLevel=4,
                alt="Examples of 'wrong' call to action appearance",
-               src="/elements/call-to-action/cta-best-practice-2.png" %}
+               src="/elements/call-to-action/cta-best-practice-2.png" %}{% endexample %}
 
     {%- endsection %}
 

--- a/docs/elements/index.md
+++ b/docs/elements/index.md
@@ -48,7 +48,7 @@ summaries:
                  alt=linkTitle,
                  wrapperClass=wrapperClass,
                  srcAbsolute=true,
-                 src=doc.screenshotPath %}
+                 src=doc.screenshotPath %}{% endexample %} 
     {% if not comingSoon %}</a>{% endif %}
     <h3>{{ title }}</h3>
     <p>{{ summary }}</p>

--- a/docs/patterns/announcement/index.md
+++ b/docs/patterns/announcement/index.md
@@ -14,7 +14,7 @@ audience.
 
 {% example palette="medium",
            alt="Example of an announcement banner",
-           src="./announcement-sample-1.svg" %}
+           src="./announcement-sample-1.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -26,17 +26,17 @@ background container.
 
 {% example palette="medium",
            alt="Anatomy of an announcement banner",
-           src="./announcement-style-1.svg" %}
+           src="./announcement-style-1.svg" %}{% endexample %}
 
 ## Theme
 
 {% example palette="medium",
            alt="Announcement banner on light theme",
-           src="./announcement-theme-1.svg" %}
+           src="./announcement-theme-1.svg" %}{% endexample %}
 
 {% example palette="light",
            alt="Announcement banner on dark theme",
-           src="./announcement-theme-2.svg" %}
+           src="./announcement-theme-2.svg" %}{% endexample %}
 
 ## Usage
 
@@ -60,7 +60,7 @@ places.
 
 {% example palette="medium",
            alt="Announcement banner positioned above the main menu on Redhat.com",
-           src="./announcement-usage-2.svg" %}
+           src="./announcement-usage-2.svg" %}{% endexample %}
 
 ### Content
 
@@ -70,7 +70,7 @@ its objective is.
 
 {% example palette="medium",
            alt="One announcement banner showing center-aligned content and one showing left and right-aligned content",
-           src="./announcement-usage-content.svg" %}
+           src="./announcement-usage-content.svg" %}{% endexample %}
 
 ## Best practices
 
@@ -78,7 +78,7 @@ Do not position the announcement banner below the navigation.
 
 {% example palette="wrong",
            alt="Example of an announcement banner below the primary navigation",
-           src="./announcement-bestpractice-1.svg" %}
+           src="./announcement-bestpractice-1.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -130,7 +130,7 @@ The announcement banner uses [space tokens](/tokens/space/) to define spacing va
 
 {% example palette="medium",
            alt="Example of an announcement banner with spacers",
-           src="./announcement-spacing-1.svg"  %}
+           src="./announcement-spacing-1.svg"  %}{% endexample %}
 
 {% include 'feedback.html' %}
 

--- a/docs/patterns/disclosure/index.md
+++ b/docs/patterns/disclosure/index.md
@@ -43,17 +43,17 @@ of an active border on the left and a slight drop shadow, similar to an
 
 {% example palette="light",
            alt="Anatomy of a disclosure",
-           src="./disclosure-style-1.svg" %}
+           src="./disclosure-style-1.svg" %}{% endexample %}
 
 ### Theme
 
 {% example palette="light",
            alt="A disclosure in a light theme",
-           src="./disclosure-theme-1.svg" %}
+           src="./disclosure-theme-1.svg" %}{% endexample %}
 
 {% example palette="darkest",
            alt="A disclosure in a dark theme",
-           src="./disclosure-theme-2.svg" %}
+           src="./disclosure-theme-2.svg" %}{% endexample %}
 
 ## Usage
 
@@ -69,7 +69,7 @@ or requires more focus to read, don’t use a disclosure.
 {% example palette = "light",
            class="centered",
            alt="A disclosure in a dark theme",
-           src="./disclosure-usage-1.svg" %}
+           src="./disclosure-usage-1.svg" %}{% endexample %}
 
 ### Usage vs. Accordion
 
@@ -87,12 +87,12 @@ text label.
 {% example palette = "light",
            class="centered",
            alt="Example of a disclosure",
-           src="./disclosure-usage-2.svg" %}
+           src="./disclosure-usage-2.svg" %}{% endexample %}
 
 {% example palette = "light",
            class="centered",
            alt="Example of an accordion",
-           src="./disclosure-usage-3.svg" %}
+           src="./disclosure-usage-3.svg" %}{% endexample %}
 </div>
 
 ### Label formatting
@@ -117,7 +117,7 @@ a disclosure and act as persistent navigation.
 {% example palette = "light",
            class="centered",
            alt="Example of Jump links wrapped in a disclosure",
-           src="./disclosure-usage-4.svg" %}
+           src="./disclosure-usage-4.svg" %}{% endexample %}
 
 ### Best practices
 
@@ -127,12 +127,12 @@ an accordion instead.
 {% example palette="wrong",
            class="centered",
            alt="Inline alert in the top right corner of a page",
-           src="./disclosure-bestpractice-1.svg" %}
+           src="./disclosure-bestpractice-1.svg" %}{% endexample %}
 
 {% example palette="wrong",
            class="centered",
            alt="Inline alert in the top right corner of a page",
-           src="./disclosure-bestpractice-1.svg" %}
+           src="./disclosure-bestpractice-1.svg" %}{% endexample %}
 
 Text inside the panel shouldn’t exceed eight grid columns to maintain optimal 
 readability.
@@ -140,7 +140,7 @@ readability.
 {% example palette="wrong",
            class="centered",
            alt="Inline alert in the top right corner of a page",
-           src="./disclosure-bestpractice-2.svg" %}
+           src="./disclosure-bestpractice-2.svg" %}{% endexample %}
 
 Don’t wrap other complex components inside of a disclosure unless absolutely 
 necessary, like jump links.
@@ -148,7 +148,7 @@ necessary, like jump links.
 {% example palette="wrong",
            class="centered",
            alt="Inline alert in the top right corner of a page",
-           src="./disclosure-bestpractice-3.svg" %}
+           src="./disclosure-bestpractice-3.svg" %}{% endexample %}
 
 <hgroup>
 
@@ -172,7 +172,7 @@ inside.
 {% example palette="light",
            class="centered",
            alt="Disclosure with the expand/collapse panel highlighted",
-           src="./disclosure-behavior-1.svg" %}
+           src="./disclosure-behavior-1.svg" %}{% endexample %}
 
 ### Tab order
 
@@ -185,7 +185,7 @@ of content.
 {% example palette="light",
            class="centered",
            alt="Disclosure showing links with the focus style",
-           src="./disclosure-behavior-2.svg" %}
+           src="./disclosure-behavior-2.svg" %}{% endexample %}
 
 ## Responsive design
 
@@ -202,7 +202,7 @@ content is included.
 {% example palette="light",
            class="centered",
            alt="Example of a disclosure on desktop",
-           src="./disclosure-responsive-1.svg" %}
+           src="./disclosure-responsive-1.svg" %}{% endexample %}
 
 ![Example of a disclosure on desktop](./disclosure-responsive-1.svg)
 
@@ -211,14 +211,14 @@ content is included.
 {% example palette="light",
            class="centered",
            alt="Example of a disclosure on tablet",
-           src="./disclosure-responsive-2.svg" %}
+           src="./disclosure-responsive-2.svg" %}{% endexample %}
 
 ### Mobile
 
 {% example palette="light",
            class="centered",
            alt="Example of a disclosure on mobile",
-           src="./disclosure-responsive-3.svg" %}
+           src="./disclosure-responsive-3.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -252,7 +252,7 @@ values between elements.
 {% example palette="light",
            class="centered",
            alt="Disclosure showing with spacing blocks",
-           src="./disclosure-spacing-1.svg" %}
+           src="./disclosure-spacing-1.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}
 

--- a/docs/patterns/filter/index.md
+++ b/docs/patterns/filter/index.md
@@ -13,11 +13,11 @@ A Filter gives users the ability to sort a results listing by turning on and off
 <div class="multi-column--300-wide"><div>
     {% example palette="none",
           alt="Example of a filter using an accordion",
-          src="./filter-sample-1.svg" %}
+          src="./filter-sample-1.svg" %}{% endexample %}
   </div><div>
     {% example palette="none",
           alt="Example of a filter using a disclosure",
-          src="./filter-sample-2.svg" %}
+          src="./filter-sample-2.svg" %}{% endexample %}
 </div></div>
 
 {% repoStatus %}
@@ -29,7 +29,7 @@ A filter can be used in the light theme only. It features a list of checkboxes a
 
 {% example palette="light",
       alt="Filter component with different parts labeled",
-      src="./filter-style-1.svg" %}
+      src="./filter-style-1.svg" %}{% endexample %}
 
 
 ## Usage
@@ -45,7 +45,7 @@ A filter has several selection methods that enable users to narrow down what the
 <div class="multi-column--min-300-wide"><div>
     {% example palette="light",
       alt="Expanded disclosure panel with one checkbox",
-      src="./filter-usage-1.svg" %}
+      src="./filter-usage-1.svg" %}{% endexample %}
 
     A user can select one or multiple tags to sort by in one category
     {.example-notes}
@@ -53,7 +53,7 @@ A filter has several selection methods that enable users to narrow down what the
   </div><div>
     {% example palette="light",
       alt="Expanded accordion panels with multiple checkboxes selected",
-      src="./filter-usage-2.svg" %}
+      src="./filter-usage-2.svg" %}{% endexample %}
 
     A user can select multiple tags to sort by in multiple categories
     {.example-notes}
@@ -75,14 +75,14 @@ Even when used in a filter, accordions still require at least two panels. If onl
 
 {% example palette="wrong",
           alt="A filter using an accordion instead of a disclosure even though it has only one panel",
-          src="./filter-best-practices-1.svg" %}
+          src="./filter-best-practices-1.svg" %}{% endexample %}
 
   
 Don’t change the width of a filter on large screens because the aside region is already a fixed width.
 
 {% example palette="wrong",
         alt="A filter that is abnormally wide on desktop",
-        src="./filter-best-practices-2.svg" %}
+        src="./filter-best-practices-2.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -92,7 +92,7 @@ By default, a filter loads with all category panels collapsed, enabling users to
 
 {% example palette="light",
         alt="Two filters showing collapsed and expanded states of the enclosed accordions",
-        src="./filter-behavior-1.svg" %}
+        src="./filter-behavior-1.svg" %}{% endexample %}
 
 ### Multiple panels
   
@@ -100,7 +100,7 @@ Multiple category panels can be expanded simultaneously or stack. Expanding one 
 
 {% example palette="light",
         alt="Two filters, one showing an expanded accordion panel and one showing two expanded accordion panels",
-        src="./filter-behavior-2.svg" %}
+        src="./filter-behavior-2.svg" %}{% endexample %}
 
 ### Selecting checkboxes
   
@@ -108,7 +108,7 @@ A filter is also required to load with all checkboxes unselected which means tha
 
 {% example palette="light",
         alt="Two accordions, one showing an expanded accordion with unselected checkboxes, and one showing selected checkboxes.",
-        src="./filter-behavior-3.svg" %}
+        src="./filter-behavior-3.svg" %}{% endexample %}
 
 ### Progressive disclosure
   
@@ -116,7 +116,7 @@ If there are more than 10 checkboxes in one category panel, not all of them shou
 
 {% example palette="light",
         alt="A filter showing 10 checkboxes and an link to see more",
-        src="./filter-behavior-4.svg" %}
+        src="./filter-behavior-4.svg" %}{% endexample %}
 
 ### Clear all button
   
@@ -133,22 +133,22 @@ A filter can work well in a variety of layouts. On small screens, it stretches t
 
 {% example palette="light",
       alt="A filter that stretches across the entire grid",
-      src="./filter-responsive-1.svg" %}
+      src="./filter-responsive-1.svg" %}{% endexample %}
 
 ### Desktop
   {% example palette="none",
            alt="A filter on desktop taking up almost 4 columns",
-           src="./filter-responsive-2.svg" %}
+           src="./filter-responsive-2.svg" %}{% endexample %}
 
 ### Tablet
   {% example palette="none",
            alt="A filter on a tablet taking up the full width",
-           src="./filter-responsive-3.svg" %}
+           src="./filter-responsive-3.svg" %}{% endexample %}
 
 ### Mobile
   {% example palette="none",
            alt="A filter on a mobile device taking up the full width",
-           src="./filter-responsive-4.svg" %}
+           src="./filter-responsive-4.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -157,17 +157,17 @@ A filter is a collection of components and the interaction states remain the sam
 ### Default
 {% example palette="none",
       alt="Example of expanded accordions with filter checkboxes",
-      src="./filter-interaction-1.svg" %}
+      src="./filter-interaction-1.svg" %}{% endexample %}
 
 ### Focus
 {% example palette="none",
       alt="Example of focus states for filters",
-      src="./filter-interaction-2.svg" %}
+      src="./filter-interaction-2.svg" %}{% endexample %}
 
 ### Hover
 {% example palette="none",
       alt="Example of hover states for filters",
-      src="./filter-interaction-3.svg" %}
+      src="./filter-interaction-3.svg" %}{% endexample %}
 
 ### Tab order
   
@@ -175,7 +175,7 @@ When the Tab key is pressed repeatedly, the focus indicator moves from top to bo
 
 {% example palette="light",
     alt="Example of interaction states for a filter",
-    src="./filter-interaction-4.svg" %}
+    src="./filter-interaction-4.svg" %}{% endexample %}
 
 ## Spacing
 
@@ -191,6 +191,6 @@ values between elements.
 
 {% example palette="light",
             alt="A filter with spacers",
-            src="./filter-spacing-1.svg" %}
+            src="./filter-spacing-1.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}

--- a/docs/patterns/form/index.md
+++ b/docs/patterns/form/index.md
@@ -11,7 +11,7 @@ A Form is a group of elements used to collect information from a user. It can in
 ## Sample component
   {% example palette="none",
            alt="Form component samples",
-           src="./form-samples.svg" %}
+           src="./form-samples.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -19,7 +19,7 @@ A Form is a group of elements used to collect information from a user. It can in
 
 {% example palette="lightest",
            alt="Form component blueprint",
-           src="./form-blueprint.svg" %}
+           src="./form-blueprint.svg" %}{% endexample %}
 
 ### Visual elements
 
@@ -38,7 +38,7 @@ Visit the [Popover](https://ux.redhat.com/elements/popover/) component page to l
 
 {% example palette="lightest",
            alt="Form component visual elements",
-           src="./form-visual-elements.svg" %}
+           src="./form-visual-elements.svg" %}{% endexample %}
 
 ### Variants
 
@@ -48,7 +48,7 @@ There are two form variants available for use.
 
 {% example palette="lightest",
            alt="Form component variants",
-           src="./form-variants.svg" %}
+           src="./form-variants.svg" %}{% endexample %}
 
 ## Theme
 
@@ -56,7 +56,7 @@ There are two form variants available for use.
 
 {% example palette="lightest",
            alt="Form component, light theme",
-           src="./form-theme-light.svg" %}
+           src="./form-theme-light.svg" %}{% endexample %}
 
 ### Dark theme
 
@@ -66,7 +66,7 @@ More details and specs surrounding dark theme are coming soon.
 
 {% example palette="darkest",
            alt="Form component, dark theme",
-           src="./form-theme-dark.svg" %}
+           src="./form-theme-dark.svg" %}{% endexample %}
 
 ## Orientation
 
@@ -80,7 +80,7 @@ Do not write text labels with **more than a few words** as they might break to t
 
 {% example palette="none",
         alt="Form components (Container and Floating), default orientaton",
-        src="./form-container-floating-orientation-default.svg" %}
+        src="./form-container-floating-orientation-default.svg" %}{% endexample %}
 
 ### Horizontal
   
@@ -96,11 +96,11 @@ Do not write text labels with **more than a few words** as they might break to t
 
 {% example palette="none",
         alt="Form component (Container), horizontal orientaton",
-        src="./form-container-orientation-horizontal.svg" %}
+        src="./form-container-orientation-horizontal.svg" %}{% endexample %}
         
 {% example palette="none",
         alt="Form component (Floating), horizontal orientaton",
-        src="./form-floating-orientation-horizontal.svg" %}
+        src="./form-floating-orientation-horizontal.svg" %}{% endexample %}
            
 
 ### Text label alignment
@@ -109,7 +109,7 @@ In the Horizontal orientation, text labels should be **left justified** making i
 
 {% example palette="lightest",
            alt="Form component text label alignment",
-           src="./form-text-label-alignment.svg" %}
+           src="./form-text-label-alignment.svg" %}{% endexample %}
 
 ## Usage
   
@@ -125,11 +125,11 @@ When the Container variant is positioned near content, there should be **at leas
 
 {% example palette="none",
         alt="Form (Container), default orientaton",
-        src="./form-in-use-container-default-orientation.svg" %}
+        src="./form-in-use-container-default-orientation.svg" %}{% endexample %}
         
 {% example palette="none",
         alt="Form (Container), horizontal orientaton",
-        src="./form-in-use-container-horizontal-orientation.svg" %}
+        src="./form-in-use-container-horizontal-orientation.svg" %}{% endexample %}
            
 ### Floating variant
 
@@ -141,11 +141,11 @@ When the Floating variant is positioned near content, there should be **at least
 
 {% example palette="none",
         alt="Form (Floating), default orientaton",
-        src="./form-in-use-floating-default-orientation.svg" %}
+        src="./form-in-use-floating-default-orientation.svg" %}{% endexample %}
         
 {% example palette="none",
         alt="Form (Floating), horizontal orientaton",
-        src="./form-in-use-floating-horizontal-orientation.svg" %}   
+        src="./form-in-use-floating-horizontal-orientation.svg" %}{% endexample %}   
 
 ### Form content
 
@@ -158,7 +158,7 @@ A user will have a better experience with submitting a form if the elements are 
 
 {% example palette="lightest",
            alt="Form component content",
-           src="./form-content.svg" %}
+           src="./form-content.svg" %}{% endexample %}
 
 ### Required fields
   
@@ -166,7 +166,7 @@ If a user is required to input information when submitting a form, indicate exac
 
 {% example palette="none",
            alt="Form component required fields",
-           src="./form-required-fields.svg" %}
+           src="./form-required-fields.svg" %}{% endexample %}
 
 ### Data inputs
 
@@ -174,7 +174,7 @@ Data inputs provide additional ways for a user to submit information. Each data 
 
 {% example palette="lightest",
            alt="Form component data inputs",
-           src="./form-data-inputs.svg" %}
+           src="./form-data-inputs.svg" %}{% endexample %}
 
 ### Using data inputs
 
@@ -195,7 +195,7 @@ Radio buttons and checkboxes can be stacked horizontally or vertically depending
 
 {% example palette="lightest",
            alt="Form component arranging data inputs",
-           src="./form-arranging-data-inputs.svg" %}
+           src="./form-arranging-data-inputs.svg" %}{% endexample %}
 
 ### Popover
 
@@ -211,7 +211,7 @@ Avoid using a popover for critical information, a user will have a hard time fin
 
 {% example palette="lightest",
            alt="Form component popover",
-           src="./form-popover.svg" %}
+           src="./form-popover.svg" %}{% endexample %}
 
 ### Placement
 
@@ -219,11 +219,11 @@ A form can span various grid columns when used on a page. To preserve readabilit
 
 {% example palette="none",
         alt="Form component placement, default orientaton",
-        src="./form-placement-default-orientation.svg" %}
+        src="./form-placement-default-orientation.svg" %}{% endexample %}
         
 {% example palette="none",
         alt="Form component placement, horizontal orientaton",
-        src="./form-placement-horizontal-orientation.svg" %}
+        src="./form-placement-horizontal-orientation.svg" %}{% endexample %}
            
 ## Behavior
 
@@ -237,7 +237,7 @@ Do not disable form elements that **require** input as a user might skip over th
 
 {% example palette="lightest",
            alt="Form component disabled state",
-           src="./form-disabled-state.svg" %}
+           src="./form-disabled-state.svg" %}{% endexample %}
 
 ### Error states
 
@@ -249,7 +249,7 @@ An error will be displayed after a user moves the focus away from a required for
 
 {% example palette="none",
         alt="Form component, error validation on loss of focus",
-        src="./form-error-loss-of-focus.svg" %}
+        src="./form-error-loss-of-focus.svg" %}{% endexample %}
 
 ### Error validation on submission
   
@@ -257,7 +257,7 @@ Errors will be displayed if a user tries to submit a completed form with invalid
 
 {% example palette="none",
         alt="Form component, error validation on submission",
-        src="./form-error-submission.svg" %}
+        src="./form-error-submission.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -269,7 +269,7 @@ Visit the [Button](https://ux.redhat.com/elements/button/) and [Link](https://ux
 
 {% example palette="lightest",
            alt="Form component interaction state, link",
-           src="./form-interaction-states-link.svg" %}
+           src="./form-interaction-states-link.svg" %}{% endexample %}
 
 ### Hover
   
@@ -277,7 +277,7 @@ Form fields and select lists share the same hover state.
 
 {% example palette="lightest",
            alt="Form component interaction state, hover",
-           src="./form-interaction-states-hover.svg" %}
+           src="./form-interaction-states-hover.svg" %}{% endexample %}
 
 ### Focus
   
@@ -285,7 +285,7 @@ When the focus is moved to a form field with placeholder text, the text will dis
 
 {% example palette="lightest",
            alt="Form component interaction state, focus",
-           src="./form-interaction-states-focus.svg" %}
+           src="./form-interaction-states-focus.svg" %}{% endexample %}
 
 ### Active
 
@@ -293,7 +293,7 @@ Form fields and select lists share the same active state.
 
 {% example palette="lightest",
            alt="Form component interaction state, active",
-           src="./form-interaction-states-active.svg" %}
+           src="./form-interaction-states-active.svg" %}{% endexample %}
 
 ### Tab order
 
@@ -301,7 +301,7 @@ When the Tab key is pressed repeatedly, the focus highlights each form element i
 
 {% example palette="none",
         alt="Form component tab order",
-        src="./form-tab-order.svg" %}
+        src="./form-tab-order.svg" %}{% endexample %}
 
 ## Accessibility
 
@@ -320,11 +320,11 @@ The Default variant mostly remains the same on large and small screens, but the 
 
 {% example palette="none",
         alt="Form component (Default) responsive design, desktop",
-        src="./form-responsive-default-desktop.svg" %}
+        src="./form-responsive-default-desktop.svg" %}{% endexample %}
         
 {% example palette="none",
         alt="Form component (Horizontal) responsive design, desktop",
-        src="./form-responsive-horizontal-desktop.svg" %}
+        src="./form-responsive-horizontal-desktop.svg" %}{% endexample %}
            
 
 ### Tablet
@@ -333,13 +333,13 @@ As screens get smaller, the Horizontal variant will switch to the Default varian
 
 {% example palette="none",
         alt="Form component responsive design, tablet",
-        src="./form-responsive-tablet.svg" %}
+        src="./form-responsive-tablet.svg" %}{% endexample %}
 
 ### Mobile
 
 {% example palette="none",
         alt="Form component responsive design, mobile",
-        src="./form-responsive-mobile.svg" %}
+        src="./form-responsive-mobile.svg" %}{% endexample %}
 
 ## Best practices
 
@@ -349,7 +349,7 @@ Do not align the button group and privacy link to the **right edge** of other fo
 
 {% example palette="wrong",
            alt="Form component, best practice 1",
-           src="./form-best-practice-1.svg" %}
+           src="./form-best-practice-1.svg" %}{% endexample %}
 
 ### Two Primary buttons
 
@@ -361,7 +361,7 @@ Visit the [Button](https://ux.redhat.com/elements/button/) component page to lea
 
 {% example palette="wrong",
            alt="Form component, best practice 2",
-           src="./form-best-practice-2.svg" %}
+           src="./form-best-practice-2.svg" %}{% endexample %}
 
 ### Too many required fields
 
@@ -369,7 +369,7 @@ If all inputs are required, **do not** add an asterisk next to every text label.
 
 {% example palette="wrong",
            alt="Form component, best practice 3",
-           src="./form-best-practice-3.svg" %}
+           src="./form-best-practice-3.svg" %}{% endexample %}
 
 ### 12 columns
 
@@ -381,7 +381,7 @@ Visit the [Grid](https://ux.redhat.com/foundations/grid/) foundation page to lea
 
 {% example palette="wrong",
            alt="Form component, best practice 4",
-           src="./form-best-practice-4.svg" %}
+           src="./form-best-practice-4.svg" %}{% endexample %}
 
 ### Rearranging data inputs and button groups
 
@@ -389,7 +389,7 @@ Do not change the stacking order of data inputs and button groups, except in rar
 
 {% example palette="wrong",
            alt="Form component, best practice 5",
-           src="./form-best-practice-5.svg" %}
+           src="./form-best-practice-5.svg" %}{% endexample %}
 
 ## Spacing
 
@@ -407,12 +407,12 @@ values between elements.
 
 {% example palette="lightest",
            alt="Form component spacing, default",
-           src="./form-spacing-default.svg" %}
+           src="./form-spacing-default.svg" %}{% endexample %}
 
 ### Horizontal
 
 {% example palette="lightest",
            alt="Form component spacing, horizontal",
-           src="./form-spacing-horizontal.svg" %}
+           src="./form-spacing-horizontal.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -36,7 +36,7 @@ create uniform, accessible experiences.
                  wrapperClass=wrapperClass,
                  alt=pattern.data.title,
                  srcAbsolute="true",
-                 src=('/assets/patterns/all-patterns-' + slug + '.png') %}
+                 src=('/assets/patterns/all-patterns-' + slug + '.png') %}{% endexample %}
     </a>
     <a href="{{ pattern.url }}"><h3>{{ pattern.data.title }}</h3></a>
     <p>{{ summary }}</p>

--- a/docs/patterns/link-with-icon/index.md
+++ b/docs/patterns/link-with-icon/index.md
@@ -13,7 +13,7 @@ Link with icon features an icon that adds context to the link itself. It’s pos
 
 {% example palette="none",
            alt="Link with icon",
-           src="./link-with-icon.svg" %}
+           src="./link-with-icon.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -23,17 +23,17 @@ Link with icon is available in light and dark themes. It’s a grouping of a sma
 
 {% example palette="light",
            alt="Link with icon specs",
-           src="./link-with-icon-style.svg" %}
+           src="./link-with-icon-style.svg" %}{% endexample %}
 
 ### Theme
 
 {% example palette="light",
            alt="Link with icon theme light",
-           src="./link-with-icon-theme-light.svg" %}
+           src="./link-with-icon-theme-light.svg" %}{% endexample %}
   
 {% example palette="darkest",
            alt="Link with icon theme dark",
-           src="./link-with-icon-theme-dark.svg" %}
+           src="./link-with-icon-theme-dark.svg" %}{% endexample %}
 
 ## Usage
 
@@ -45,7 +45,7 @@ Don't increase the icon size because the link text size will appear smaller.
 
 {% example palette="wrong",
            alt="Link with icon icon size issue",
-           src="./link-with-icon-best-practices.svg" %}
+           src="./link-with-icon-best-practices.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -55,11 +55,11 @@ Link with icon can be used on large and small screens. When the width of the lin
 
 {% example palette="none",
            alt="Link with icon responsive desktop",
-           src="./link-with-icon-responsive.svg" %}
+           src="./link-with-icon-responsive.svg" %}{% endexample %}
 
 {% example palette="none",
            alt="Link with icon responsive mobile",
-           src="./link-with-icon-responsive-mobile.svg" %}
+           src="./link-with-icon-responsive-mobile.svg" %}{% endexample %}
 
 Some text styles reduce in size on small screens. Learn more about typography on mobile
 {.footnote}
@@ -70,11 +70,11 @@ The icon and the link are always vertically-aligned.
 
 {% example palette="light",
            alt="Link with icon alignment",
-           src="./link-with-icon-alignment-1.svg" %}
+           src="./link-with-icon-alignment-1.svg" %}{% endexample %}
 
 {% example palette="light",
            alt="Link with icon alignment",
-           src="./link-with-icon-alignment-2.svg" %}
+           src="./link-with-icon-alignment-2.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -86,7 +86,7 @@ Link with icon uses [space tokens](/tokens/space/) to define spacing values betw
 
 {% example palette="light",
            alt="Link with icon spacing",
-           src="./link-with-icon-spacing.svg" %}
+           src="./link-with-icon-spacing.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}
 

--- a/docs/patterns/link/index.md
+++ b/docs/patterns/link/index.md
@@ -13,7 +13,7 @@ Links are navigational elements that allow a user to move between content, pages
 
 {% example palette="none",
            alt="Link component examples",
-           src="./example-links.svg" %}
+           src="./example-links.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -29,7 +29,7 @@ View a live version of the Call to action link and see how it can be customized.
 
 {% example palette="lightest",
            alt="Link component blueprint",
-           src="./link-blueprint.svg" %}
+           src="./link-blueprint.svg" %}{% endexample %}
 
 ### Variants
 
@@ -53,7 +53,7 @@ Visit the [Call to action](https://ux.redhat.com/elements/call-to-action/) compo
 
 {% example palette="lightest",
            alt="Link component visual elements",
-           src="./link-visual-elements.svg" %}
+           src="./link-visual-elements.svg" %}{% endexample %}
 
 ### Text size
 
@@ -73,7 +73,7 @@ Visit the [Call to action](https://ux.redhat.com/elements/call-to-action/) compo
 
 {% example palette="lightest",
            alt="Link component, light theme",
-           src="./theme-light.svg" %}
+           src="./theme-light.svg" %}{% endexample %}
 
 ### Dark theme
 
@@ -83,7 +83,7 @@ Visit the [Call to action](https://ux.redhat.com/elements/call-to-action/) compo
 
 {% example palette="darkest",
            alt="Link component, light theme",
-           src="./theme-dark.svg" %}
+           src="./theme-dark.svg" %}{% endexample %}
 
 ## Usage
 
@@ -91,7 +91,7 @@ Links should be applied when a user needs to jump to content on the same page, v
 
 {% example palette="lightest",
            alt="Link component usage",
-           src="./when-to-use.svg" %}
+           src="./when-to-use.svg" %}{% endexample %}
 
 ### Content
 
@@ -103,7 +103,7 @@ Link content needs to be written clearly in order to be understood, therefore wr
   
 {% example palette="lightest",
            alt="Link component usage, content",
-           src="./usage-content.svg" %}
+           src="./usage-content.svg" %}{% endexample %}
 
 ### Images
 
@@ -123,7 +123,7 @@ In a form, selecting a button will trigger an action whereas selecting a link wi
 
 {% example palette="lightest",
            alt="Link component usage, buttons",
-           src="./usage-buttons.svg" %}
+           src="./usage-buttons.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -145,7 +145,7 @@ If navigating to a new page in the same tab is very disruptive to the experience
 
 {% example palette="lightest",
            alt="Link component, internal vs. external pages",
-           src="./external-pages.svg" %}
+           src="./external-pages.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -157,41 +157,41 @@ Visit the [Call to action](https://ux.redhat.com/elements/call-to-action/) compo
 
 {% example palette="lightest",
            alt="Link component interaction state, link (light theme)",
-           src="./interaction-state-link-light.svg" %}
+           src="./interaction-state-link-light.svg" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Link component interaction state, link (dark theme)",
-           src="./interaction-state-link-dark.svg" %}
+           src="./interaction-state-link-dark.svg" %}{% endexample %}
 
 ### Hover
 
 {% example palette="lightest",
            alt="Link component interaction state, hover (light theme)",
-           src="./interaction-state-hover-light.svg" %}
+           src="./interaction-state-hover-light.svg" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Link component interaction state, hover (dark theme)",
-           src="./interaction-state-hover-dark.svg" %}
+           src="./interaction-state-hover-dark.svg" %}{% endexample %}
 
 ### Focus
 
 {% example palette="lightest",
            alt="Link component interaction state, focus (light theme)",
-           src="./interaction-state-focus-light.svg" %}
+           src="./interaction-state-focus-light.svg" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Link component interaction state, focus (dark theme)",
-           src="./interaction-state-focus-dark.svg" %}
+           src="./interaction-state-focus-dark.svg" %}{% endexample %}
 
 ### Active
 
 {% example palette="lightest",
            alt="Link component interaction state, active (light theme)",
-           src="./interaction-state-active-light.svg" %}
+           src="./interaction-state-active-light.svg" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Link component interaction state, active (dark theme)",
-           src="./interaction-state-active-dark.svg" %}
+           src="./interaction-state-active-dark.svg" %}{% endexample %}
 
 ### Visited
 
@@ -201,11 +201,11 @@ A popover trigger can be a linked text, or it can be an icon. For example, when 
 
 {% example palette="lightest",
            alt="Link component interaction state, visited (light theme)",
-           src="./interaction-state-visited-light.svg" %}
+           src="./interaction-state-visited-light.svg" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Link component interaction state, visited (dark theme)",
-           src="./interaction-state-visited-dark.svg" %}
+           src="./interaction-state-visited-dark.svg" %}{% endexample %}
 
 ### Tab order
 
@@ -213,7 +213,7 @@ When the Tab key is pressed repeatedly, the focus highlights each Inline and Cal
 
 {% example palette="lightest",
            alt="Link component tab order",
-           src="./tab-order.svg" %}
+           src="./tab-order.svg" %}{% endexample %}
 
 ### Accessibility
 
@@ -231,19 +231,19 @@ Both link variants mostly remain the same on large and small screens. Inline lin
 
 {% example palette="none",
            alt="Link component responsive design, desktop",
-           src="./responsive-design-desktop.svg" %}
+           src="./responsive-design-desktop.svg" %}{% endexample %}
 
 ### Tablet
     
 {% example palette="none",
            alt="Link component responsive design, tablet",
-           src="./responsive-design-tablet.svg" %}
+           src="./responsive-design-tablet.svg" %}{% endexample %}
   
 ### Mobile
 
 {% example palette="none",
            alt="Link component responsive design, mobile",
-           src="./responsive-design-mobile.svg" %}
+           src="./responsive-design-mobile.svg" %}{% endexample %}
  
 ## Best practices
 
@@ -253,7 +253,7 @@ Do not apply lots of links to paragraph text otherwise a user will have trouble 
 
 {% example palette="wrong",
            alt="Link component best practice 1",
-           src="./link-best-practice-1.svg" %}
+           src="./link-best-practice-1.svg" %}{% endexample %}
 
 ### Different link variants
 
@@ -261,7 +261,7 @@ Do not use different link variants to direct a user to the same page.
     
 {% example palette="wrong",
            alt="Link component best practice 2",
-           src="./link-best-practice-2.svg" %}
+           src="./link-best-practice-2.svg" %}{% endexample %}
 
 ### Ambiguity
 
@@ -269,7 +269,7 @@ When writing link content, avoid ambiguous phrases or a full website URL. A user
 
 {% example palette="wrong",
            alt="Link component best practice 3",
-           src="./link-best-practice-3.svg" %}
+           src="./link-best-practice-3.svg" %}{% endexample %}
 
 ### Long links
 
@@ -277,7 +277,7 @@ Do not apply links to long strings of text.
     
 {% example palette="wrong",
            alt="Link component best practice 4",
-           src="./link-best-practice-4.svg" %}
+           src="./link-best-practice-4.svg" %}{% endexample %}
 
 ### Buttons
 
@@ -289,7 +289,7 @@ Visit the [Button](https://ux.redhat.com/elements/button/) component page to lea
     
 {% example palette="wrong",
            alt="Link component best practice 5",
-           src="./link-best-practice-5.svg" %}
+           src="./link-best-practice-5.svg" %}{% endexample %}
 
 ### External link icon
 
@@ -301,7 +301,7 @@ Visit the [Call to action](https://ux.redhat.com/elements/call-to-action/) compo
     
 {% example palette="wrong",
            alt="Link component best practice 6",
-           src="./link-best-practice-6.svg" %}
+           src="./link-best-practice-6.svg" %}{% endexample %}
 
 ### Widows
 
@@ -309,7 +309,7 @@ The Default call to action link arrow and the external link icon should not appe
 
 {% example palette="wrong",
         alt="Link component best practice 7",
-        src="./link-best-practice-7.svg" %}
+        src="./link-best-practice-7.svg" %}{% endexample %}
 
 ## Spacing
 

--- a/docs/patterns/search-bar/index.md
+++ b/docs/patterns/search-bar/index.md
@@ -14,7 +14,7 @@ a button. It allows a user to input text and then perform a search.
 
 {% example palette="none",
     alt="Search bar component sample",
-    src="./search-bar-sample.svg" %}
+    src="./search-bar-sample.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -25,7 +25,7 @@ red button that is placed on the right.
 
 {% example palette="lightest",
     alt="Search bar component blueprint",
-    src="./search-bar-blueprint.svg" %}
+    src="./search-bar-blueprint.svg" %}{% endexample %}
 
 #### Button
 
@@ -41,7 +41,7 @@ buttons and calls to action.
 
 {% example palette="lightest",
     alt="Search bar component button vs. CTA",
-    src="./search-bar-button-vs-cta.svg" %}
+    src="./search-bar-button-vs-cta.svg" %}{% endexample %}
 
 ## Theme
 
@@ -51,7 +51,7 @@ The light theme search bar includes a light theme form field and red button.
 
 {% example palette="lightest",
     alt="Search bar component, light theme",
-    src="./search-bar-light-theme.svg" %}
+    src="./search-bar-light-theme.svg" %}{% endexample %}
   
 
 #### Dark theme
@@ -60,7 +60,7 @@ For now, the light theme search bar can also be used in the dark theme.
 
 {% example palette="darkest",
     alt="Search bar component, dark theme",
-    src="./search-bar-dark-theme.svg" %}
+    src="./search-bar-dark-theme.svg" %}{% endexample %}
 
 ## Usage
 
@@ -74,7 +74,7 @@ boundaries of whatever container or grid it is placed in.
 
 {% example palette="medium",
     alt="Search bar component usage",
-    src="./search-bar-layout.svg" %}
+    src="./search-bar-layout.svg" %}{% endexample %}
 
 #### Content
 
@@ -85,7 +85,7 @@ resources), a user might expect to search through an individual page.
 
 {% example palette="lightest",
     alt="Search bar component placeholder text options",
-    src="./search-bar-placeholder-text.svg" %}
+    src="./search-bar-placeholder-text.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -102,7 +102,7 @@ Visit the [Form](/patterns/form/) pattern page to learn more about form fields.
 
 {% example palette="lightest",
     alt="Search bar component styling changes",
-    src="./search-bar-form-field.svg" %}
+    src="./search-bar-form-field.svg" %}{% endexample %}
 
 #### Typeahead
 
@@ -112,7 +112,7 @@ options.
 
 {% example palette="lightest",
     alt="Search bar component typeahead",
-    src="./search-bar-typeahead.svg" %}
+    src="./search-bar-typeahead.svg" %}{% endexample %}
   
 #### Errors
 
@@ -127,7 +127,7 @@ errors.
 
 {% example palette="lightest",
     alt="Search bar component form field errors",
-    src="./search-bar-errors.svg" %}
+    src="./search-bar-errors.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -140,7 +140,7 @@ more about interaction states.
 
 {% example palette="lightest",
     alt="Search bar component interaction state, link",
-    src="./search-bar-interaction-states-link.svg" %}
+    src="./search-bar-interaction-states-link.svg" %}{% endexample %}
 
 #### Hover
 
@@ -148,7 +148,7 @@ A blue line appears at the bottom of the form field indicating it is selectable.
 
 {% example palette="lightest",
     alt="Search bar component interaction state, hover",
-    src="./search-bar-interaction-states-hover.svg" %}
+    src="./search-bar-interaction-states-hover.svg" %}{% endexample %}
 
 #### Focus
 
@@ -158,7 +158,7 @@ moved away, the placeholder text will be visible again.
 
 {% example palette="lightest",
     alt="Search bar component interaction state, focus",
-    src="./search-bar-interaction-states-focus.svg" %}
+    src="./search-bar-interaction-states-focus.svg" %}{% endexample %}
 
 #### Active
 
@@ -168,7 +168,7 @@ away, the placeholder text will be visible again.
 
 {% example palette="lightest",
     alt="Search bar component interaction state, active",
-    src="./search-bar-interaction-states-active.svg" %}
+    src="./search-bar-interaction-states-active.svg" %}{% endexample %}
 
 #### Tab order
 
@@ -178,7 +178,7 @@ button without an error being displayed.
 
 {% example palette="lightest",
     alt="Search bar component tab order",
-    src="./search-bar-tab-order.svg" %}
+    src="./search-bar-tab-order.svg" %}{% endexample %}
   
 ## Accessibility
 
@@ -201,19 +201,19 @@ whereas the button always stays the same size.
 
 {% example palette="none",
     alt="Search bar component responsive design, desktop",
-    src="./search-bar-responsive-desktop.svg" %}
+    src="./search-bar-responsive-desktop.svg" %}{% endexample %}
 
 #### Tablet
 
 {% example palette="none",
     alt="Search bar component responsive design, tablet",
-    src="./search-bar-responsive-tablet.svg" %}
+    src="./search-bar-responsive-tablet.svg" %}{% endexample %}
 
 #### Mobile
 
 {% example palette="none",
     alt="Search bar component responsive design, mobile",
-    src="./search-bar-responsive-mobile.svg" %}
+    src="./search-bar-responsive-mobile.svg" %}{% endexample %}
 
 ## Best practices
 
@@ -224,7 +224,7 @@ Do not write placeholder text too long, it should be short and to the point
 
 {% example palette="wrong",
     alt="Search component best practice 1",
-    src="./search-bar-best-practice-1.svg" %}
+    src="./search-bar-best-practice-1.svg" %}{% endexample %}
 
 #### Call to action as button
 
@@ -232,7 +232,7 @@ Do not replace the button with a call to action.
 
 {% example palette="wrong",
     alt="Search component best practice 2",
-    src="./search-bar-best-practice-2.svg" %}
+    src="./search-bar-best-practice-2.svg" %}{% endexample %}
 
 #### Different style or color
 
@@ -241,7 +241,7 @@ Do not use a different button color or style when using a search bar on Red Hat
 
 {% example palette="wrong",
     alt="Search component best practice 3",
-    src="./search-bar-best-practice-3.svg" %}
+    src="./search-bar-best-practice-3.svg" %}{% endexample %}
 
 #### Disabled
 
@@ -251,7 +251,7 @@ in the form field, an error should be displayed instead.
 
 {% example palette="wrong",
     alt="Search component best practice 4",
-    src="./search-bar-best-practice-4.svg" %}
+    src="./search-bar-best-practice-4.svg" %}{% endexample %}
 
 
 #### Solo button
@@ -265,7 +265,7 @@ use buttons.
 
 {% example palette="wrong",
     alt="Search component best practice 5",
-    src="./search-bar-best-practice-5.svg" %}
+    src="./search-bar-best-practice-5.svg" %}{% endexample %}
 
 #### Rearranging the component
 
@@ -274,7 +274,7 @@ changing its width.
 
 {% example palette="wrong",
     alt="Search component best practice 6",
-    src="./search-bar-best-practice-6.svg" %}
+    src="./search-bar-best-practice-6.svg" %}{% endexample %}
 
 ## Spacing
 
@@ -289,6 +289,6 @@ between elements.
 
 {% example palette="light",
         alt="Search bar spacing",
-        src="./search-bar-spacing.svg" %}
+        src="./search-bar-spacing.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}

--- a/docs/patterns/skip-navigation/index.md
+++ b/docs/patterns/skip-navigation/index.md
@@ -12,7 +12,7 @@ Skip navigation is a styled link that appears at the top of a page when the Tab 
 
 {% example palette="none",
            alt="Skip navigation",
-           src="./skip-nav.svg" %}
+           src="./skip-nav.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -21,7 +21,7 @@ Skip navigation is a styled link that appears at the top of a page when the Tab 
 Skip to main content is a styled link that consists of a text label and a background container. Even though it looks like a Button, it functions more like a jump link.
 {% example palette="medium",
            alt="Skip navigation specs",
-           src="./skip-nav-style.svg" %}
+           src="./skip-nav-style.svg" %}{% endexample %}
 
 ## Usage
 
@@ -29,22 +29,22 @@ A skip to main content link helps some users browse the web more effectively. It
 
 {% example palette="none",
            alt="Skip navigation usage",
-           src="./skip-nav-usage-1.svg" %}
+           src="./skip-nav-usage-1.svg" %}{% endexample %}
 
 {% example palette="none",
            alt="Skip navigation usage",
-           src="./skip-nav-usage-2.svg" %}
+           src="./skip-nav-usage-2.svg" %}{% endexample %}
 
 {% example palette="none",
            alt="Skip navigation usage",
-           src="./skip-nav-usage-3.svg" %}
+           src="./skip-nav-usage-3.svg" %}{% endexample %}
 
 ## Best practices
 
 Don't apply the skip to main content link style to other components.
 {% example palette="wrong",
            alt="Skip navigation style errors",
-           src="./skip-nav-best-practices-1.svg" %}
+           src="./skip-nav-best-practices-1.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -52,7 +52,7 @@ When a user presses the Tab key upon page load, the skip to main content link wi
 
 {% example palette="none",
            alt="Skip navigation behavior",
-           src="./skip-nav-behavior.svg" %}
+           src="./skip-nav-behavior.svg" %}{% endexample %}
 
 ## Spacing
 
@@ -68,6 +68,6 @@ values between elements.
 
 {% example palette="none",
            alt="Skip navigation spacing diagram",
-           src="./skip-nav-spacing.svg" %}
+           src="./skip-nav-spacing.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}

--- a/docs/patterns/sticky-banner/index.md
+++ b/docs/patterns/sticky-banner/index.md
@@ -11,7 +11,7 @@ A Sticky banner slides into view at a certain scroll position and then anchors i
 ## Sample component
 {% example palette="none",
            alt="Sticky banner",
-           src="./sticky-banner.svg" %}
+           src="./sticky-banner.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -21,7 +21,7 @@ A sticky banner can be used in the light theme only. The large size can include 
 
 {% example palette="lightest",
            alt="Sticky banner style",
-           src="./sticky-banner-style.svg" %}
+           src="./sticky-banner-style.svg" %}{% endexample %}
 
 ### Sizes
 
@@ -31,12 +31,12 @@ Large and Small are the two sticky banner sizes. The large size spans the full-w
 
 {% example palette="none",
            alt="Sticky banner large size",
-           src="./sticky-banner-size-desktop.svg" %}
+           src="./sticky-banner-size-desktop.svg" %}{% endexample %}
 
         
 {% example palette="none",
            alt="Sticky banner small size",
-           src="./sticky-banner-size-mobile.svg" %}
+           src="./sticky-banner-size-mobile.svg" %}{% endexample %}
 
 ### Content
 
@@ -61,12 +61,12 @@ A sticky banner is anchored on the bottom of the page where it doesn’t distrac
         
 {% example palette="none",
            alt="Sticky banner desktop placement",
-           src="./sticky-banner-usage.svg" %}
+           src="./sticky-banner-usage.svg" %}{% endexample %}
 
         
 {% example palette="none",
            alt="Sticky banner desktop placement",
-           src="./sticky-banner-usage-mobile.svg" %}
+           src="./sticky-banner-usage-mobile.svg" %}{% endexample %}
 
 ### Layout
 
@@ -89,26 +89,26 @@ Don't change the large sticky banner to be fixed width.
 
 {% example palette="wrong",
            alt="Fixed width issue",
-           src="./sticky-banner-best-practices-1.svg" %}
+           src="./sticky-banner-best-practices-1.svg" %}{% endexample %}
 
 Don’t omit the thumbnail image from the sticky banner on large screens like _Desktop_ or _Tablet, landscape_, it helps users get a better idea of what they’re downloading.
 
 {% example palette="wrong",
            alt="Full width small banner issue",
-           src="./sticky-banner-best-practices-2.svg" %}
+           src="./sticky-banner-best-practices-2.svg" %}{% endexample %}
 
 Don’t omit the drop shadow because the banner will blend into the background.
 
 {% example palette="wrong",
            alt="Banner without thumbnail issue",
-           src="./sticky-banner-best-practices-3.svg" %}
+           src="./sticky-banner-best-practices-3.svg" %}{% endexample %}
 
 ## Behavior
 
 The behavior of a sticky banner is similar to a Sticky card, they stick to the edge of a browser window and remain there until a user dismisses them. The difference is that a sticky banner is conversion-driven, they promote a more important offer that drives a user to a landing page whereas a sticky card promotes a less important offer like a resource or webinar.
 {% example palette="none",
            alt="Sticky banner behavior",
-           src="./sticky-banner-behavior.svg" %}
+           src="./sticky-banner-behavior.svg" %}{% endexample %}
 
 ### Sliding
 
@@ -127,24 +127,24 @@ A sticky banner can work on both large and small screens. Some elements will be 
 ### Desktop
 {% example palette="none",
            alt="Sticky banner desktop breakpoint",
-           src="./sticky-banner-breakpoints-desktop.svg" %}
+           src="./sticky-banner-breakpoints-desktop.svg" %}{% endexample %}
 
 ### Tablet
 {% example palette="none",
            alt="Sticky banner tablet breakpoint",
-           src="./sticky-banner-breakpoints-tablet.svg" %}
+           src="./sticky-banner-breakpoints-tablet.svg" %}{% endexample %}
 
 ### Mobile, landscape
 {% example palette="none",
            alt="Sticky banner mobile landscape breakpoint",
-           src="./sticky-banner-breakpoints-mobile-landscape.svg" %}
+           src="./sticky-banner-breakpoints-mobile-landscape.svg" %}{% endexample %}
 
     <p class="footnote">Some text styles reduce in size on small screens. Learn more about typography on mobile
 
 ### Mobile, portrait
 {% example palette="none",
            alt="Sticky banner mobile portrait breakpoint",
-           src="./sticky-banner-breakpoints-mobile-portrait.svg" %}
+           src="./sticky-banner-breakpoints-mobile-portrait.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -165,13 +165,13 @@ values between elements.
 ### Large size
 {% example palette="lightest",
            alt="Sticky banner large spacing",
-           src="./sticky-banner-spacing-large-screens.svg" %}
+           src="./sticky-banner-spacing-large-screens.svg" %}{% endexample %}
 
 ### Small size
 Content padding defines how far away elements are from each other inside each section.
 
 {% example palette="light",
            alt="Sticky banner spacing small",
-           src="./sticky-banner-spacing-small-screens.svg" %}
+           src="./sticky-banner-spacing-small-screens.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}

--- a/docs/patterns/sticky-card/index.md
+++ b/docs/patterns/sticky-card/index.md
@@ -11,7 +11,7 @@ Sticky cards slide into view at a certain scroll position and then anchor themse
 ## Sample component
 {% example palette="none",
           alt="Sticky card",
-          src="./sticky-card.svg" %}
+          src="./sticky-card.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -21,7 +21,7 @@ A sticky card acts as a small container for a limited amount of content.
 
 {% example palette="lightest",
            alt="Sticky card naming",
-           src="./sticky-card-style.svg" %}
+           src="./sticky-card-style.svg" %}{% endexample %}
 
 ### Theme
 
@@ -29,11 +29,11 @@ The required elements in a sticky card are a close button, a title or a headline
 
 {% example palette="lightest",
         alt="Sticky card light theme",
-        src="./sticky-card-theme-light.svg" %}
+        src="./sticky-card-theme-light.svg" %}{% endexample %}
 
 {% example palette="darkest",
         alt="Sticky card dark theme",
-        src="./sticky-card-theme-dark.svg" %}
+        src="./sticky-card-theme-dark.svg" %}{% endexample %}
 
 ### Layout
 
@@ -57,7 +57,7 @@ The footer section can include normal links or a call to action. A sticky card f
 
 {% example palette="lightest",
         alt="Sticky card content sections",
-        src="./sticky-card-layout.svg" %}
+        src="./sticky-card-layout.svg" %}{% endexample %}
 
 ## Usage
 
@@ -69,7 +69,7 @@ A sticky card can be placed on the left or the right edge of a page and it has a
 
 {% example palette="medium",
         alt="Sticky card on right side",
-        src="./sticky-card-layout-right.svg" %}
+        src="./sticky-card-layout-right.svg" %}{% endexample %}
 
 ### Content
 
@@ -77,7 +77,7 @@ A sticky card has limited vertical height, so keep content short and only includ
 
 {% example palette="lightest",
         alt="Sticky card content sections",
-        src="./sticky-card-content.svg" %}
+        src="./sticky-card-content.svg" %}{% endexample %}
 
 ### Alignment
 
@@ -89,31 +89,31 @@ Don’t use more than one sticky card per page.
 
 {% example palette="wrong",
         alt="Sticky card multiple issue",
-        src="./sticky-card-best-practices-1.svg" %}
+        src="./sticky-card-best-practices-1.svg" %}{% endexample %}
 
 Don’t change the width of a sticky card on large screens, it’s fixed at 262px.
 
 {% example palette="wrong",
         alt="Sticky card width issue",
-        src="./sticky-card-best-practices-2.svg" %}
+        src="./sticky-card-best-practices-2.svg" %}{% endexample %}
 
 Don’t anchor a sticky card on small screens, it covers too much content.
 
 {% example palette="wrong",
         alt="Sticky card overlap issue",
-        src="./sticky-card-best-practices-3.svg" %}
+        src="./sticky-card-best-practices-3.svg" %}{% endexample %}
 
 Don't omit the close button, it’s needed for accessibility.
 
 {% example palette="wrong",
         alt="Sticky card close button issue",
-        src="./sticky-card-best-practices-4.svg" %}
+        src="./sticky-card-best-practices-4.svg" %}{% endexample %}
 
 Don’t use more than one call to action.
 
 {% example palette="wrong",
         alt="Sticky card call to action issue",
-        src="./sticky-card-best-practices-5.svg" %}
+        src="./sticky-card-best-practices-5.svg" %}{% endexample %}
 
 ## Behavior
 
@@ -135,7 +135,7 @@ The vertical height of a sticky card greatly expands when too much content is pl
 
 {% example palette="lightest",
         alt="Sticky card vertical height caution",
-        src="./sticky-card-behavior-height.svg" %}
+        src="./sticky-card-behavior-height.svg" %}{% endexample %}
 
 ## Breakpoints
 
@@ -145,19 +145,19 @@ A sticky card is 262px wide on large screens only. On small screens, it acts lik
 
 {% example palette="none",
         alt="Sticky card desktop layout",
-        src="./sticky-card-responsive-desktop.svg" %}
+        src="./sticky-card-responsive-desktop.svg" %}{% endexample %}
 
 ### Tablet
 
 {% example palette="none",
         alt="Sticky card tablet layout",
-        src="./sticky-card-responsive-tablet.svg" %}
+        src="./sticky-card-responsive-tablet.svg" %}{% endexample %}
 
 ### Mobile
 
 {% example palette="none",
         alt="Sticky card mobile layout",
-        src="./sticky-card-responsive-mobile.svg" %}
+        src="./sticky-card-responsive-mobile.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -177,7 +177,7 @@ values between elements.
 
   {% example palette="lightest",
            alt="Sticky card spacing",
-           src="./sticky-card-spacing.svg" %}
+           src="./sticky-card-spacing.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}
 

--- a/docs/patterns/video-thumbnail/index.md
+++ b/docs/patterns/video-thumbnail/index.md
@@ -11,7 +11,7 @@ A Video thumbnail is a graphical preview of a video overlayed with a play button
 ## Sample component
 {% example palette="none",
            alt="Video thumbnail",
-           src="./video-thumbnail.svg" %}
+           src="./video-thumbnail.svg" %}{% endexample %}
 
 {% repoStatus %}
 
@@ -21,16 +21,16 @@ A video thumbnail is a combination of a graphic with a slightly transparent play
 
 {% example palette="light",
            alt="Video thumbnail specs",
-           src="./video-thumbnail-style.svg" %}
+           src="./video-thumbnail-style.svg" %}{% endexample %}
 
 ## Theme
 {% example palette="light",
            alt="Video thumbnail light theme",
-           src="./video-thumbnail-theme-light.svg" %}
+           src="./video-thumbnail-theme-light.svg" %}{% endexample %}
            
 {% example palette="darkest",
            alt="Video thumbnail dark theme",
-           src="./video-thumbnail-theme-dark.svg" %}
+           src="./video-thumbnail-theme-dark.svg" %}{% endexample %}
 
 ### Button
 
@@ -39,11 +39,11 @@ A video thumbnail can include either a light or a dark play button, depending on
 <div class="multi-column--min-300-wide"><div>
     {% example palette="light",
               alt="Play button on light theme",
-              src="./video-button-light.svg" %}
+              src="./video-button-light.svg" %}{% endexample %}
   </div><div>
     {% example palette="darkest",
               alt="Play button on dark theme",
-              src="./video-button-dark.svg" %}
+              src="./video-button-dark.svg" %}{% endexample %}
 </div></div>
 
 ## Usage
@@ -56,7 +56,7 @@ A video thumbnail can be used in most layouts that have enough space to accommod
 
 {% example palette="light",
            alt="Specs of video button thumbnail",
-           src="./video-thumbnail-layout-specs.svg" %}
+           src="./video-thumbnail-layout-specs.svg" %}{% endexample %}
 
 ### Caption
 
@@ -68,13 +68,13 @@ Don't reposition the play button.
 
 {% example palette="wrong",
            alt="Don't reposition play button",
-           src="./video-thumbnail-best-practices-1.png" %}
+           src="./video-thumbnail-best-practices-1.png" %}{% endexample %}
 
 Don't change the aspect ratio of a video thumbnail.
 
 {% example palette="wrong",
            alt="Don't change aspect ratio",
-           src="./video-thumbnail-best-practices-2.png" %}
+           src="./video-thumbnail-best-practices-2.png" %}{% endexample %}
 
 ## Behavior
 
@@ -94,13 +94,13 @@ A video thumbnail changes size, but it should maintain its aspect ratio across a
 
 {% example palette="none",
            alt="Video thumbnail centered",
-           src="./video-thumbnail-responsive-desktop.svg" %}
+           src="./video-thumbnail-responsive-desktop.svg" %}{% endexample %}
 
 When centered, the video thumbnail and caption should span six grid columns
 
 {% example palette="none",
            alt="Video thumbnail sides",
-           src="./video-thumbnail-responsive-desktop-sides.svg" %}
+           src="./video-thumbnail-responsive-desktop-sides.svg" %}{% endexample %}
 
 When aligned on the left or right edge of the grid, the video thumbnail and caption should span five grid columns
 
@@ -108,7 +108,7 @@ When aligned on the left or right edge of the grid, the video thumbnail and capt
 
 {% example palette="none",
            alt="Video thumbnail on mobile",
-           src="./video-thumbnail-responsive-mobile.svg" %}
+           src="./video-thumbnail-responsive-mobile.svg" %}{% endexample %}
 
 ## Interaction states
 
@@ -117,34 +117,34 @@ The only interactive element in a video thumbnail is the play button. For more i
 ### Default
 {% example palette="light",
            alt="Video thumbnail default state",
-           src="./video-thumbnail-interaction-default.svg" %}
+           src="./video-thumbnail-interaction-default.svg" %}{% endexample %}
 
 ### Focus
 {% example palette="light",
            alt="Video thumbnail focus state",
-           src="./video-thumbnail-interaction-focus.svg" %}
+           src="./video-thumbnail-interaction-focus.svg" %}{% endexample %}
 
 ### Hover
 {% example palette="light",
            alt="Video thumbnail hover state",
-           src="./video-thumbnail-interaction-hover.svg" %}
+           src="./video-thumbnail-interaction-hover.svg" %}{% endexample %}
 
 ### Active
 {% example palette="light",
            alt="Video thumbnail active state",
-           src="./video-thumbnail-interaction-active.svg" %}
+           src="./video-thumbnail-interaction-active.svg" %}{% endexample %}
 
 <div class="multi-column--min-300-wide"><div>
     {% example palette="light",
               alt="Video thumbnail hover state light",
-              src="./video-button-hover-state-dark.svg" %}
+              src="./video-button-hover-state-dark.svg" %}{% endexample %}
 
     The dark play button background becomes 25% darker on hover
     {.example-notes}
 </div><div>
     {% example palette="darkest",
               alt="Video thumbnail hover state dark",
-              src="./video-button-hover-state-light.svg" %}
+              src="./video-button-hover-state-light.svg" %}{% endexample %}
 
     The light play button background becomes 25% lighter on hover
     {.example-notes}
@@ -164,6 +164,6 @@ values between elements.
 
 {% example palette="light",
            alt="Video thumbnail spacing specs",
-           src="./video-thumbnail-spacing.svg" %}
+           src="./video-thumbnail-spacing.svg" %}{% endexample %}
 
 {% include 'feedback.html' %}

--- a/docs/scss/components/_example.scss
+++ b/docs/scss/components/_example.scss
@@ -66,6 +66,10 @@ rh-alert + .example {
     }
   }
 
+  &--component {
+    justify-content: center;
+  }
+
   rh-cta {
     margin-bottom: 16px;
   }
@@ -102,6 +106,7 @@ rh-alert + .example {
 }
 
 .example--palette-darkest {
+  color: #fff;
   background: #151515;
   border-radius: 8px;
 }

--- a/docs/tokens/index.md
+++ b/docs/tokens/index.md
@@ -33,7 +33,7 @@ websites, libraries, and tools.
 
 {% example palette="lightest",
   alt="Flow showing how a color like brand red becomes a token, how it is named, and how it is applied to a call to action",
-  src="images/design-tokens-intro.png" %}
+  src="images/design-tokens-intro.png" %}{% endexample %}
 
 ## Installation
 
@@ -52,61 +52,61 @@ values or if you have an idea for an output format or tool integration.
   <figure>
     {% example
       alt="Tokens for border radius, width, color, and more",
-      src="images/design-tokens-category-border.png" %}
+      src="images/design-tokens-category-border.png" %}{% endexample %}
     <figcaption>Border</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for box shadows",
-      src="images/design-tokens-category-box-shadow.png" %}
+      src="images/design-tokens-category-box-shadow.png" %}{% endexample %}
     <figcaption>Box shadow</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for breakpoint sizes",
-      src="images/design-tokens-category-breakpoint.png" %}
+      src="images/design-tokens-category-breakpoint.png" %}{% endexample %}
     <figcaption>Breakpoint</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for colors",
-      src="images/design-tokens-category-color.png" %}
+      src="images/design-tokens-category-color.png" %}{% endexample %}
     <figcaption>Color</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for icon sizes",
-      src="images/design-tokens-category-icon.png" %}
+      src="images/design-tokens-category-icon.png" %}{% endexample %}
     <figcaption>Icon</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for length values",
-      src="images/design-tokens-category-length.png" %}
+      src="images/design-tokens-category-length.png" %}{% endexample %}
     <figcaption>Length</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for media query sizes",
-      src="images/design-tokens-category-media-query.png" %}
+      src="images/design-tokens-category-media-query.png" %}{% endexample %}
     <figcaption>Media query</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for opacity values",
-      src="images/design-tokens-category-opacity.png" %}
+      src="images/design-tokens-category-opacity.png" %}{% endexample %}
     <figcaption>Opacity</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for spacer sizes",
-      src="images/design-tokens-category-space.png" %}
+      src="images/design-tokens-category-space.png" %}{% endexample %}
     <figcaption>Space</figcaption>
   </figure>
   <figure>
     {% example
       alt="Tokens for fonts, sizes, weights, line heights, color, and more",
-      src="images/design-tokens-category-typography.png" %}
+      src="images/design-tokens-category-typography.png" %}{% endexample %}
     <figcaption>Typography</figcaption>
   </figure>
 </nav>
@@ -157,7 +157,7 @@ toward consistency even if a token is updated.
 
 {% example
   alt="Flow showing how changing a global token like a color will propagate through the entire design system",
-  src="images/design-tokens-why-we-need-tokens.png" %}
+  src="images/design-tokens-why-we-need-tokens.png" %}{% endexample %}
 
 ## Tokens and our design system
 
@@ -168,7 +168,7 @@ websites, libraries, and tools.
 
 {% example
   alt="Flow showing how tokens can be utilized in design programs as well as applied to various touchpoints like brand, web, and product",
-  src="images/design-tokens-and-our-ds.png" %}
+  src="images/design-tokens-and-our-ds.png" %}{% endexample %}
 
 ## Naming tokens
 
@@ -181,7 +181,7 @@ proceeding from the general to the specific, e.g. `colour` (general), `surface`
 
 {% example
   alt="Destructive button with a Danger text label showing its assigned token name underneath",
-  src="images/design-tokens-naming.png" %}
+  src="images/design-tokens-naming.png" %}{% endexample %}
 
 ### Aliases
 
@@ -197,7 +197,7 @@ order for it to propagate everywhere.
 
 {% example
   alt="Flow showing how 1 global token is applied to 2 different elements because the alias names are different",
-  src="images/design-tokens-aliases.png" %}
+  src="images/design-tokens-aliases.png" %}{% endexample %}
 
 ## Themes
 
@@ -208,7 +208,7 @@ different audience or brand requirements.
 
 {% example
   alt="Examples of how tokens are applied to elements in the light and dark themes",
-  src="images/design-tokens-themes.png" %}
+  src="images/design-tokens-themes.png" %}{% endexample %}
 
 [color]: /tokens/color/
 [space]: /tokens/space/

--- a/elements/rh-accordion/docs/00-overview.md
+++ b/elements/rh-accordion/docs/00-overview.md
@@ -3,7 +3,7 @@
 
 {% example palette="light",
           alt="An accordion with four collapsed panels and one expanded panel",
-          src="./accordion-sample-element.png" %}
+          src="./accordion-sample-element.png" %}{% endexample %}
 
 ## Sample component
 

--- a/elements/rh-accordion/docs/10-style.md
+++ b/elements/rh-accordion/docs/10-style.md
@@ -4,7 +4,7 @@ Accordion panels include title text, a chevron icon, body text, and other conten
 ### Anatomy 
 {% example palette="light",
           alt="Anatomy of an accordion with lots of annotations pointing to various parts",
-          src="../accordion-anatomy.png" %}
+          src="../accordion-anatomy.png" %}{% endexample %}
 
 1) Collapsed panel
 2) Expanded panel
@@ -21,45 +21,45 @@ There are two available sizes and the only difference is the title text size. Yo
 
 {% example palette="light",
           alt="A large size accordion with text underneath saying ‘Large size’ and a small size accordion with text underneath saying ‘Small size’",
-          src="../accordion-sizes.png" %}
+          src="../accordion-sizes.png" %}{% endexample %}
 
 ## Theme 
 An accordion is available in both light and dark themes. The light theme expanded panel includes a box shadow, but the dark theme does not.
 ### Light theme 
 {% example palette="light",
           alt="Light theme accordion with an expanded panel",
-          src="../accordion-theme-light.png" %}
+          src="../accordion-theme-light.png" %}{% endexample %}
 
 ### Dark theme 
 {% example palette="darkest",
           alt="Dark theme accordion with an expanded panel",
-          src="../accordion-theme-dark.png" %}
+          src="../accordion-theme-dark.png" %}{% endexample %}
 
 ## Configuration 
 An expanded panel does not have a maximum height, but it may scroll if constrained by vertical space. The width of an accordion varies based on content and page layout. Title text and icons are horizontally aligned.
 
 {% example palette="light",
           alt="How an accordion is constructed showing alignment, space, scrolling, and width details",
-          src="../accordion-configuration.png" %}
+          src="../accordion-configuration.png" %}{% endexample %}
 
 ### Nested panels 
 Panels can be nested to help organize complex or granular sections of content.
 
 {% example palette="light",
           alt="An accordion with an expanded panel and a nested expanded panel",
-          src="../accordion-nested-panels.png" %}
+          src="../accordion-nested-panels.png" %}{% endexample %}
 
 ### Stacked panels 
 Multiple panels can be expanded simultaneously even when nested.
 
 {% example palette="light",
           alt="An accordion with one collapsed panel on top and two stacked expanded panels below",
-          src="../accordion-stacked-panels.png" %}
+          src="../accordion-stacked-panels.png" %}{% endexample %}
 
 ## Space 
 {% example palette="light",
           alt="Accordion spacing within panels and in between elements like titles, body text, rules, and icons",
-          src="../accordion-space.png" %}
+          src="../accordion-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
   headline="",
@@ -74,11 +74,11 @@ Interaction states are visual representations used to communicate the status of 
 ### Hover 
 {% example palette="light",
           alt="Light theme accordion hover state examples",
-          src="../accordion-hover-theme-light.png" %}
+          src="../accordion-hover-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
           alt="Dark theme accordion hover state example",
-          src="../accordion-hover-theme-dark.png" %}
+          src="../accordion-hover-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -91,11 +91,11 @@ Interaction states are visual representations used to communicate the status of 
 ### Focus 
 {% example palette="light",
           alt="Light theme accordion focus state examples",
-          src="../accordion-focus-theme-light.png" %}
+          src="../accordion-focus-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
           alt="Dark theme accordion focus state example",
-          src="../accordion-focus-theme-dark.png" %}
+          src="../accordion-focus-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -109,11 +109,11 @@ Interaction states are visual representations used to communicate the status of 
 ### Active 
 {% example palette="light",
           alt="Light theme accordion active state examples",
-          src="../accordion-active-theme-light.png" %}
+          src="../accordion-active-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
           alt="Dark theme accordion active state example",
-          src="../accordion-active-theme-dark.png" %}
+          src="../accordion-active-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 

--- a/elements/rh-accordion/docs/20-guidelines.md
+++ b/elements/rh-accordion/docs/20-guidelines.md
@@ -7,14 +7,14 @@ An accordion is used to organize important information whereas a [Disclosure](/p
 
 {% example palette="light",
           alt="Comparison of how to use accordion vs. disclosure elements showing an accordion on top and a disclosure on the bottom",
-          src="../accordion-vs-disclosure.png" %}
+          src="../accordion-vs-disclosure.png" %}{% endexample %}
 
 ### Sizes 
 It is acceptable to use the Small size on large breakpoints, but do not use the Large size on small breakpoints.
 
 {% example palette="light",
           alt="Size comparison of accordions; a wide small size accordion is on top, which is acceptable to use, and a thin large size accordion below it which is not acceptable to use",
-          src="../accordion-sizes-best-practices.png" %}
+          src="../accordion-sizes-best-practices.png" %}{% endexample %}
 
 ## Writing content 
 ### Title text 
@@ -22,7 +22,7 @@ Title text should be written concisely so users know what to expect when they ex
 
 {% example palette="light",
           alt="Title text examples of various lengths; it should not be too long, too short, or too vague",
-          src="../accordion-title-text.png" %}
+          src="../accordion-title-text.png" %}{% endexample %}
 
 1) Title text is too long and should be broken into two sections
 2) Title text is short and might not help users understand the content within
@@ -41,21 +41,21 @@ When a panel is expanded, some content must appear below the title text and chev
 
 {% example palette="light",
           alt="Accordion showing different elements you may include in the expanded panel like headings, body text, links, cards, and more",
-          src="../accordion-panel-content.png" %}
+          src="../accordion-panel-content.png" %}{% endexample %}
 
 ### Long title text 
 Title text can be two lines on small breakpoints, but no more.
 
 {% example palette="light",
           alt="Two accordions; one wide accordion with the text title on one line and one thin accordion with the text title on two lines",
-          src="../accordion-long-title-text.png" %}
+          src="../accordion-long-title-text.png" %}{% endexample %}
 
 ## Layout 
 The width of an accordion can be adjusted on large breakpoints to fit less columns if necessary.
 
 {% example palette="light",
           alt="A thinner accordion placed on a 12-column grid and occupying eight grid columns",
-          src="../accordion-layout.png" %}
+          src="../accordion-layout.png" %}{% endexample %}
 
 ## Behavior
 
@@ -67,18 +67,18 @@ Users can expand multiple panels simultaneously either stacked on top of each ot
 
 {% example palette="light",
           alt="Two accordions; one is showing two expanded panels stacked on top of each other and the other is showing two expanded panels and one collapsed panel in between",
-          src="../accordion-expanding-multiple-panels.png" %}
+          src="../accordion-expanding-multiple-panels.png" %}{% endexample %}
 
 ## Responsive design 
 An accordion changes from the Large size to the Small size as breakpoints get smaller.
 
 {% example palette="none",
           alt="Accordions on large breakpoints",
-          src="../accordion-breakpoints-large.png" %}
+          src="../accordion-breakpoints-large.png" %}{% endexample %}
 
 {% example palette="none",
           alt="Accordions on small breakpoints",
-          src="../accordion-breakpoints-small.png" %}
+          src="../accordion-breakpoints-small.png" %}{% endexample %}
 
 ### Breakpoints
 
@@ -98,18 +98,18 @@ Do not display one panel only, use an expandable section instead.
 
 {% example palette="wrong",
           alt="Accordion having only one panel is incorrect usage",
-          src="../accordion-best-practice-1.png" %}
+          src="../accordion-best-practice-1.png" %}{% endexample %}
 
 ### Text readability 
 Text within panels should not exceed `750px` to maintain optimal readability.
 
 {% example palette="wrong",
           alt="Accordion with body text exceeding 750px wide which is incorrect usage",
-          src="../accordion-best-practice-2.png" %}
+          src="../accordion-best-practice-2.png" %}{% endexample %}
 
 ### Mixing themes 
 Do not use a dark theme accordion in a light theme environment and vice versa.
 
 {% example palette="wrong",
           alt="Do not use a dark theme accordion in a light theme environment and vice versa.",
-          src="../accordion-best-practice-3.png" %}
+          src="../accordion-best-practice-3.png" %}{% endexample %}

--- a/elements/rh-accordion/docs/40-accessibility.md
+++ b/elements/rh-accordion/docs/40-accessibility.md
@@ -3,7 +3,7 @@ Each panel is a focus stop where `Enter` or `Space` expands or collapses each pa
 
 {% example palette="light",
           alt="Accordion keyboard interactions; pressing Tab will focus the top panel, pressing Tab again will move focus to the next panel underneath, and pressing Enter or Space will expand the panel",
-          src="../accordion-keyboard-interactions.png" %}
+          src="../accordion-keyboard-interactions.png" %}{% endexample %}
 
 | Key  {style="width: 50%" }        | Result                            |
 | --------------------------------- | --------------------------------- |
@@ -16,14 +16,14 @@ Each panel is a focus stop where `Enter` or `Space` expands or collapses each pa
 
 {% example palette="light",
           alt="Accordion showing the order how focus moves through the element when pressing Tab continuously",
-          src="../accordion-focus-order.png" %}
+          src="../accordion-focus-order.png" %}{% endexample %}
 
 ## Touch targets
 Each panel is selectable instead of only title text or the chevrons.
 
 {% example palette="light",
           alt="Accordion showing touch target size examples for large and small sizes",
-          src="../accordion-touch-targets.png" %}
+          src="../accordion-touch-targets.png" %}{% endexample %}
 
 {% include 'accessibility/ariaguide.md' %}
 {% include 'accessibility/wcag.md' %}

--- a/elements/rh-alert/docs/00-overview.md
+++ b/elements/rh-alert/docs/00-overview.md
@@ -5,7 +5,7 @@
 ## Sample component
 {% example palette="light",
            alt="Two examples of the alert element",
-           src="alert-sample.svg" %}
+           src="alert-sample.svg" %}{% endexample %}
 
 
 ## Demos

--- a/elements/rh-alert/docs/10-style.md
+++ b/elements/rh-alert/docs/10-style.md
@@ -7,7 +7,7 @@ An alert contains title text with an icon, body text, and a close button. They m
 
 {% example palette="light",
            alt="Alert with numbers pointing to parts of the element",
-           src="../alert-anatomy.svg" %}
+           src="../alert-anatomy.svg" %}{% endexample %}
 
 1. Severity indicator
 2. Severity icon
@@ -25,7 +25,7 @@ The required elements of an Inline alert are a thin top bar or thin border, icon
 
 {% example palette="light",
            alt="Two examples of an inline alert",
-           src="../alert-style-inline.svg" %}
+           src="../alert-style-inline.svg" %}{% endexample %}
 
 ### Inline, alternate
 
@@ -33,7 +33,7 @@ The alternate Inline alert style includes a border instead of a line which can b
 
 {% example palette="light",
            alt="Two examples of an alternate design for inline alerts",
-           src="../alert-style-inline-alt.svg" %}
+           src="../alert-style-inline-alt.svg" %}{% endexample %}
 
 ### Toast
 
@@ -41,7 +41,7 @@ The required elements of a Toast alert are a thin top bar, icon, title, close bu
 
 {% example palette="light",
            alt="Two examples of a toast alert",
-           src="../alert-style-toast.svg" %}
+           src="../alert-style-toast.svg" %}{% endexample %}
 
 
 ## Interaction states
@@ -52,19 +52,19 @@ Interaction states are visual representations used to communicate the status of 
 
 {% example palette="light",
            alt="Examples showing hover state",
-           src="../alert-interaction-states-hover.svg" %}
+           src="../alert-interaction-states-hover.svg" %}{% endexample %}
 
 ### Focus
 
 {% example palette="light",
            alt="Examples showing focus state",
-           src="../alert-interaction-states-focus.svg" %}
+           src="../alert-interaction-states-focus.svg" %}{% endexample %}
 
 ### Active
 
 {% example palette="light",
            alt="Examples showing active state",
-           src="../alert-interaction-states-active.svg" %}
+           src="../alert-interaction-states-active.svg" %}{% endexample %}
 
 
 ## Spacing
@@ -73,19 +73,19 @@ Interaction states are visual representations used to communicate the status of 
 
 {% example palette="light",
            alt="Diagram of spacing for inline alerts",
-           src="../alert-spacing-inline.svg" %}
+           src="../alert-spacing-inline.svg" %}{% endexample %}
 
 ### Toast
 
 {% example palette="light",
            alt="Diagram of spacing for toast alerts",
-           src="../alert-spacing-toast.svg" %}
+           src="../alert-spacing-toast.svg" %}{% endexample %}
 
 ### Toast (stacked)
 
 {% example palette="none",
            alt="Diagram of spacing between stacked toast alerts",
-           src="../alert-spacing-toast-layout.svg" %}
+           src="../alert-spacing-toast-layout.svg" %}{% endexample %}
 
 {% spacerTokensTable 
     caption='',

--- a/elements/rh-alert/docs/20-guidelines.md
+++ b/elements/rh-alert/docs/20-guidelines.md
@@ -28,7 +28,7 @@ for status and severity.
 
 {% example palette="light",
            alt="Examples of the different colors indicating alert severity",
-           src="../alert-severity.svg" %}
+           src="../alert-severity.svg" %}{% endexample %}
 
 ### Dismissal
 
@@ -46,7 +46,7 @@ If an issue cannot be resolved on the current page or if a user needs to correct
 {% example palette="light",
            class="medium",
            alt="Alert element dismissal examples",
-           src="../alert-dismissal-examples.svg" %}
+           src="../alert-dismissal-examples.svg" %}{% endexample %}
 
 
 ## Writing content
@@ -73,11 +73,11 @@ An Inline alert can be placed toward the **top of a layout** if the message appl
 
 {% example palette="none",
            alt="Example of an inline alert at the top of a layout",
-           src="../alert-positioning-inline-global.svg" %}
+           src="../alert-positioning-inline-global.svg" %}{% endexample %}
 
 {% example palette="none",
            alt="Example of an inline alert inside a form",
-           src="../alert-positioning-inline-local.svg" %}
+           src="../alert-positioning-inline-local.svg" %}{% endexample %}
 
 ### Toast
 
@@ -91,13 +91,13 @@ If a Toast alert is set to persistent, a close button needs to be included so a 
 
 {% example palette="none",
            alt="Toast alert with a link in the body text includes a close button",
-           src="../alert-positioning-toast-persistent.svg" %}
+           src="../alert-positioning-toast-persistent.svg" %}{% endexample %}
 
 If a Toast alert is set to be temporary or time out, the alert will disappear after **eight seconds**. A user might want to dismiss the alert before then, in which case a close button needs be included.
 
 {% example palette="none",
            alt="Toast alert without actions or links includes a close button",
-           src="../alert-positioning-toast-temporary.svg" %}
+           src="../alert-positioning-toast-temporary.svg" %}{% endexample %}
 
 
 
@@ -109,11 +109,11 @@ When multiple Toast alerts are triggered around the same time, they will stack o
 
 {% example palette="none",
            alt="Three toast alerts are stacked in the top left corner of a layout",
-           src="../alert-behavior-stack-1.svg" %}
+           src="../alert-behavior-stack-1.svg" %}{% endexample %}
 
 {% example palette="none",
            alt="Only one toast alert in the stack from the previous image is left",
-           src="../alert-behavior-stack-2.svg" %}
+           src="../alert-behavior-stack-2.svg" %}{% endexample %}
 
 
 
@@ -125,7 +125,7 @@ The maximum width of a Toast alert on large screens is **six grid columns**.
 
 {% example palette="none",
            alt="Toast alert spans six grid columns, while inline alert spans all grid columns",
-           src="../alert-responsive-large-screens.svg" %}
+           src="../alert-responsive-large-screens.svg" %}{% endexample %}
 
 ### Small screens
 
@@ -133,7 +133,7 @@ On small screens, both alert variants will span the full column of the layout. T
 
 {% example palette="none",
            alt="Toast and inline alerts span full column of small screen layout",
-           src="../alert-responsive-small-screens.svg" %}
+           src="../alert-responsive-small-screens.svg" %}{% endexample %}
 
 
 
@@ -145,7 +145,7 @@ Do not use an Inline alert to communicate messages about important events, updat
 
 {% example palette="wrong",
            alt="Inline alert is incorrectly positioned like a toast alert",
-           src="../alert-bestpractice-1.svg" %}
+           src="../alert-bestpractice-1.svg" %}{% endexample %}
 
 ### Toast as Inline
 
@@ -153,7 +153,7 @@ Do not use a Toast alert to present simple information or inline messages.
 
 {% example palette="wrong",
            alt="Toast alert incorrectly placed inline with a layout",
-           src="../alert-bestpractice-2.svg" %}
+           src="../alert-bestpractice-2.svg" %}{% endexample %}
 
 ### Different variants
 
@@ -161,5 +161,5 @@ Do not use both variants when stacking.
 
 {% example palette="wrong",
            alt="Toast and inline alerts incorrectly stacked in top left corner of page",
-           src="../alert-bestpractice-3.svg" %}
+           src="../alert-bestpractice-3.svg" %}{% endexample %}
 

--- a/elements/rh-alert/docs/40-accessibility.md
+++ b/elements/rh-alert/docs/40-accessibility.md
@@ -15,7 +15,7 @@ A logical focus order helps visitors understand and operate our websites. Elemen
 
 {% example palette="light",
            alt="Focus goes to action buttons and to the close button last",
-           src="../alert-focus-order.svg" %}
+           src="../alert-focus-order.svg" %}{% endexample %}
 
 {% include 'accessibility/ariaguide.md' %}
 

--- a/elements/rh-audio-player/docs/10-style.md
+++ b/elements/rh-audio-player/docs/10-style.md
@@ -9,7 +9,7 @@ The audio player is a collection of elements used to play audio clips and browse
 ### Anatomy
 {% example palette="light",
           alt="Image of audio player anatomy showing all players with lots of annotations",
-          src="../audio-player-anatomy.png" %}
+          src="../audio-player-anatomy.png" %}{% endexample %}
 
 1) Image
 2) Description
@@ -31,7 +31,7 @@ There are three available sizes and the only difference is the amount of interfa
 
 {% example palette="light",
           alt="Image of all audio player sizes with text labels",
-          src="../audio-player-style-sizes.png" %}
+          src="../audio-player-style-sizes.png" %}{% endexample %}
 
 ## Theme
 The audio player is available in both light and dark themes.
@@ -39,12 +39,12 @@ The audio player is available in both light and dark themes.
 ### Light theme
 {% example palette="light",
           alt="Image of light theme audio players",
-          src="../audio-player-theme-light.png" %}
+          src="../audio-player-theme-light.png" %}{% endexample %}
 
 ### Dark theme
 {% example palette="darkest",
           alt="Image of dark theme audio players",
-          src="../audio-player-theme-dark.png" %}
+          src="../audio-player-theme-dark.png" %}{% endexample %}
 
 ### Custom theme
 {% alert title="Helpful tip" %}
@@ -54,21 +54,21 @@ If your audio player requires a custom theme, [contact](https://github.com/orgs/
 
 {% example palette="darkest",
           alt="Image of custom theme audio players",
-          src="../audio-player-theme-custom.png" %}
+          src="../audio-player-theme-custom.png" %}{% endexample %}
 
 ## Configuration
 The size of audio players change if an image is included or not.
 
 {% example palette="light",
           alt="Image of all audio players showing various specs like alignment, border radius, height, width, and more",
-          src="../audio-player-configuration.png" %}
+          src="../audio-player-configuration.png" %}{% endexample %}
 
 ## Space
 The amount of space in all audio players remains the same on all breakpoints.
 
 {% example palette="light",
           alt="Image of audio player spacing for all sizes",
-          src="../audio-player-space.png" %}
+          src="../audio-player-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
     caption='',
@@ -87,12 +87,12 @@ Every interactive element includes a tooltip as part of the Hover state. To lear
 
 {% example palette="light",
           alt="Image of light theme audio player hover states",
-          src="../audio-player-interaction-state-hover-theme-light.png" %}
+          src="../audio-player-interaction-state-hover-theme-light.png" %}{% endexample %}
 
 
 {% example palette="darkest",
           alt="Image of dark theme audio player hover states",
-          src="../audio-player-interaction-state-hover-theme-dark.png" %}
+          src="../audio-player-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
 ### Focus
 {% alert title="Helpful tip" %}
@@ -102,11 +102,11 @@ The Focus state has the same styles as the Hover state.
 
 {% example palette="light",
           alt="Image of light theme audio player focus states",
-          src="../audio-player-interaction-state-focus-theme-light.png" %}
+          src="../audio-player-interaction-state-focus-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
           alt="Image of dark theme audio player focus states",
-          src="../audio-player-interaction-state-focus-theme-dark.png" %}
+          src="../audio-player-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
 
 ### Active
@@ -117,10 +117,10 @@ The Active state has the same styles as the Hover state.
 
 {% example palette="light",
           alt="Image of light theme audio player active states",
-          src="../audio-player-interaction-state-active-theme-light.png" %}
+          src="../audio-player-interaction-state-active-theme-light.png" %}{% endexample %}
 
 
 {% example palette="darkest",
           alt="Image of dark theme audio player active states",
-          src="../audio-player-interaction-state-active-theme-dark.png" %}
+          src="../audio-player-interaction-state-active-theme-dark.png" %}{% endexample %}
 

--- a/elements/rh-audio-player/docs/20-features.md
+++ b/elements/rh-audio-player/docs/20-features.md
@@ -6,14 +6,14 @@ Pressing the `More options` button opens the contextual menu. The description an
 
 {% example palette="none",
           alt="Image of all audio player sizes showing the open contextual menu",
-          src="../audio-player-contextual-menu.png" %}
+          src="../audio-player-contextual-menu.png" %}{% endexample %}
 
 ## Content panel 
 When a feature is selected, the audio player expands and reveals the content panel. In the Full player, some interface elements get smaller, rearrange, or become hidden. In the Compact and Mini players, the content panel is below the controls. The `More options` button changes to a `Close` button as well which allows users to close the panel and return to the audio player at any time.
 
 {% example palette="light",
           alt="Image of all audio player sizes showing the open content panel",
-          src="../audio-player-content-panel.png" %}
+          src="../audio-player-content-panel.png" %}{% endexample %}
 
 
 
@@ -22,7 +22,7 @@ Displays the description and title in the Compact player only.
 
 {% example palette="light",
           alt="Image of two Compact players; one is showing the description and title and the other is showing only the title",
-          src="../audio-player-audio-info.png" %}
+          src="../audio-player-audio-info.png" %}{% endexample %}
 
 
 
@@ -36,25 +36,25 @@ When renaming this feature, the maximum character count is 20.
 
 {% example palette="light",
           alt="Image of the Full and Compact players showing the Audio summary feature in the content panel",
-          src="../audio-player-audio-summary.png" %}
+          src="../audio-player-audio-summary.png" %}{% endexample %}
 
 ## Subscribe 
 Provides users with links to various audio websites so they can subscribe.
 
 {% example palette="light",
           alt="Image of the Full and Compact audio players showing the Subscribe feature in the content panel",
-          src="../audio-player-subscribe.png" %}
+          src="../audio-player-subscribe.png" %}{% endexample %}
 
 ## Transcript 
 A transcript is an accessible alternative for users who are hard of hearing, deaf, or just want to read along.
 
 {% example palette="light",
           alt="Image of the Full and Compact players showing the Transcript feature in the content panel",
-          src="../audio-player-subscribe.png" %}
+          src="../audio-player-subscribe.png" %}{% endexample %}
 
 ### Highlighting 
 When audio is playing, the transcript scrolls automatically and words are highlighted as they are spoken. Users also have the option to scroll on their own or download the entire transcript.
 
 {% example palette="light",
           alt="Image of the Full and Compact players showing a phrase being highlighting as it is spoken in the Transcript feature",
-          src="../audio-player-transcript-highlighting.png" %}
+          src="../audio-player-transcript-highlighting.png" %}{% endexample %}

--- a/elements/rh-audio-player/docs/30-guidelines.md
+++ b/elements/rh-audio-player/docs/30-guidelines.md
@@ -9,7 +9,7 @@ When choosing one size over the other, consider where it is being used and what 
 
 {% example palette="light",
           alt="Image of all audio player sizes with text labels",
-          src="../audio-player-guidelines-sizes.png" %}
+          src="../audio-player-guidelines-sizes.png" %}{% endexample %}
 
 
 | Size {style="width: 25%" } | Use case                                                                                           |
@@ -24,7 +24,7 @@ It is acceptable to remove optional elements, but doing so will change the heigh
 
 {% example palette="light",
           alt="Image of two Full players; one is without an image and the other is without an image and description text",
-          src="../audio-player-removing-elements.png" %}
+          src="../audio-player-removing-elements.png" %}{% endexample %}
 
 
 
@@ -34,7 +34,7 @@ In certain edge cases, the Mini player can hide the volume and contextual menu b
 
 {% example palette="light",
           alt="Image of three Mini players; one is the default state, one is missing the menu button, and one is missing both the volume and menu buttons",
-          src="../audio-player-mini-player.png" %}
+          src="../audio-player-mini-player.png" %}{% endexample %}
 
 
 ## Writing content 
@@ -50,7 +50,7 @@ The description and title are not included in the Mini size players.
 
 {% example palette="light",
           alt="Image of the Full player and two Compact players; one Compact player has both description and title text and the other Compact player has only title text",
-          src="../audio-player-description-and-title.png" %}
+          src="../audio-player-description-and-title.png" %}{% endexample %}
 
 
 ### Character count 
@@ -69,7 +69,7 @@ Compact and Mini players can be used inline with titles, headings, and a call to
 
 {% example palette="light",
           alt="Image of Compact and Mini players used with titles, headings, and calls to action",
-          src="../audio-player-layout-inline.png" %}
+          src="../audio-player-layout-inline.png" %}{% endexample %}
 
 
 ### Stacking 
@@ -77,7 +77,7 @@ Compact players can be stacked with headings, text, and horizontal rules.
 
 {% example palette="light",
           alt="Image of the Compact player in a stacked layout with headers, text, and horizontal rules ",
-          src="../audio-player-layout-stacking.png" %}
+          src="../audio-player-layout-stacking.png" %}{% endexample %}
 
 
 ### Full-width 
@@ -91,12 +91,12 @@ When a Compact size is used full-width, the contextual menu button is replaced b
 
 {% example palette="none",
           alt="Image of a full-width Compact player in a light theme context",
-          src="../audio-player-layout-full-width-1.png" %}
+          src="../audio-player-layout-full-width-1.png" %}{% endexample %}
 
 
 {% example palette="none",
           alt="Image of a full-width Compact player in a dark theme context",
-          src="../audio-player-layout-full-width-2.png" %}
+          src="../audio-player-layout-full-width-2.png" %}{% endexample %}
 
 
 ## Behavior 
@@ -106,7 +106,7 @@ When a page loads, audio should **never** start playing automatically without re
 
 {% example palette="light",
           alt="Image of the Full player showing audio stopped",
-          src="../audio-player-behavior-autoplay.png" %}
+          src="../audio-player-behavior-autoplay.png" %}{% endexample %}
 
 
 ### Scrolling text 
@@ -114,7 +114,7 @@ If the description or title is long, it scrolls from left to right while audio i
 
 {% example palette="light",
           alt="Image of the Full player with description and title text cut off and scrolling from left to right as audio plays",
-          src="../audio-player-behavior-scrolling-text.png" %}
+          src="../audio-player-behavior-scrolling-text.png" %}{% endexample %}
 
 
 ## Playback 
@@ -125,7 +125,7 @@ Dragging the current time indicator will jump to a specific time. Arrow keys wil
 
 {% example palette="light",
           alt="Image of the Full player showing how to seek with a cursor or keyboard",
-          src="../audio-player-playback-seek.png" %}
+          src="../audio-player-playback-seek.png" %}{% endexample %}
 
 
 ### Unmute/mute 
@@ -133,7 +133,7 @@ Audio can be toggled on or off by pressing the unmute/mute button.
 
 {% example palette="light",
           alt="Image of the Full player showing how to toggle the unmute/mute button with a cursor or keyboard",
-          src="../audio-player-playback-unmute-mute.png" %}
+          src="../audio-player-playback-unmute-mute.png" %}{% endexample %}
 
 
 ### Volume 
@@ -141,7 +141,7 @@ Dragging the slider will adjust the volume. Arrow keys will increase or decrease
 
 {% example palette="light",
           alt="Image of the Full player showing how to adjust the volume with a cursor or keyboard",
-          src="../audio-player-playback-volume.png" %}
+          src="../audio-player-playback-volume.png" %}{% endexample %}
 
 
 ### Speed 
@@ -149,7 +149,7 @@ The rate of speed can be adjusted by clicking the carets or selecting the speed 
 
 {% example palette="light",
           alt="Image of the Full player showing how to open the speed menu and selecting another speed with a cursor or keyboard",
-          src="../audio-player-playback-speed.png" %}
+          src="../audio-player-playback-speed.png" %}{% endexample %}
 
 
 ### Rewind/forward 
@@ -157,7 +157,7 @@ Audio rewinds or advances by 15 seconds if either button is pressed.
 
 {% example palette="light",
           alt="Image of the Full player showing how to toggle the rewind or forward buttons with a cursor or keyboard",
-          src="../audio-player-playback-rewind-forward.png" %}
+          src="../audio-player-playback-rewind-forward.png" %}{% endexample %}
 
 
 ### Play/pause 
@@ -165,7 +165,7 @@ Audio playback can be resumed/stopped by pressing the play/pause button.
 
 {% example palette="light",
           alt="Image of the Full player showing how to toggle the play/pause button with a cursor or keyboard",
-          src="../audio-player-playback-play-pause.png" %}
+          src="../audio-player-playback-play-pause.png" %}{% endexample %}
 
 
 ## Responsive design 
@@ -175,20 +175,20 @@ All audio players can be used on large breakpoints. The Mini player can be stret
 
 {% example palette="none",
           alt="Image of the Full, Full without image, and Compact players as well as a stretched Mini player on desktop breakpoints",
-          src="../audio-player-responsive-breakpoints-desktop.png" %}
+          src="../audio-player-responsive-breakpoints-desktop.png" %}{% endexample %}
 
 
 The Full player will change to the Compact player and the Compact player will change to the Mini player as breakpoints get smaller.
 
 {% example palette="none",
           alt="Image of the Compact player and a stretched Mini player on tablet breakpoints",
-          src="../audio-player-responsive-breakpoints-tablet.png" %}
+          src="../audio-player-responsive-breakpoints-tablet.png" %}{% endexample %}
 
 
 ### Small breakpoints 
 {% example palette="none",
           alt="Image of Mini players on mobile breakpoints",
-          src="../audio-player-responsive-breakpoints-mobile.png" %}
+          src="../audio-player-responsive-breakpoints-mobile.png" %}{% endexample %}
 
 
 ## Best practices 
@@ -198,7 +198,7 @@ Be careful when using the Full player near too many other elements.
 
 {% example palette="wrong",
           alt="Image of the Full player used near lots of other elements",
-          src="../audio-player-best-practice-1.png" %}
+          src="../audio-player-best-practice-1.png" %}{% endexample %}
 
 
 ### Contextual menu 
@@ -206,4 +206,4 @@ Do not alter contextual menu theming.
 
 {% example palette="wrong",
           alt="Image of Compact players with contextual menus that are a different theme than the audio player which is incorrect usage",
-          src="../audio-player-best-practice-2.png" %}
+          src="../audio-player-best-practice-2.png" %}{% endexample %}

--- a/elements/rh-audio-player/docs/50-accessibility.md
+++ b/elements/rh-audio-player/docs/50-accessibility.md
@@ -4,7 +4,7 @@ Every interactive element is a focus stop and controls are operated using differ
 
 {% example palette="light",
           alt="Image of all players with labels of how to activate or adjust all controls and menus",
-          src="../audio-player-a11y-keyboard-interactions.png" %}
+          src="../audio-player-a11y-keyboard-interactions.png" %}{% endexample %}
 
 
 | Key {style="width: 33%" } | Result                                                                          |
@@ -23,7 +23,7 @@ A logical focus order helps keyboard users operate our websites. Elements need t
 
 {% example palette="light",
           alt="Image of all players and the Compact player with a contextual menu open showing the focus order from left to right and top to bottom",
-          src="../audio-player-a11y-focus-order.png" %}
+          src="../audio-player-a11y-focus-order.png" %}{% endexample %}
 
 
 ### Toggling a feature
@@ -31,7 +31,7 @@ When a user closes a feature by pressing <kbd>Space</kbd> or <kbd>Esc</kbd>, foc
 
 {% example palette="light",
           alt="Image of the Compact player showing focus landing on the contextual menu or close buttons regardless if a feature is open or closed",
-          src="../audio-player-a11y-toggling-feature.png" %}
+          src="../audio-player-a11y-toggling-feature.png" %}{% endexample %}
 
 
 {% include 'accessibility/ariaguide.md' %}

--- a/elements/rh-avatar/docs/00-overview.md
+++ b/elements/rh-avatar/docs/00-overview.md
@@ -3,7 +3,7 @@
 
   {% example palette="light",
               alt=" Image of an avatar group with a photo of a woman and text",
-              src="./avatar-sample.png" %}
+              src="./avatar-sample.png" %}{% endexample %}
 
 
 ## Sample component

--- a/elements/rh-avatar/docs/10-style.md
+++ b/elements/rh-avatar/docs/10-style.md
@@ -15,7 +15,7 @@
 
   {% example palette="light",
               alt="Anatomy of an avatar group with numbered annotations",
-              src="../avatar-anatomy.png" %}
+              src="../avatar-anatomy.png" %}{% endexample %}
 
   1. Thumbnail
   2. Job details text
@@ -32,7 +32,7 @@
 
   {% example palette="light",
               alt="Image of all avatar groups including default, photo, green squares, purple squares, and blue triangles",
-              src="../avatar-variations.png" %}
+              src="../avatar-variations.png" %}{% endexample %}
 
 ### Plain
   The avatar thumbnail can be used on its own in places like 
@@ -41,7 +41,7 @@
 
   {% example palette="light",
               alt="Image of a row of only avatar thumbnails",
-              src="../avatar-plain.png" %}
+              src="../avatar-plain.png" %}{% endexample %}
 
 ### Link
   Links can be applied to full name or job details text.
@@ -52,7 +52,7 @@
 
   {% example palette="light",
               alt="Image of two avatar groups; one has the full name linked and the other has the company name linked",
-              src="../avatar-links.png" %}
+              src="../avatar-links.png" %}{% endexample %}
 
 
 ## Theme
@@ -63,11 +63,11 @@
 
   {% example palette="light",
               alt="Image of a light theme avatar group",
-              src="../avatar-theme-light.png" %}
+              src="../avatar-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
               alt="Image of a dark theme avatar group",
-              src="../avatar-theme-dark.png" %}
+              src="../avatar-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -89,14 +89,14 @@
 
   {% example palette="light",
               alt="Image of two avatar groups showing specs like height, width, and centering/alignment",
-              src="../avatar-configuration.png" %}
+              src="../avatar-configuration.png" %}{% endexample %}
 
 ### Job details text
   Job details text has specific styles applied to it.
 
   {% example palette="light",
               alt="Image of two avatar groups showing only job details text left justified and center justified",
-              src="../avatar-job-details-text.png" %}
+              src="../avatar-job-details-text.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -116,7 +116,7 @@
 
   {% example palette="light",
               alt="Image of all avatar groups with spacing values in between",
-              src="../avatar-space.png" %}
+              src="../avatar-space.png" %}{% endexample %}
 
   {% spacerTokensTable 
       headline='',
@@ -134,11 +134,11 @@
 
   {% example palette="light",
              alt="Image of light theme avatar group hover states",
-             src="../avatar-interaction-state-hover-theme-light.png" %}
+             src="../avatar-interaction-state-hover-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
               alt="Image of dark theme avatar group hover states",
-              src="../avatar-interaction-state-hover-theme-dark.png" %}
+              src="../avatar-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -159,11 +159,11 @@
 
   {% example palette="light",
               alt="Image of light theme avatar group focus states",
-              src="../avatar-interaction-state-focus-theme-light.png" %}
+              src="../avatar-interaction-state-focus-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
               alt="Image of dark theme avatar group focus states",
-              src="../avatar-interaction-state-focus-theme-dark.png" %}
+              src="../avatar-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -184,11 +184,11 @@
   {% example palette="light",
              class="centered",
              alt="Image of light theme avatar group active states",
-             src="../avatar-interaction-state-active-theme-light.png" %}
+             src="../avatar-interaction-state-active-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
               alt="Image of dark theme avatar group active states",
-              src="../avatar-interaction-state-active-theme-dark.png" %}
+              src="../avatar-interaction-state-active-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 

--- a/elements/rh-avatar/docs/20-guidelines.md
+++ b/elements/rh-avatar/docs/20-guidelines.md
@@ -18,7 +18,7 @@
 
   {% example palette="light",
               alt="Image of all avatar thumbnail sizes and their pixel values underneath",
-              src="../avatar-usage-sizes.png" %}
+              src="../avatar-usage-sizes.png" %}{% endexample %}
 
   | Variation and range  | Use case                                                  |
   | -------------------- | --------------------------------------------------------- |
@@ -34,7 +34,7 @@
 
   {% example palette="light",
               alt="Image of three job details text, ranging from short to long",
-              src="../avatar-writing-content.png" %}
+              src="../avatar-writing-content.png" %}{% endexample %}
 
 
 ## Layout
@@ -46,14 +46,14 @@
 
   {% example palette="light",
               alt="Image of two avatar groups; one is horizontally centered and the other is vertically centered",
-              src="../avatar-usage-alignment.png" %}
+              src="../avatar-usage-alignment.png" %}{% endexample %}
 
 ### Stacking
   There is `48px` of space when avatar groups are stacked vertically.
 
   {% example palette="light",
               alt="Image of three avatar groups stacked vertically with 48 pixel of space in between",
-              src="../avatar-usage-stacking.png" %}
+              src="../avatar-usage-stacking.png" %}{% endexample %}
 
 
 ## Responsive design
@@ -62,13 +62,13 @@
 
   {% example palette="none",
               alt="Image of two avatar groups used on large breakpoints; one is aligned left and the other is aligned in the center",
-              src="../avatar-breakpoints-large.png" %}
+              src="../avatar-breakpoints-large.png" %}{% endexample %}
 
 ### Small breakpoints
 
   {% example palette="none",
               alt="Image of four avatar groups used on small breakpoints; two are aligned left and the other two are aligned in the center",
-              src="../avatar-breakpoints-small.png" %}
+              src="../avatar-breakpoints-small.png" %}{% endexample %}
 
 ### Line breaks
 
@@ -77,7 +77,7 @@
 
   {% example palette="light",
               alt="Image of two avatar groups with specs on top; one has two lines and the other has five lines",
-              src="../avatar-line-breaks.png" %}
+              src="../avatar-line-breaks.png" %}{% endexample %}
 
 
 ## Best practices
@@ -88,7 +88,7 @@
 
   {% example palette="wrong",
               alt="Image of a square avatar thumbnail which is incorrect usage",
-              src="../avatar-best-practice-1.png" %}
+              src="../avatar-best-practice-1.png" %}{% endexample %}
 
 ### Light theme thumbnail
 
@@ -96,7 +96,7 @@
 
   {% example palette="wrong",
               alt="Image of a light theme avatar thumbnail placed on a black background which is incorrect usage",
-              src="../avatar-best-practice-2.png" %}
+              src="../avatar-best-practice-2.png" %}{% endexample %}
 
 ### Icon vs. avatar thumbnail
 
@@ -104,5 +104,5 @@
 
   {% example palette="wrong",
               alt="Image of an icon and avatar thumbnail right next to each other",
-              src="../avatar-best-practice-3.png" %}
+              src="../avatar-best-practice-3.png" %}{% endexample %}
 

--- a/elements/rh-badge/docs/00-overview.md
+++ b/elements/rh-badge/docs/00-overview.md
@@ -3,7 +3,7 @@
 {% example palette="light",
           width=143,
           alt="Two badges; from left to right, one badge has a light gray background with a dark gray counter number and the other badge has a blue background with a white counter number",
-          src="./badge-sample-element.png" %}
+          src="./badge-sample-element.png" %}{% endexample %}
 
 
 ## Sample component

--- a/elements/rh-badge/docs/10-style.md
+++ b/elements/rh-badge/docs/10-style.md
@@ -4,7 +4,7 @@ A badge is number text on a pill background used to reflect the count of somethi
 ### Anatomy 
 {% example palette="light",
           alt="Anatomy of a badge with annotations; number 1 is pointing to the container and number 2 is pointing to the counter number",
-          src="../badge-anatomy.png" %}
+          src="../badge-anatomy.png" %}{% endexample %}
 
 1. Container
 2. Counter number
@@ -15,19 +15,19 @@ A badge is available in the light theme only.
 
 {% example palette="light",
           alt="Light theme badges",
-          src="../badge-theme-light.png" %}
+          src="../badge-theme-light.png" %}{% endexample %}
 
 ## Configuration 
 All badges have the same height and border radius.
 
 {% example palette="light",
           alt="How a badge is constructed showing border radius and height details",
-          src="../badge-configuration.png" %}
+          src="../badge-configuration.png" %}{% endexample %}
 
 ## Space and width 
 {% example palette="light",
           alt="Badge spacing and minimum width",
-          src="../badge-space-and-width.png" %}
+          src="../badge-space-and-width.png" %}{% endexample %}
 
 {% spacerTokensTable 
   headline="",

--- a/elements/rh-badge/docs/20-guidelines.md
+++ b/elements/rh-badge/docs/20-guidelines.md
@@ -14,7 +14,8 @@ many readers. Go to the Accessibility page to learn more.
 {% example palette="light",
           alt="Image of neutral, default, success, warning, error, and danger 
           badges in a row",
-          src="../badge-variants.png" %}
+          src="../badge-variants.png" %}{% endexample %}
+#}
 
 | Badge {style="width: 33%%" }             | Name {style="width: 33%%" } | Use case                               |
 | ---------------------------------------- | --------------------------- | -------------------------------------- |
@@ -40,7 +41,7 @@ threshold, using `1,000` or larger will display `999+`.
 
 {% example palette="light",
   alt="Badges with various counter numbers; from left to right, a badge with 1, a badge with 50, a badge with 500, and a badge with 999+",
-  src="../badge-counter-number.png" %}
+  src="../badge-counter-number.png" %}{% endexample %}
 
 
 ## Behavior
@@ -50,7 +51,7 @@ that are made in a toolbar filter or select list.
 
 {% example palette="light",
           alt="A badge used in a filter dropdown and counting three selected checkboxes within a menu",
-          src="../badge-filtering.png" %}
+          src="../badge-filtering.png" %}{% endexample %}
 
 ## Best practices
 
@@ -60,7 +61,7 @@ Do not allow a badge to display a count over 999.
 
 {% example palette="wrong",
           alt="A badge counting to 1,00,000 which is incorrect usage",
-          src="../badge-best-practice-1.png" %}
+          src="../badge-best-practice-1.png" %}{% endexample %}
 
 ### Two badges
 
@@ -70,4 +71,4 @@ with the badges.
 
 {% example palette="wrong",
           alt="Two badges with the same counter number, but with different background colors and no other unique visual cues which is incorrect usage",
-          src="../badge-best-practice-2.png" %}
+          src="../badge-best-practice-2.png" %}{% endexample %}

--- a/elements/rh-badge/docs/20-guidelines.md
+++ b/elements/rh-badge/docs/20-guidelines.md
@@ -15,7 +15,6 @@ many readers. Go to the Accessibility page to learn more.
           alt="Image of neutral, default, success, warning, error, and danger 
           badges in a row",
           src="../badge-variants.png" %}{% endexample %}
-#}
 
 | Badge {style="width: 33%%" }             | Name {style="width: 33%%" } | Use case                               |
 | ---------------------------------------- | --------------------------- | -------------------------------------- |

--- a/elements/rh-blockquote/docs/00-overview.md
+++ b/elements/rh-blockquote/docs/00-overview.md
@@ -6,7 +6,7 @@ A blockquote is a styled quotation and citation offset from other text styles on
 {% example palette="light",
            class="centered",
            alt="Image of a blockquote including a quote icon, quotation text, and citation text",
-           src="./blockquote-sample.png" %}
+           src="./blockquote-sample.png" %}{% endexample %}
 
 ## Demo
   View a live version of this component and see how it can be customized.

--- a/elements/rh-blockquote/docs/10-style.md
+++ b/elements/rh-blockquote/docs/10-style.md
@@ -12,7 +12,7 @@ also include the following optional elements:
 {% example palette="light",
            class="centered",
            alt="Anatomy image of a blockquote with numbered annotations",
-           src="../blockquote-anatomy.png" %}
+           src="../blockquote-anatomy.png" %}{% endexample %}
 
 1. Quote icon
 2. Quotation text
@@ -26,7 +26,7 @@ also include the following optional elements:
 {% example palette="light",
            class="centered",
            alt="Image of two blockquotes, default size on the left and large size on the right",
-           src="../blockquote-style-sizes.png" %}
+           src="../blockquote-style-sizes.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -52,7 +52,7 @@ A blockquote is available in both light and dark themes.
 {% example palette="light",
            class="centered",
            alt="Image of a light theme blockquote, red quote icon, black quotation text, and dark gray citation text",
-           src="../blockquote-theme-light.png" %}
+           src="../blockquote-theme-light.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -71,7 +71,7 @@ A blockquote is available in both light and dark themes.
 {% example palette="darkest",
            class="centered",
            alt=" Image of a dark theme blockquote, red quote icon, white quotation text, and light gray citation text",
-           src="../blockquote-theme-dark.png" %}
+           src="../blockquote-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -90,12 +90,12 @@ A blockquote is available in both light and dark themes.
 {% example palette="light",
            class="centered",
            alt="Image of two blockquotes, a red emphasis border on the left and a black emphasis border on the right",
-           src="../blockquote-emphasis-theme-light.png" %}
+           src="../blockquote-emphasis-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
            class="centered",
            alt="Image of two blockquotes, a red emphasis border on the left and a black emphasis border on the right",
-           src="../blockquote-emphasis-theme-dark.png" %}
+           src="../blockquote-emphasis-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -113,12 +113,12 @@ A blockquote is available in both light and dark themes.
 {% example palette="light",
            class="centered",
            alt="Image of two blockquotes, both with red title text and black header text",
-           src="../blockquote-title-heading-theme-light.png" %}
+           src="../blockquote-title-heading-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
            class="centered",
            alt="Image of two blockquotes, both with red title text and white header text",
-           src="../blockquote-title-heading-theme-dark.png" %}
+           src="../blockquote-title-heading-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -138,7 +138,7 @@ The base elements in both sizes are stacked and left aligned by default, but the
 {% example palette="light",
            class="centered",
            alt="Image of four blockquotes, two are left aligned and two are vertically centered, the quote icon is 20px tall",
-           src="../blockquote-configuration.png" %}
+           src="../blockquote-configuration.png" %}{% endexample %}
 
 ### Order
 A blockquote was designed to be read from top to bottom. If certain optional elements are included, the order will change.
@@ -146,7 +146,7 @@ A blockquote was designed to be read from top to bottom. If certain optional ele
 {% example palette="light",
            class="centered",
            alt="Image of a blockquote with numbers 1 - 4 on the right side going from top to bottom",
-           src="../blockquote-configuration.png" %}
+           src="../blockquote-configuration.png" %}{% endexample %}
 
 1. Logo or text (always ordered first if included)
 2. Quotate icon (always included and ordered first if there is no logo or text)
@@ -160,7 +160,7 @@ Citation text has specific styles applied to it.
 {% example palette="light",
            class="centered",
            alt="Image of three citation text examples",
-           src="../blockquote-configuration-citation.png" %}
+           src="../blockquote-configuration-citation.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -182,7 +182,7 @@ Space values are the same in both sizes and on all breakpoints.
 {% example palette="light",
            class="centered",
            alt="Image of four blockquotes with spacing values in between",
-           src="../blockquote-space.png" %}
+           src="../blockquote-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
   headline="",

--- a/elements/rh-blockquote/docs/20-guidelines.md
+++ b/elements/rh-blockquote/docs/20-guidelines.md
@@ -7,7 +7,7 @@ Use the Default size for larger amounts of text and the Large size for smaller a
 {% example palette="light",
            class="centered",
            alt="Image of two blockquotes, default size on the left and large size on the right with green check icons below",
-           src="../blockquote-usage-sizes.png" %}
+           src="../blockquote-usage-sizes.png" %}{% endexample %}
 
 ## Alignment
 Both blockquote sizes can be left or center aligned.
@@ -20,7 +20,7 @@ Both blockquote sizes can be left or center aligned.
 {% example palette="light",
            class="centered",
            alt="Image of two blockquotes, default and large sizes both vertically centered",
-           src="../blockquote-alignment.png" %}
+           src="../blockquote-alignment.png" %}{% endexample %}
          
 ## Variations
 A variety of extras including an emphasis border, logo, and text styles may be added to a blockquote.
@@ -29,23 +29,23 @@ A variety of extras including an emphasis border, logo, and text styles may be a
 {% example palette="light",
            class="centered",
            alt="Image of a light theme blockquote with red emphasis border",
-           src="../blockquote-variations-emphasis-a-theme-light.png" %}
+           src="../blockquote-variations-emphasis-a-theme-light.png" %}{% endexample %}
 
 {% example palette="light",
            class="centered",
            alt="Image of two light theme blockquotes, left example is default size with logo and right example is default size with title text and heading text",
-           src="../blockquote-variations-emphasis-b-theme-light.png" %}  
+           src="../blockquote-variations-emphasis-b-theme-light.png" %}{% endexample %}  
 
 ### Dark theme
 {% example palette="darkest",
            class="centered",
            alt="Image of a dark theme blockquote with red emphasis border",
-           src="../blockquote-variations-emphasis-a-theme-dark.png" %}
+           src="../blockquote-variations-emphasis-a-theme-dark.png" %}{% endexample %}
 
 {% example palette="darkest",
            class="centered",
            alt="Image of two dark theme blockquotes, left example is default size with logo and right example is default size with title text and heading text",
-           src="../blockquote-variations-emphasis-b-theme-dark.png" %}  
+           src="../blockquote-variations-emphasis-b-theme-dark.png" %}{% endexample %}  
 
 ### Other elements
 Other elements including a video or card may also be added to a blockquote. They are aligned to the top of the quote icon if included.
@@ -53,12 +53,12 @@ Other elements including a video or card may also be added to a blockquote. They
 {% example palette="none",
            class="centered",
            alt="Image of blockquote with video to the right",
-           src="../blockquote-other-elements-video.png" %}
+           src="../blockquote-other-elements-video.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of blockquote with card to the right",
-           src="../blockquote-other-elements-card.png" %}             
+           src="../blockquote-other-elements-card.png" %}{% endexample %}             
 
 ## Layout
 ### Minimum width
@@ -67,12 +67,12 @@ A minimum width is hard to determine because a blockquote can be placed in a var
 {% example palette="none",
            class="centered",
            alt="Image of default size blockquote left aligned with a minimum width of 450px",
-           src="../blockquote-min-width-a.png" %}
+           src="../blockquote-min-width-a.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of large size blockquote vertically centered with a minimum width of 450px",
-           src="../blockquote-min-width-b.png" %}
+           src="../blockquote-min-width-b.png" %}{% endexample %}
 
 ### Maximum width
 The maximum width of a blockquote anywhere is <code>750px</code> to avoid reader fatigue.
@@ -80,12 +80,12 @@ The maximum width of a blockquote anywhere is <code>750px</code> to avoid reader
 {% example palette="none",
            class="centered",
            alt="Image of default size blockquote left aligned with a maximum width of 750px",
-           src="../blockquote-max-width-a.png" %}
+           src="../blockquote-max-width-a.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of large size blockquote vertically centered with a maximum width of 750px",
-           src="../blockquote-max-width-b.png" %}
+           src="../blockquote-max-width-b.png" %}{% endexample %}
 
 ### Card
 A Default size blockquote can be placed in a card if the text is short enough. Otherwise, keep blockquotes with lots of text in the page layout to avoid readability issues. A blockquote will get taller as containers and breakpoints get smaller, so take that into consideration as well.
@@ -93,7 +93,7 @@ A Default size blockquote can be placed in a card if the text is short enough. O
 {% example palette="none",
            class="centered",
            alt="Image of blockquotes in two cards, card on the left shows the default size and a success icon and the card on the right shows the large size and a warning icon",
-           src="../blockquote-usage-card.png" %}
+           src="../blockquote-usage-card.png" %}{% endexample %}
 
 ### Other elements
 When other elements are used with blockquotes, they are placed on the right. Some elements like a video will cause the width of a blockquote to decrease or increase.
@@ -106,12 +106,12 @@ When other elements are used with blockquotes, they are placed on the right. Som
 {% example palette="none",
            class="centered",
            alt="Image of blockquote with video to the right and a grid overlaid on top",
-           src="../blockquote-other-elements-video-grid.png" %}
+           src="../blockquote-other-elements-video-grid.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of blockquote with card to the right and a grid overlaid on top",
-           src="../blockquote-other-elements-card-grid.png" %} 
+           src="../blockquote-other-elements-card-grid.png" %}{% endexample %} 
 
 ## Responsive design
 As breakpoints get smaller, blockquote text sizes will be reduced based on the mobile typography scale.
@@ -120,64 +120,64 @@ As breakpoints get smaller, blockquote text sizes will be reduced based on the m
 {% example palette="none",
            class="centered",
            alt="Image of a default size blockquote for desktop",
-           src="../blockquote-default-desktop.png" %}
+           src="../blockquote-default-desktop.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a default size blockquote for tablet",
-           src="../blockquote-default-tablet.png" %}
+           src="../blockquote-default-tablet.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a default size blockquote for large mobile screens",
-           src="../blockquote-default-mobile-large.png" %}
+           src="../blockquote-default-mobile-large.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a default size blockquote for small mobile screens",
-           src="../blockquote-default-mobile-small.png" %}            
+           src="../blockquote-default-mobile-small.png" %}{% endexample %}            
 
 ### Large size
 {% example palette="none",
            class="centered",
            alt="Image of a large size blockquote for desktop",
-           src="../blockquote-large-desktop.png" %}
+           src="../blockquote-large-desktop.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a large size blockquote for tablet",
-           src="../blockquote-large-tablet.png" %}
+           src="../blockquote-large-tablet.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a large size blockquote for large mobile screens",
-           src="../blockquote-large-mobile-large.png" %}
+           src="../blockquote-large-mobile-large.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a large size blockquote for small mobile screens",
-           src="../blockquote-large-mobile-small.png" %}  
+           src="../blockquote-large-mobile-small.png" %}{% endexample %}  
 
 ### Other elements
 {% example palette="none",
            class="centered",
            alt="Image of a blockquote with video for desktop",
-           src="../blockquote-other-elements-desktop.png" %}
+           src="../blockquote-other-elements-desktop.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a blockquote with video for tablet",
-           src="../blockquote-other-elements-tablet.png" %}
+           src="../blockquote-other-elements-tablet.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a blockquote with video for large mobile screens",
-           src="../blockquote-other-elements-mobile-large.png" %}
+           src="../blockquote-other-elements-mobile-large.png" %}{% endexample %}
 
 {% example palette="none",
            class="centered",
            alt="Image of a blockquote with video for small mobile screens",
-           src="../blockquote-other-elements-mobile-small.png" %}  
+           src="../blockquote-other-elements-mobile-small.png" %}{% endexample %}  
 
 
 ## Best practices
@@ -187,7 +187,7 @@ The quote icon and citation text must always be included.
 {% example palette="wrong",
            class="centered",
            alt="Image of two blockquotes both missing elements which is incorrect usage",
-           src="../blockquote-best-practice-1.png" %} 
+           src="../blockquote-best-practice-1.png" %}{% endexample %} 
 
 ### Readability issues
 Blockquotes that are too thin are sometimes hard to read.
@@ -195,7 +195,7 @@ Blockquotes that are too thin are sometimes hard to read.
 {% example palette="wrong",
            class="centered",
            alt="Image of two very thin blockquotes which is incorrect usage",
-           src="../blockquote-best-practice-2.png" %} 
+           src="../blockquote-best-practice-2.png" %}{% endexample %} 
 
 ### Adding an emphasis border
 Do not add an emphasis border to a centered blockquote.
@@ -203,7 +203,7 @@ Do not add an emphasis border to a centered blockquote.
 {% example palette="wrong",
            class="centered",
            alt="Image of a large size blockquote with an emphasis border on the left",
-           src="../blockquote-best-practice-3.png" %}  
+           src="../blockquote-best-practice-3.png" %}{% endexample %}  
 
 ### Centered blockquotes
 Do not place any elements near centered blockquotes.
@@ -211,4 +211,4 @@ Do not place any elements near centered blockquotes.
 {% example palette="wrong",
            class="centered",
            alt="Image of a vertically centered blockquote with a placeholder element next to it which is incorrect usage",
-           src="../blockquote-best-practice-4.png" %}                       
+           src="../blockquote-best-practice-4.png" %}{% endexample %}                       

--- a/elements/rh-button/docs/00-overview.md
+++ b/elements/rh-button/docs/00-overview.md
@@ -3,7 +3,7 @@
 
 {% example palette="light",
           alt="Image of Danger, Primary, Secondary, Tertiary, and Link buttons in the first row and Play and Close buttons in the second row",
-          src="./button-sample.png" %}
+          src="./button-sample.png" %}{% endexample %}
 
 
 ## Sample component

--- a/elements/rh-button/docs/10-style.md
+++ b/elements/rh-button/docs/10-style.md
@@ -7,7 +7,7 @@ used on its own or grouped with other buttons.
 
 {% example palette="light",
           alt=" Anatomy image of buttons with numbered annotations",
-          src="../button-anatomy.png" %}
+          src="../button-anatomy.png" %}{% endexample %}
 
 1) Text
 2) Container
@@ -26,11 +26,11 @@ Buttons are available in both light and dark themes.
 
 {% example palette="light",
       alt=" Image of light theme Danger, Primary, Secondary, Tertiary, Link, Play, and Close buttons",
-      src="../button-theme-light.png" %}
+      src="../button-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
       alt=" Image of dark theme Danger, Primary, Secondary, Tertiary, Link, Play, and Close buttons",
-      src="../button-theme-dark.png" %}
+      src="../button-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -61,7 +61,7 @@ or small the image gets.
 
 {% example palette="light",
           alt=" Image of buttons and various specs like border radius, height, icon size, width, alignment, placement, and more",
-          src="../button-configuration.png" %}
+          src="../button-configuration.png" %}{% endexample %}
 
 ## Space
 
@@ -74,7 +74,7 @@ Buttons include a custom `6px` spacer, do not use it anywhere else.
 
 {% example palette="light",
           alt=" Image of Danger, Primary, Secondary, Tertiary, Link, and Close buttons with spacing values in between",
-          src="../button-space.png" %}
+          src="../button-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
   headline="",
@@ -92,11 +92,11 @@ an element or pattern.
 
 {% example palette="light",
           alt=" Image of light theme button hover states",
-          src="../button-interaction-state-hover-theme-light.png" %}
+          src="../button-interaction-state-hover-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
           alt=" Image of dark theme button hover states",
-          src="../button-interaction-state-hover-theme-dark.png" %}
+          src="../button-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -121,11 +121,11 @@ The Focus state has the same styles as the Hover state.
 
 {% example palette="light",
           alt=" Image of light theme button focus states",
-          src="../button-interaction-state-focus-theme-light.png" %}
+          src="../button-interaction-state-focus-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
           alt=" Image of dark theme button focus states",
-          src="../button-interaction-state-focus-theme-dark.png" %}
+          src="../button-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -143,11 +143,11 @@ The Active state has the same styles as the Hover state.
 
 {% example palette="light",
           alt=" Image of light theme button active states",
-          src="../button-interaction-state-active-theme-light.png" %}
+          src="../button-interaction-state-active-theme-light.png" %}{% endexample %}
 
 {% example palette="light",
           alt=" Image of dark theme button active states",
-          src="../button-interaction-state-active-theme-dark.png" %}
+          src="../button-interaction-state-active-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 

--- a/elements/rh-button/docs/20-guidelines.md
+++ b/elements/rh-button/docs/20-guidelines.md
@@ -24,7 +24,7 @@ consistently so they communicate the correct actions.
 
 {% example palette="light",
           alt="Image of the seven available button variant",
-          src="../button-variants.png" %}
+          src="../button-variants.png" %}{% endexample %}
 
 | Variant {style="width: 25%" } | Use case                                                                                                                                                                                                 |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -47,7 +47,7 @@ image or photo.
 
 {% example palette="light",
           alt="Image of play button examples; a video thumbnail on the left and a text layout on the right",
-          src="../button-usage-play.png" %}
+          src="../button-usage-play.png" %}{% endexample %}
 
 ### Close button
 
@@ -56,7 +56,7 @@ Close buttons are mostly found in [dialogs](/elements/dialog/).
 
 {% example palette="none",
           alt="Image of a dialog with a close button in the top right corner",
-          src="../button-usage-close.png" %}
+          src="../button-usage-close.png" %}{% endexample %}
 
 ### Disabled
 
@@ -66,7 +66,7 @@ buttons do not include a disabled state.
 
 {% example palette="light",
           alt="Image of five disabled buttons not including play and close buttons, underneath is a dropdown with a disabled button",
-          src="../button-usage-disabled.png" %}
+          src="../button-usage-disabled.png" %}{% endexample %}
 
 ## Writing content
 
@@ -93,7 +93,7 @@ that matches what users will see when they arrive at their location.
 
 {% example palette="light",
           alt="Image of link button text labels",
-          src="../button-link-text-labels.png" %}
+          src="../button-link-text-labels.png" %}{% endexample %}
 
 ### Button vs. call to action text labels
 
@@ -102,7 +102,7 @@ call to action text labels are written to entice users to select a link.
 
 {% example palette="light",
           alt="Image of two buttons on the left and two calls to action on the right",
-          src="../button-vs-cta-text-labels.png" %}
+          src="../button-vs-cta-text-labels.png" %}{% endexample %}
 
 ### Character and word count
 
@@ -128,7 +128,7 @@ elements are stacked vertically
 
 {% example palette="none",
           alt="Image of buttons used in a dialog and a form",
-          src="../button-layout-placement.png" %}
+          src="../button-layout-placement.png" %}{% endexample %}
 
 ### Hierarchy
 
@@ -137,7 +137,7 @@ Primary, or Close buttons in the same area.
 
 {% example palette="light",
           alt="Image of buttons grouped by hierarchy from left to right",
-          src="../button-layout-hierarchy.png" %}
+          src="../button-layout-hierarchy.png" %}{% endexample %}
 
 ### Grouping
 
@@ -146,7 +146,7 @@ Group buttons logically into sets based on hierarchy and usage.
 
 {% example palette="light",
           alt="Image of button groups and their hierarchy from left to right",
-          src="../button-layout-grouping.png" %}
+          src="../button-layout-grouping.png" %}{% endexample %}
 
 ### Space in groups
 
@@ -156,7 +156,7 @@ buttons. If buttons are stacked, the spacing between each button should be
 
 {% example palette="light",
           alt="Image of button groups and their horizontal and vertical spacing in between each button",
-          src="../button-layout-spacing.png" %}
+          src="../button-layout-spacing.png" %}{% endexample %}
 
 ## Best practices
 
@@ -166,7 +166,7 @@ Buttons should never have more than one line of text.
 
 {% example palette="wrong",
           alt="Image of a button with two lines of text which is incorrect usage",
-          src="../button-best-practice-1.png" %}
+          src="../button-best-practice-1.png" %}{% endexample %}
 
 ### Multiple buttons
 
@@ -174,7 +174,7 @@ Do not use multiple Danger or Primary buttons in the same area.
 
 {% example palette="wrong",
           alt="Image of two danger and two primary button groups which is incorrect usage",
-          src="../button-best-practice-2.png" %}
+          src="../button-best-practice-2.png" %}{% endexample %}
 
 ### Text labels
 
@@ -182,7 +182,7 @@ Do not write button text labels that are expressive or ambiguous.
 
 {% example palette="wrong",
           alt="Image of two buttons; one has expressive language and the other has ambiguous language which is incorrect usage ",
-          src="../button-best-practice-3.png" %}
+          src="../button-best-practice-3.png" %}{% endexample %}
 
 ### Danger button
 
@@ -190,7 +190,7 @@ Do not use a Danger button for non-destructive purposes.
 
 {% example palette="wrong",
           alt="Image of a search bar using a danger button which is incorrect usage",
-          src="../button-best-practice-4.png" %}
+          src="../button-best-practice-4.png" %}{% endexample %}
 
 ### Button as a call to action
 
@@ -199,5 +199,5 @@ call to action instead.
 
 {% example palette="wrong",
           alt="Image of text styles with a button underneath that resembles a call to action",
-          src="../button-best-practice-5.png" %}
+          src="../button-best-practice-5.png" %}{% endexample %}
 

--- a/elements/rh-button/docs/40-accessibility.md
+++ b/elements/rh-button/docs/40-accessibility.md
@@ -15,7 +15,7 @@ Users should have the ability to navigate to and interact with buttons using the
 {% example palette="light",
           class="inline-flex centered",
           alt="Image of a button group showing focus indicators and tab key labels",
-          src="../button-a11y-keyboard-interactions.png" %}
+          src="../button-a11y-keyboard-interactions.png" %}{% endexample %}
 
 | Key {style="width: 50%" }         | Result                                                    |
 | --------------------------------- | --------------------------------------------------------- |
@@ -29,14 +29,14 @@ Users should have the ability to navigate to and interact with buttons using the
 
 {% example palette="light",
           alt="Image of rows of button groups with numbers; one row has focus indicators only and the other has focus indicators and a tooltip",
-          src="../button-a11y-focus-order.png" %}
+          src="../button-a11y-focus-order.png" %}{% endexample %}
 
 ## Touch targets
 Buttons in groups are adequately spaced for optimal touch targets.
 
 {% example palette="light",
           alt="Image of button group with touch targets on top of each button",
-          src="../button-a11y-touch-targets.png" %}
+          src="../button-a11y-touch-targets.png" %}{% endexample %}
 
 ## Screen reader guidelines
 

--- a/elements/rh-card/docs/00-overview.md
+++ b/elements/rh-card/docs/00-overview.md
@@ -6,7 +6,7 @@
   {% example palette="light",
              width=360,
              alt="Example of a card element",
-             src="card.svg" %}
+             src="card.svg" %}{% endexample %}
 
 
 ## Demos

--- a/elements/rh-card/docs/10-style.md
+++ b/elements/rh-card/docs/10-style.md
@@ -8,7 +8,7 @@
              width=599,
              style="margin-block:var(--rh-space-2xl);",
              alt="A breakdown of the parts of a card",
-             src="../card-style.svg" %}
+             src="../card-style.svg" %}{% endexample %}
 
 
 ## Theme
@@ -17,13 +17,13 @@
              class="inline-flex centered",
              width=784,
              alt="Card in light theme",
-             src="../card-theme-light.svg" %}
+             src="../card-theme-light.svg" %}{% endexample %}
 
   {% example palette="darkest",
              class="inline-flex centered",
              width=784,
              alt="Card in dark theme",
-             src="../card-theme-dark.svg" %}
+             src="../card-theme-dark.svg" %}{% endexample %}
 
 ### Color
   Cards are secondary layouts that shouldn’t command too much attention and 
@@ -38,7 +38,7 @@
                  class="centered",
                  width=242,
                  alt="White card colors",
-                 src="../card-color-light-white.svg" %}
+                 src="../card-color-light-white.svg" %}{% endexample %}
       <figcaption class="footnote">
         A white card with a light gray border is the most common use case in the 
         light theme
@@ -49,7 +49,7 @@
                  class="centered",
                  width=242,
                  alt="Gray card colors",
-                 src="../card-color-light-gray.svg" %}
+                 src="../card-color-light-gray.svg" %}{% endexample %}
       <figcaption class="footnote">
         A light gray card without a border can also be used as an alternate 
         option
@@ -60,7 +60,7 @@
                  class="centered",
                  width=242,
                  alt="Black card colors",
-                 src="../card-color-dark-black.svg" %}
+                 src="../card-color-dark-black.svg" %}{% endexample %}
       <figcaption class="footnote">
         A black card with a dark gray border is the most common use case in the 
         dark theme
@@ -71,7 +71,7 @@
                  class="centered",
                  width=242,
                  alt="Dark theme gray card colors",
-                 src="../card-color-dark-gray.svg" %}
+                 src="../card-color-dark-gray.svg" %}{% endexample %}
      <figcaption class="footnote">
        A dark gray card without a border can also be used as an alternate option
      </figcaption>
@@ -88,12 +88,13 @@
                class="centered",
                width=360,
                alt="Example of a card layout",
-               src="../card-layout-1.svg" %}
+               src="../card-layout-1.svg" %}{% endexample %}
+
     {% example palette="light",
                class="centered",
                width=360,
                alt="Anatomy of a card layout",
-               src="../card-layout-2.svg" %}
+               src="../card-layout-2.svg" %}{% endexample %}
   </div>
 
 ### Header
@@ -121,7 +122,7 @@
       width=784,
       alt="Card layout on desktop",
       src="../card-layout-desktop.svg"
-  %}
+  %}{% endexample %}
 
 ### Small screens
   {% example 
@@ -129,7 +130,7 @@
       width=360,
       alt="Card layout on mobile",
       src="../card-layout-mobile.svg"
-  %}
+  %}{% endexample %}
 
 
 ## Spacing
@@ -149,12 +150,12 @@
              class="centered",
              width=360,
              alt="Card spacing on desktop",
-             src="../card-spacing-desktop.svg" %}
+             src="../card-spacing-desktop.svg" %}{% endexample %}
 
 ### Mobile
   {% example palette="light",
              class="inline-flex centered",
              width=360,
              alt="Card spacing on mobile",
-             src="../card-spacing-mobile.svg" %}
+             src="../card-spacing-mobile.svg" %}{% endexample %}
 

--- a/elements/rh-card/docs/20-guidelines.md
+++ b/elements/rh-card/docs/20-guidelines.md
@@ -79,7 +79,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=784,
              alt="Grouping of a card",
-             src="../card-usage-grouping.svg" %}
+             src="../card-usage-grouping.svg" %}{% endexample %}
 
   These cards can be grouped together because they have similar styles and 
   content {.footnote}
@@ -99,7 +99,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=664,
              alt="Alternative card usage",
-             src="../card-usage-other.svg" %}
+             src="../card-usage-other.svg" %}{% endexample %}
 
 
 
@@ -111,7 +111,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=872,
              alt="Too many cards",
-             src="../card-bestpractice-1.svg" %}
+             src="../card-bestpractice-1.svg" %}{% endexample %}
 
   Don’t use a primary call to action in any card unless the primary action of a 
   page is positioned inside of that card.
@@ -120,7 +120,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=360,
              alt="Card width error",
-             src="../card-bestpractice-2.svg" %}
+             src="../card-bestpractice-2.svg" %}{% endexample %}
 
   Don’t use multiple calls to action in one card. Instead, distribute them to 
   other cards.
@@ -129,7 +129,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=360,
              alt="Multiple calls to action",
-             src="../card-bestpractice-3.svg" %}
+             src="../card-bestpractice-3.svg" %}{% endexample %}
 
 
 
@@ -144,7 +144,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=784,
              alt="Card height behavior",
-             src="../card-behavior-height.svg" %}
+             src="../card-behavior-height.svg" %}{% endexample %}
 
 ### Interactivity
   If a card contains only one link destination, the entire container and any 
@@ -155,7 +155,7 @@ There are several card variants that can be used for a variety of use cases.
              class="inline-flex centered",
              width=784,
              alt="Card interaction",
-             src="../card-behavior-interaction.svg" %}
+             src="../card-behavior-interaction.svg" %}{% endexample %}
 
 
 ## Interaction states

--- a/elements/rh-code-block/docs/10-overview.md
+++ b/elements/rh-code-block/docs/10-overview.md
@@ -5,7 +5,7 @@
 {% example palette="light",
            width=360,
            alt="Image of a code block with black code text within a light gray container",
-           src="./code-block-sample.png" %}
+           src="./code-block-sample.png" %}{% endexample %}
 
 ## Sample element
 

--- a/elements/rh-code-block/docs/20-style.md
+++ b/elements/rh-code-block/docs/20-style.md
@@ -7,7 +7,7 @@ container.
 
 {% example palette="lightest",
            alt="Image of code block anatomy showing two annotations",
-           src="../code-block-anatomy.png" %}
+           src="../code-block-anatomy.png" %}{% endexample %}
 
 1) Code text
 2) Container
@@ -21,13 +21,13 @@ A code block is available in both light and dark themes.
 
 {% example palette="lightest",
            alt="Image of light theme code block",
-           src="../code-block-theme-light.png" %}
+           src="../code-block-theme-light.png" %}{% endexample %}
 
 ### Dark theme
 
 {% example palette="darkest",
            alt="Image of light dark code block",
-           src="../code-block-theme-dark.png" %}
+           src="../code-block-theme-dark.png" %}{% endexample %}
 
 
 ### Configuration
@@ -36,14 +36,14 @@ Code block text is always horizontally and vertically centered.
 
 {% example palette="lightest",
            alt="Image of a code block showing alignment and border radius specs",
-           src="../code-block-configuration.png" %}
+           src="../code-block-configuration.png" %}{% endexample %}
 
 ## Space
 Container spacing reduces as breakpoints get smaller.
 
 {% example palette="lightest",
            alt="Image of a code block spacing for all breakpoints",
-           src="../code-block-space.png" %}
+           src="../code-block-space.png" %}{% endexample %}
 
 {% spacerTokensTable tokens="--rh-space-lg, --rh-space-xl" %}{% endspacerTokensTable %}
 

--- a/elements/rh-code-block/docs/30-guidelines.md
+++ b/elements/rh-code-block/docs/30-guidelines.md
@@ -14,7 +14,7 @@ width.
 
 {% example palette="lightest",
            alt="Image of fluid width and fixed width code block sizes with text labels below",
-           src="../code-block-sizes.png" %}
+           src="../code-block-sizes.png" %}{% endexample %}
 
 ## Content
 
@@ -23,7 +23,7 @@ of a code block.
 
 {% example palette="lightest",
            alt="Image of two code blocks; one code block is fluid width showing only one line and the other code block is fixed width showing 10 lines",
-           src="../code-block-content.png" %}
+           src="../code-block-content.png" %}{% endexample %}
 
 <hgroup>
 
@@ -34,7 +34,7 @@ of a code block.
 
 {% example palette="none",
            alt="Image of code blocks on desktop and tablet breakpoints",
-           src="../code-block-breakpoints-large.png" %}
+           src="../code-block-breakpoints-large.png" %}{% endexample %}
 
 ### Small breakpoints
 
@@ -42,7 +42,7 @@ Container spacing and code text size reduces as breakpoints get smaller.
 
 {% example palette="none",
            alt="Image of code blocks on large and small mobile breakpoints",
-           src="../code-block-breakpoints-small.png" %}
+           src="../code-block-breakpoints-small.png" %}{% endexample %}
 
 <hgroup>
 
@@ -55,7 +55,7 @@ Do not use a different font than `--rh-font-family-code`.
 
 {% example palette="wrong",
            alt="Image of a code block showing the Red Hat Text font used for code text which is incorrect usage",
-           src="../code-block-best-practice-1.png" %}
+           src="../code-block-best-practice-1.png" %}{% endexample %}
 
 ### Different styling
 
@@ -63,4 +63,4 @@ Do not change any of the code block styling.
 
 {% example palette="wrong",
            alt="Image of a code block showing different styles which is incorrect usage",
-           src="../code-block-best-practice-2.png" %}
+           src="../code-block-best-practice-2.png" %}{% endexample %}

--- a/elements/rh-cta/docs/00-overview.md
+++ b/elements/rh-cta/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 {% example palette="light",
             alt="Image of variants including Primary (red background and white text), Secondary (black border and black text), Brick (light gray border and blue text), and Default (blue text and blue icon)",
-            src="./cta-sample.png" %}
+            src="./cta-sample.png" %}{% endexample %}
 
 ## Sample element
 

--- a/elements/rh-cta/docs/10-style.md
+++ b/elements/rh-cta/docs/10-style.md
@@ -6,7 +6,7 @@ A call to action is text in a container or paired with an icon that directs user
 
 {% example palette="light",
             alt="Anatomy image showing calls to action with various annotation numbers",
-            src="../cta-anatomy.png" %}
+            src="../cta-anatomy.png" %}{% endexample %}
 
 1. Text label
 2. Container
@@ -22,11 +22,11 @@ Calls to action are available in both light and dark themes.
 
 {% example palette="light",
             alt="Image of light theme Primary, Secondary, Brick, Default, and Default video variants",
-            src="../cta-theme-light.png" %}
+            src="../cta-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme Primary, Secondary, Brick, Default, and Default video variants",
-            src="../cta-theme-dark.png" %}
+            src="../cta-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property                          | Light theme      | Dark theme       |
@@ -52,11 +52,11 @@ The Brick variant includes a slot for an icon as well as an extra orientation.
 
 {% example palette="light",
             alt="Image of light theme Brick variants; one with text and no icon, one with an icon on the left of text, and one with an icon on top of text",
-            src="../cta-bricks-theme-light.png" %}
+            src="../cta-bricks-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of light theme Brick variants; one with text and no icon, one with an icon on the left of text, and one with an icon on top of text",
-            src="../cta-bricks-theme-dark.png" %}
+            src="../cta-bricks-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property     | Light theme | Dark theme |
@@ -72,7 +72,7 @@ Primary, Secondary, and Default variants include a slot for a video icon. The vi
 
 {% example palette="light",
             alt="Image of Primary, Secondary, and Default variants with video icons to the right of text",
-            src="../cta-video-variants.png" %}
+            src="../cta-video-variants.png" %}{% endexample %}
 
 ### White variants
 
@@ -80,7 +80,7 @@ Dark theme includes white variants if other variants are duplicative or if they 
 
 {% example palette="darkest",
             alt="Image of Primary and Primary video variants with a white background and black text and Default and Default video variants with white text",
-            src="../cta-white-variants.png" %}
+            src="../cta-white-variants.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property                      | Current Value  |
@@ -99,7 +99,7 @@ All calls to action with a container have the same border radius, but the height
 
 {% example palette="light",
             alt="Image of all variants with various specs like border radius, height, width, alignment, and more",
-            src="../cta-configuration.png" %}
+            src="../cta-configuration.png" %}{% endexample %}
 
 ## Space
 
@@ -107,7 +107,7 @@ Space values are the same on all breakpoints for calls to action. To see space v
 
 {% example palette="light",
             alt="Image of Primary, Secondary, two Brick variants, and two Default variants with spacing values in between",
-            src="../cta-space.png" %}
+            src="../cta-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
     headline='',
@@ -123,15 +123,15 @@ Interaction states are visual representations used to communicate the status of 
 
 {% example palette="light",
             alt="Image of light theme hover states",
-            src="../cta-interaction-state-hover-theme-light.png" %}
+            src="../cta-interaction-state-hover-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme hover states",
-            src="../cta-interaction-state-hover-theme-dark.png" %}
+            src="../cta-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme white variant hover states",
-            src="../cta-interaction-state-hover-white-variants.png" %}
+            src="../cta-interaction-state-hover-white-variants.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property                          | Light theme | Dark theme |
@@ -158,15 +158,15 @@ The Focus state has the same styles as the Hover state.
 
 {% example palette="light",
             alt="Image of light theme focus states",
-            src="../cta-interaction-state-focus-theme-light.png" %}
+            src="../cta-interaction-state-focus-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme focus states",
-            src="../cta-interaction-state-focus-theme-dark.png" %}
+            src="../cta-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme white variant focus states",
-            src="../cta-interaction-state-focus-white-variants.png" %}
+            src="../cta-interaction-state-focus-white-variants.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property           | Light theme | Dark theme |
@@ -184,15 +184,15 @@ The Active state has the same styles as the Hover state.
 
 {% example palette="light",
             alt="Image of light theme active states",
-            src="../cta-interaction-state-active-theme-light.png" %}
+            src="../cta-interaction-state-active-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme active states",
-            src="../cta-interaction-state-active-theme-dark.png" %}
+            src="../cta-interaction-state-active-theme-dark.png" %}{% endexample %}
 
 {% example palette="darkest",
             alt="Image of dark theme white variant active states",
-            src="../cta-interaction-state-active-white-variants.png" %}
+            src="../cta-interaction-state-active-white-variants.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property           | Light theme | Dark theme |

--- a/elements/rh-cta/docs/20-guidelines.md
+++ b/elements/rh-cta/docs/20-guidelines.md
@@ -16,7 +16,7 @@ Each call to action has a specific function and the design of each variant signa
 
 {% example palette="light",
             alt="Image of the Primary, Secondary, Brick, and Default variants with descriptive text labels below",
-            src="../cta-variants.png" %}
+            src="../cta-variants.png" %}{% endexample %}
 
 | Variant     | Use case                                                                                                     |
 | ------------| -------------------------------------------------------------------------------------------------------------|
@@ -34,7 +34,7 @@ To indicate that a link is currently unavailable, calls to action can become dis
 
 {% example palette="light",
             alt="Image of disabled Primary, Secondary, Brick, and Default variants",
-            src="../cta-disabled.png" %}
+            src="../cta-disabled.png" %}{% endexample %}
 
 ### Brick icons
 
@@ -42,7 +42,7 @@ When grouping Brick variants, icons can be paired with text labels to communicat
 
 {% example palette="light",
             alt="Image of Brick variants with an icon on the left of text and on top of text",
-            src="../cta-brick-icons.png" %}
+            src="../cta-brick-icons.png" %}{% endexample %}
 
 ## Writing content
 
@@ -61,7 +61,7 @@ Call to action text labels should be more action-oriented than button text label
 
 {% example palette="light",
            alt="Image of Default variants showing how to incorrectly and correctly write text labels",
-           src="../cta-text-labels.png" %}
+           src="../cta-text-labels.png" %}{% endexample %}
 
 ### Clarity of language
   
@@ -70,7 +70,7 @@ help our users make informed decisions.
 
 {% example palette="light",
            alt="Image of how to incorrectly and correctly use clear and straightforward language",
-           src="../cta-clarity-of-language.png" %}
+           src="../cta-clarity-of-language.png" %}{% endexample %}
 
 ### Long text labels
 
@@ -78,7 +78,7 @@ Users do not want to spend more time reading than necessary, so write text label
 
 {% example palette="light",
         alt="Image of comparing very long and shortened text labels",
-        src="../cta-long-text-labels-1.png" %}
+        src="../cta-long-text-labels-1.png" %}{% endexample %}
 
 Long text labels will break to two lines on small breakpoints or when translated to certain languages. This can be avoided by writing less text.
 
@@ -88,7 +88,7 @@ The arrow icon in the Default variant should always be connected to at least one
 
 {% example palette="light",
         alt="Image of Primary, Default, and Brick variants within a small breakpoint showing each text label breaking to two lines",
-        src="../cta-long-text-labels-2.png" %}
+        src="../cta-long-text-labels-2.png" %}{% endexample %}
 
 ### Call to action vs. button text labels
 
@@ -96,7 +96,7 @@ Call to action text labels are written to entice users to select a link whereas 
 
 {% example palette="light",
         alt="Image of comparing text labels in calls to action versus text labels in buttons",
-        src="../cta-call-to-action-vs-button-text-labels.png" %}
+        src="../cta-call-to-action-vs-button-text-labels.png" %}{% endexample %}
 
 ### Character count
 
@@ -117,7 +117,7 @@ Calls to action are ordered by hierarchy with the Primary variant being the most
 
 {% example palette="light",
             alt="Image of calls to action hierarchy and usage guidance",
-            src="../cta-layout-hierarchy.png" %}
+            src="../cta-layout-hierarchy.png" %}{% endexample %}
 
 ### Placement
 
@@ -125,11 +125,11 @@ Calls to action can be placed in a variety of layouts including cards, grids, li
 
 {% example palette="light",
             alt="Image of calls to action used in context including under a text block and within a card",
-            src="../cta-placement-examples-1.png" %}
+            src="../cta-placement-examples-1.png" %}{% endexample %}
 
 {% example palette="light",
             alt="Image of calls to action used in context including within a grid and in a list",
-            src="../cta-placement-examples-2.png" %}
+            src="../cta-placement-examples-2.png" %}{% endexample %}
 
 ### Grouping
 
@@ -137,7 +137,7 @@ Call to action variants are ordered by hierarchy with Primary being the highest.
 
 {% example palette="light",
             alt="Image of call to action groups and their hierarchy from left to right",
-            src="../cta-layout-grouping.png" %}
+            src="../cta-layout-grouping.png" %}{% endexample %}
 
 ### Bricks
 
@@ -149,7 +149,7 @@ Long text labels will break to two lines, therefore write no more than **two or 
 
 {% example palette="light",
             alt="Image of Brick variants stretched to fit a variety of grid formations",
-            src="../cta-layout-bricks.png" %}
+            src="../cta-layout-bricks.png" %}{% endexample %}
 
 ### Space in groups
   
@@ -161,19 +161,19 @@ Spacing guidance between calls to action and text or other elements are on the S
 
 {% example palette="light",
             alt="Image of 24px spacers in between Primary and Secondary variants",
-            src="../cta-layout-space-in-groups-1.png" %}
+            src="../cta-layout-space-in-groups-1.png" %}{% endexample %}
 
 Horizontal and vertical spacing between the Default variant is `24px`.
 
 {% example palette="light",
             alt="Image of 24px spacers in between Default variants",
-            src="../cta-layout-space-in-groups-2.png" %}
+            src="../cta-layout-space-in-groups-2.png" %}{% endexample %}
 
 Horizontal and vertical spacing between Brick variants should be the same as grid gutters.
 
 {% example palette="light",
             alt="Image of a variety of space values in between Brick variants",
-            src="../cta-layout-space-in-groups-3.png" %}
+            src="../cta-layout-space-in-groups-3.png" %}{% endexample %}
 
 ## Behavior
 
@@ -183,7 +183,7 @@ A Brick variant can hide and reveal a panel of content when selected like an [ac
 
 {% example palette="none",
             alt="Image of Brick variants with a panel open showing a variety of styles and content formations",
-            src="../cta-bricks-hide-and-reveal.png" %}
+            src="../cta-bricks-hide-and-reveal.png" %}{% endexample %}
 
 ## Responsive design
 
@@ -191,11 +191,11 @@ On large breakpoints, calls to action are ordered by hierarchy from left to righ
 
 {% example palette="none",
             alt="Image of calls to action in a layout on a large breakpoint showing them all in one row",
-            src="../cta-breakpoints-large.png" %}
+            src="../cta-breakpoints-large.png" %}{% endexample %}
 
 {% example palette="none",
             alt="Image of calls to action in a layout on a small breakpoint showing two variants in one row and one variant in a second row",
-            src="../cta-breakpoints-small.png" %}
+            src="../cta-breakpoints-small.png" %}{% endexample %}
 
 ## Best practices
 
@@ -205,7 +205,7 @@ Do not change the styles of any variant.
 
 {% example palette="wrong",
             alt="Image of several variants with brand new styles which is incorrect usage",
-            src="../cta-best-practice-1.png" %}
+            src="../cta-best-practice-1.png" %}{% endexample %}
 
 ### Primary variants
 
@@ -213,7 +213,7 @@ Do not use more than one Primary variant on any page.
 
 {% example palette="wrong",
             alt="Image of two Primary variants in one row which is incorrect usage",
-            src="../cta-best-practice-2.png" %}
+            src="../cta-best-practice-2.png" %}{% endexample %}
 
 ### Brick variants
 
@@ -221,7 +221,7 @@ Do not group different Brick variants together, use one variant per grid.
 
 {% example palette="wrong",
             alt="Image of Brick variants in one row with and without icons which is incorrect usage",
-            src="../cta-best-practice-3.png" %}
+            src="../cta-best-practice-3.png" %}{% endexample %}
 
 
 ### Grouping
@@ -230,7 +230,7 @@ Do not group more than two different variants together.
 
 {% example palette="wrong",
             alt="Image of Primary, Secondary, and Default variants in one row which is incorrect usage",
-            src="../cta-best-practice-4.png" %}
+            src="../cta-best-practice-4.png" %}{% endexample %}
 
 ### Changing heirarchy
 
@@ -242,7 +242,7 @@ Hierarchy should be reversed when using right-to-left languages.
 
 {% example palette="wrong",
             alt="Image of the Primary variant last in a row which is incorrect usage",
-            src="../cta-best-practice-5.png" %}
+            src="../cta-best-practice-5.png" %}{% endexample %}
 
 ### Too many options
 
@@ -250,7 +250,7 @@ Do not group more than three variants together otherwise the risk of [choice par
 
 {% example palette="wrong",
             alt="Image of two rows of calls to action with four variants in each row which is incorrect usage",
-            src="../cta-best-practice-6.png" %}
+            src="../cta-best-practice-6.png" %}{% endexample %}
 
 ### Stretching
 
@@ -258,6 +258,6 @@ Do not add extra spacing or stretch the width of any variant except for Bricks.
 
 {% example palette="wrong",
             alt="Image of Primary and Secondary variants stretched which is incorrect usage",
-            src="../cta-best-practice-7.png" %}
+            src="../cta-best-practice-7.png" %}{% endexample %}
 
 [paralysis]: https://www.shopify.com/partners/blog/choice-paralysis

--- a/elements/rh-cta/docs/40-accessibility.md
+++ b/elements/rh-cta/docs/40-accessibility.md
@@ -4,7 +4,7 @@ Users should have the ability to navigate to and interact with calls to action u
 
 {% example palette="light",
             alt="Image of three groups with different variants showing focus indicators and tab key labels",
-            src="../cta-a11y-keyboard-interactions.png" %}
+            src="../cta-a11y-keyboard-interactions.png" %}{% endexample %}
 
 | Key         | Result                                                            |
 | ------------| ------------------------------------------------------------------|
@@ -21,7 +21,7 @@ A logical focus order helps keyboard users operate our websites. Elements need t
 
 {% example palette="light",
             alt="Image of groups of three variants with numbers one through three moving from left to right and top to bottom",
-            src="../cta-a11y-focus-order.png" %}
+            src="../cta-a11y-focus-order.png" %}{% endexample %}
 
 ## Touch targets
 
@@ -29,7 +29,7 @@ Grouped calls to action are adequately spaced for optimal touch targets.
 
 {% example palette="light",
             alt="Image of groups of variants with touch targets on top of each",
-            src="../cta-a11y-touch-targets.png" %}
+            src="../cta-a11y-touch-targets.png" %}{% endexample %}
 
 ## Screen reader guidelines
 

--- a/elements/rh-dialog/docs/00-overview.md
+++ b/elements/rh-dialog/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 {% example palette="none",
            alt="A dialog container with a black headline, black body text, two blue buttons, and a dark gray close button all on a white background on top of a slightly transparent black background",
-           src="./dialog-sample.png" %}
+           src="./dialog-sample.png" %}{% endexample %}
 
 
 

--- a/elements/rh-dialog/docs/10-style.md
+++ b/elements/rh-dialog/docs/10-style.md
@@ -8,7 +8,7 @@ helps users focus on the dialog content.
 
 {% example palette="light",
            alt="Anatomy of a dialog with lots of annotations pointing to various parts",
-           src="../dialog-anatomy.png" %}
+           src="../dialog-anatomy.png" %}{% endexample %}
 
 1. Backdrop
 2. Container
@@ -25,7 +25,7 @@ A dialog is available in the light theme only.
 
 {% example palette="none",
            alt="Light theme dialog",
-           src="../dialog-theme-light.png" %}
+           src="../dialog-theme-light.png" %}{% endexample %}
 
 ## Configuration
 
@@ -34,7 +34,7 @@ body text section will cause scrolling.
 
 {% example palette="none",
            alt="How a dialog container is constructed showing border radius, region, and scrolling details",
-           src="../dialog-configuration.png" %}
+           src="../dialog-configuration.png" %}{% endexample %}
 
 ## Space
 
@@ -44,13 +44,13 @@ The amount of space in a dialog reduces as breakpoints get smaller.
 
 {% example palette="none",
            alt="A dialog container on a large breakpoint with spacing between all elements",
-           src="../dialog-space-breakpoint-large.png" %}
+           src="../dialog-space-breakpoint-large.png" %}{% endexample %}
 
 ### Small breakpoints
 
 {% example palette="none",
            alt="A dialog container on a small breakpoint with spacing between all elements",
-           src="../dialog-space-breakpoint-small.png" %}
+           src="../dialog-space-breakpoint-small.png" %}{% endexample %}
 
 {% spacerTokensTable 
     headingLevel="4",
@@ -70,7 +70,7 @@ is not interactive so it has no hover state.
 
 {% example palette="none",
            alt="Light theme dialog hover state example",
-           src="../dialog-interaction-state-hover.png" %}
+           src="../dialog-interaction-state-hover.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -84,7 +84,7 @@ is not interactive so it has no hover state.
 
 {% example palette="none",
            alt="Light theme dialog focus state example",
-           src="../dialog-interaction-state-focus.png" %}
+           src="../dialog-interaction-state-focus.png" %}{% endexample %}
 
 {% tokensTable %}           
 
@@ -99,7 +99,7 @@ is not interactive so it has no hover state.
 
 {% example palette="none",
            alt="Light theme dialog active state example",
-           src="../dialog-interaction-state-active.png" %}
+           src="../dialog-interaction-state-active.png" %}{% endexample %}
 
 {% tokensTable %}           
 

--- a/elements/rh-dialog/docs/20-guidelines.md
+++ b/elements/rh-dialog/docs/20-guidelines.md
@@ -34,7 +34,7 @@ like marketing pages.
 
 {% example palette="none",
            alt="A dialog container spanning a 12-column grid that is fixed in the center of the page",
-           src="../dialog-width-fixed.png" %}
+           src="../dialog-width-fixed.png" %}{% endexample %}
 
 ### Full-width
 
@@ -43,7 +43,7 @@ grid like apps or dashboards.
 
 {% example palette="none",
            alt="A dialog container spanning a 6-column fluid grid that takes up the whole screen",
-           src="../dialog-width-full.png" %}
+           src="../dialog-width-full.png" %}{% endexample %}
 
 
 
@@ -63,7 +63,7 @@ actions. When confirming a non-destructive action, do the following:
 
 {% example palette="none",
            alt="Non-destructive confirmation dialog example with a blue primary button",
-           src="../dialog-confirmation-non-destructive.png" %}
+           src="../dialog-confirmation-non-destructive.png" %}{% endexample %}
 
 When confirming a destructive action, do the following.
 
@@ -72,7 +72,7 @@ When confirming a destructive action, do the following.
 
 {% example palette="none",
            alt="Destructive confirmation dialog example with a red primary button",
-           src="../dialog-confirmation-destructive.png" %}
+           src="../dialog-confirmation-destructive.png" %}{% endexample %}
 
 ### Error
 
@@ -82,7 +82,7 @@ and then provide actionable steps toward a solution.
 
 {% example palette="none",
            alt="Error dialog example with a blue primary button",
-           src="../dialog-error.png" %}
+           src="../dialog-error.png" %}{% endexample %}
 
 ### Passive
 
@@ -99,7 +99,7 @@ using a passive dialog, consider the following:
 
 {% example palette="none",
            alt="Passive dialog example with a blue primary button",
-           src="../dialog-passive.png" %}
+           src="../dialog-passive.png" %}{% endexample %}
 
 ### Video player dialog
 
@@ -108,7 +108,7 @@ width and include a close button.
 
 {% example palette="none",
            alt="A dialog video player spanning a 12-column grid with a white close button",
-           src="../dialog-video-player.png" %}
+           src="../dialog-video-player.png" %}{% endexample %}
 
 
 
@@ -156,7 +156,7 @@ scroll horizontally.
 
 {% example palette="none",
            alt="Dialog with a long amount of content showing visible gradient at the bottom of the body text section",
-           src="../dialog-overflow.png" %}
+           src="../dialog-overflow.png" %}{% endexample %}
 
 
 
@@ -169,14 +169,14 @@ the backdrop and viewport.
 
 {% example palette="none",
            alt="Dialog with container horizontally and vertically centered",
-           src="../dialog-placement-center.png" %}
+           src="../dialog-placement-center.png" %}{% endexample %}
 
 By default, a dialog container is horizontally and vertically centered on top of 
 the backdrop and viewport.
 
 {% example palette="none",
            alt="Dialog with container horizontally centered, but positioned at the top of the page",
-           src="../dialog-placement-top.png" %}
+           src="../dialog-placement-top.png" %}{% endexample %}
 
 
 
@@ -189,7 +189,7 @@ breakpoints.
 
 {% example palette="none",
            alt="A dialog container on a large breakpoint",
-           src="../dialog-breakpoint-large.png" %}
+           src="../dialog-breakpoint-large.png" %}{% endexample %}
 
 ### Small breakpoints
 
@@ -198,7 +198,7 @@ full-width and become taller.
 
 {% example palette="none",
            alt="Two dialog containers on small breakpoints, one tablet size and one mobile size",
-           src="../dialog-breakpoint-small.png" %}
+           src="../dialog-breakpoint-small.png" %}{% endexample %}
 
 
 
@@ -212,7 +212,7 @@ bring users back to their original workflow as quickly as possible.
 
 {% example palette="wrong",
            alt="A dialog container with a three-panel accordion which is incorrect usage",
-           src="../dialog-best-practice-1.png" %}
+           src="../dialog-best-practice-1.png" %}{% endexample %}
 
 ### Unclear context
 
@@ -221,7 +221,7 @@ action.
 
 {% example palette="wrong",
            alt="A dialog container with vague text which is incorrect usage",
-           src="../dialog-best-practice-2.png" %}
+           src="../dialog-best-practice-2.png" %}{% endexample %}
 
 ### Two many buttons
 
@@ -230,5 +230,5 @@ variants.
 
 {% example palette="wrong",
            alt="A dialog container with three buttons which is incorrect usage",
-           src="../dialog-best-practice-3.png" %}
+           src="../dialog-best-practice-3.png" %}{% endexample %}
 

--- a/elements/rh-dialog/docs/40-accessibility.md
+++ b/elements/rh-dialog/docs/40-accessibility.md
@@ -6,7 +6,7 @@ A dialog can be opened by pressing `Enter` when the dialog trigger has focus. Wh
 
 {% example palette="none",
            alt="Flowchart of a dialog container outlining several keyboard interactions",
-           src="../dialog-a11y-keyboard-interactions.png" %}
+           src="../dialog-a11y-keyboard-interactions.png" %}{% endexample %}
 
 | Key   | Result                                                   |
 | ----- | -------------------------------------------------------- |
@@ -36,7 +36,7 @@ Only the close button and any interactive elements are selectable.
 
 {% example palette="none",
            alt="A dialog container with three touch targets; one on the close button and one on each button",
-           src="../dialog-a11y-touch-targets.png" %}
+           src="../dialog-a11y-touch-targets.png" %}{% endexample %}
 
 ### Backdrop
 

--- a/elements/rh-footer/docs/10-style.md
+++ b/elements/rh-footer/docs/10-style.md
@@ -11,7 +11,7 @@ websites.
 
 {% example palette="none",
           alt="Image of a footer showing lots of annotation numbers next to various styles and other elements",
-          src="../footer-anatomy.png" %}
+          src="../footer-anatomy.png" %}{% endexample %}
 
 1) Website logo
 2) Social media links
@@ -34,7 +34,7 @@ distinguish both footers from each other.
 
 {% example palette="none",
           alt="Image of a footer with no elements except for backgrounds; the top background is dark gray and the bottom is black",
-          src="../footer-grays.png" %}
+          src="../footer-grays.png" %}{% endexample %}
 
 ## Theme
 
@@ -43,7 +43,7 @@ theme.
 
 {% example palette="none",
           alt="Image of a large footer",
-          src="../footer-theme.png" %}
+          src="../footer-theme.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -79,7 +79,7 @@ theme.
 
 {% example palette="none",
           alt="Image of a footer with the language selector menu open",
-          src="../footer-language-selector.png" %}
+          src="../footer-language-selector.png" %}{% endexample %}
 
 {% tokensTable %}          
 
@@ -100,25 +100,25 @@ maintain consistency.
 
 {% example palette="none",
           alt="Image of how a footer is architected showing lots of alignment examples",
-          src="../footer-configuration.png" %}
+          src="../footer-configuration.png" %}{% endexample %}
 
 ## Space 
 
 {% example palette="none",
           alt="Image of a desktop footer showing space values in between elements",
-          src="../footer-space-desktop.png" %}
+          src="../footer-space-desktop.png" %}{% endexample %}
 
 {% example palette="none",
           alt="Image of a tablet footer showing space values in between elements",
-          src="../footer-space-tablet.png" %}
+          src="../footer-space-tablet.png" %}{% endexample %}
 
 {% example palette="none",
           alt="Image of a mobile footer showing space values in between elements",
-          src="../footer-space-mobile.png" %}
+          src="../footer-space-mobile.png" %}{% endexample %}
 
 {% example palette="none",
           alt="Image of a footer showing space values in the language selector menu",
-          src="../footer-space-language-selector.png" %}
+          src="../footer-space-language-selector.png" %}{% endexample %}
 
 {% spacerTokensTable 
   headline="Spacing tokens",
@@ -133,7 +133,7 @@ maintain consistency.
 
 {% example palette="none",
           alt="Hover state examples within a footer",
-          src="../footer-interaction-state-hover.png" %}
+          src="../footer-interaction-state-hover.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -151,7 +151,7 @@ maintain consistency.
 
 {% example palette="none",
           alt="Hover state example within the language selector menu",
-          src="../footer-ls-interaction-state-hover.png" %}
+          src="../footer-ls-interaction-state-hover.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -169,7 +169,7 @@ The Focus state has the same styles as the Hover state.
 
 {% example palette="none",
           alt="Focus state examples within a footer",
-          src="../footer-interaction-state-focus.png" %}
+          src="../footer-interaction-state-focus.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -187,7 +187,7 @@ The Focus state has the same styles as the Hover state.
 
 {% example palette="none",
           alt="Focus state example within the language selector menu",
-          src="../footer-ls-interaction-state-focus.png" %}
+          src="../footer-ls-interaction-state-focus.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -205,7 +205,7 @@ The Active state has the same styles as the Hover state.
 
 {% example palette="none",
           alt="Active state examples within a footer",
-          src="../footer-interaction-state-active.png" %}
+          src="../footer-interaction-state-active.png" %}{% endexample %}
 
 
 {% tokensTable %}
@@ -224,7 +224,7 @@ The Active state has the same styles as the Hover state.
 
 {% example palette="none",
           alt="Active state example within the language selector menu",
-          src="../footer-ls-interaction-state-active.png" %}
+          src="../footer-ls-interaction-state-active.png" %}{% endexample %}
 
 {% tokensTable %}
 

--- a/elements/rh-footer/docs/20-guidelines.md
+++ b/elements/rh-footer/docs/20-guidelines.md
@@ -15,7 +15,7 @@ Most of the content in the website-specific footer can be customized.
 
 {% example palette="none",
           alt="Image of the website-specific footer showing regions that can and cannot be customized",
-          src="../footer-variant-website-specific.png" %}
+          src="../footer-variant-website-specific.png" %}{% endexample %}
 
 | Region {style="width: 25%" } | Customizable {style="width: 25%" } | Use case                                                    |
 | ---------------------------- | ---------------------------------- | ----------------------------------------------------------- |
@@ -32,7 +32,7 @@ Content in the universal footer is always the same across all websites.
 
 {% example palette="none",
           alt=" Image of the universal footer showing only one region that cannot be customized",
-          src="../footer-variant-universal.png" %}
+          src="../footer-variant-universal.png" %}{% endexample %}
 
 | Region {style="width: 25%" } | Customizable {style="width: 25%" } | Use case                                              |
 | ---------------------------- | ---------------------------------- | ----------------------------------------------------- |
@@ -44,7 +44,7 @@ A footer spans the entire width of the browser window at all breakpoints.
 
 {% example palette="none",
           alt=" Image of a footer in a layout spanning the width of the browser window",
-          src="../footer-layout-browser-window.png" %}
+          src="../footer-layout-browser-window.png" %}{% endexample %}
 
 ### Universal footer
 
@@ -59,7 +59,7 @@ website-specific footer by itself.
 
 {% example palette="none",
           alt=" Image of the universal footer by itself",
-          src="../footer-layout-universal-footer.png" %}
+          src="../footer-layout-universal-footer.png" %}{% endexample %}
 
 ### Other web properties
 
@@ -68,15 +68,15 @@ is flexible enough to accommodate grids, elements, text, and more.
 
 {% example palette="none",
           alt=" Image of a footer on a Customer Portal website",
-          src="../footer-layout-customer-portal.png" %}
+          src="../footer-layout-customer-portal.png" %}{% endexample %}
 
 {% example palette="none",
           alt=" Image of a footer on a Developer website",
-          src="../footer-layout-developer.png" %}
+          src="../footer-layout-developer.png" %}{% endexample %}
 
 {% example palette="none",
           alt=" Image of a footer on a Partner Connect website",
-          src="../footer-layout-partner-connect.png" %}
+          src="../footer-layout-partner-connect.png" %}{% endexample %}
 
 ## Behavior
 
@@ -87,21 +87,21 @@ below the first row of columns.
 
 {% example palette="none",
           alt=" Image of a footer with four columns of links in one row and two columns in the second row",
-          src="../footer-behavior-columns-two-rows.png" %}
+          src="../footer-behavior-columns-two-rows.png" %}{% endexample %}
 
 If the website-specific footer includes less content, columns will stretch to 
 fill the empty space.
 
 {% example palette="none",
           alt=" Image of a footer with only two columns of links in one row",
-          src="../footer-behavior-columns-less-content.png" %}
+          src="../footer-behavior-columns-less-content.png" %}{% endexample %}
 
 If the number of columns changes, social media links will shift position to 
 remain aligned to the left edge of the last column.
 
 {% example palette="none",
           alt=" Image of a footer with three columns of links showing an example of social media icons shifting",
-          src="../footer-behavior-columns-social-media-icons.png" %}
+          src="../footer-behavior-columns-social-media-icons.png" %}{% endexample %}
 
 ## Responsive design
 
@@ -109,7 +109,7 @@ remain aligned to the left edge of the last column.
 
 {% example palette="none",
           alt=" Image of a large breakpoint footer",
-          src="../footer-responsive-large-breakpoints.png" %}
+          src="../footer-responsive-large-breakpoints.png" %}{% endexample %}
 
 ### Small breakpoints
 
@@ -123,11 +123,11 @@ is no longer visible.
 
 {% example palette="none",
           alt=" Image of a tablet breakpoint footer",
-          src="../footer-responsive-small-breakpoints-a.png" %}
+          src="../footer-responsive-small-breakpoints-a.png" %}{% endexample %}
 
 {% example palette="none",
           alt=" Image of a mobile breakpoint footer",
-          src="../footer-responsive-small-breakpoints-b.png" %}
+          src="../footer-responsive-small-breakpoints-b.png" %}{% endexample %}
 
 | Breakpoint {style="width: 33%" } | Range {style="width: 33%" } | Content layout |
 | -------------------------------- | --------------------------- | -------------- |
@@ -147,7 +147,7 @@ be on top.
 
 {% example palette="none",
           alt=" Image of the global footer on top of the website-specific footer which is incorrect usage",
-          src="../footer-best-practice-1.png" %}
+          src="../footer-best-practice-1.png" %}{% endexample %}
 
 ### Replacing columns
 
@@ -155,7 +155,7 @@ Do not replace columns with an accordion if there is still adequate space.
 
 {% example palette="none",
           alt=" Image of a desktop footer with an accordion replacing four columns of links which is incorrect usage",
-          src="../footer-best-practice-2.png" %}
+          src="../footer-best-practice-2.png" %}{% endexample %}
 
 ### Website-specific footer
 
@@ -163,7 +163,7 @@ Do not use the website-specific footer without the universal footer.
 
 {% example palette="none",
           alt=" Image of a footer missing the universal footer which is incorrect usage",
-          src="../footer-best-practice-3.png" %}
+          src="../footer-best-practice-3.png" %}{% endexample %}
 
 ### Custom universal footer
 
@@ -172,4 +172,4 @@ rearranging any elements.
 
 {% example palette="none",
           alt=" Image of a universal footer with a new design which is incorrect usage",
-          src="../footer-best-practice-4.png" %}
+          src="../footer-best-practice-4.png" %}{% endexample %}

--- a/elements/rh-footer/docs/40-accessibility.md
+++ b/elements/rh-footer/docs/40-accessibility.md
@@ -17,20 +17,20 @@ Users can skip opening the language selector menu, but the trigger still receive
 
 {% example palette="none",
           alt="Image of a footer showing groups of focus indicators in different regions with annotation numbers",
-          src="../footer-a11y-focus-order.png" %}
+          src="../footer-a11y-focus-order.png" %}{% endexample %}
 
 ### Language selector
 Users can open the language selector menu by pressing `Enter` if the trigger has focus. If they do, they can press `Tab` to move focus to the first language. Each language can receive focus from left to right and top to bottom.
 
 {% example palette="none",
           alt="Image of a footer with the language selector menu open showing the focus order of languages",
-          src="../footer-a11y-language-selector-a.png" %}
+          src="../footer-a11y-language-selector-a.png" %}{% endexample %}
 
 When the focus is moved outside of the menu, the menu closes.
 
 {% example palette="none",
           alt="Image of a footer with the language selector menu open showing the menu closing when focus is moved",
-          src="../footer-a11y-language-selector-b.png" %}
+          src="../footer-a11y-language-selector-b.png" %}{% endexample %}
 
 ## Additional guidelines
 - Content outside of a dialog cannot be interacted with or navigated to while the dialog is open

--- a/elements/rh-jump-links/docs/10-style.md
+++ b/elements/rh-jump-links/docs/10-style.md
@@ -10,7 +10,7 @@
              width=537,
              class="inline-flex centered",
              alt="Jump links specs",
-             src="../jump-links-style.svg" %}
+             src="../jump-links-style.svg" %}{% endexample %}
 
 ### Theme
 
@@ -18,13 +18,13 @@
              width=385,
              class="inline-flex centered",
              alt="Jump links theme light",
-             src="../jump-links-theme-light.svg" %}
+             src="../jump-links-theme-light.svg" %}{% endexample %}
 
   {% example palette="darkest",
              width=385,
              class="inline-flex centered",
              alt="Jump links theme dark",
-             src="../jump-links-theme-dark.svg" %}
+             src="../jump-links-theme-dark.svg" %}{% endexample %}
 
 ### Label
   Jump links display a label at the top indicating there are section links that 
@@ -45,7 +45,7 @@
              width=129,
              class="inline-flex centered",
              alt="Jump links nested section",
-             src="../jump-links-nested.svg" %}
+             src="../jump-links-nested.svg" %}{% endexample %}
 
 ### Active indicator bar
   A red indicator bar highlights what the active section is. It’s positioned on 
@@ -55,7 +55,7 @@
              width=206,
              class="inline-flex centered",
              alt="Jump links active indicator bar",
-             src="../jump-links-indicator.svg" %}
+             src="../jump-links-indicator.svg" %}{% endexample %}
 
 
 ## Responsive design
@@ -102,11 +102,11 @@
              width=385,
              class="inline-flex centered",
              alt="Jump links spacing on desktop",
-             src="../jump-links-spacing.svg" %}
+             src="../jump-links-spacing.svg" %}{% endexample %}
 
   {% example palette="light",
              width=872,
              class="inline-flex centered",
              alt="Jump links spacing on mobile",
-             src="../jump-links-spacing-2.svg" %}
+             src="../jump-links-spacing-2.svg" %}{% endexample %}
 

--- a/elements/rh-jump-links/docs/20-guidelines.md
+++ b/elements/rh-jump-links/docs/20-guidelines.md
@@ -28,7 +28,7 @@
              width=129,
              class="inline-flex centered",
              alt="Jump links not enough links issue",
-             src="../jump-links-best-practices-1.svg" %}
+             src="../jump-links-best-practices-1.svg" %}{% endexample %}
 
   Don’t include section links that are really long, they can be customized to be 
   shorter when added to a group of jump links.
@@ -37,7 +37,7 @@
              width=361,
              class="inline-flex centered",
              alt="Jump links too long titles",
-             src="../jump-links-best-practices-2.svg" %}
+             src="../jump-links-best-practices-2.svg" %}{% endexample %}
 
   Don’t overload jump links with too many section links, but including lots 
   of nested section links is acceptable.
@@ -46,7 +46,7 @@
              width=146,
              class="inline-flex centered",
              alt="Jump links too many top level links issue",
-             src="../jump-links-best-practices-3.svg" %}
+             src="../jump-links-best-practices-3.svg" %}{% endexample %}
 
   Don’t nest section links within nested section links.
 
@@ -54,7 +54,7 @@
              width=141,
              class="inline-flex centered",
              alt="Jump links nesting issue",
-             src="../jump-links-best-practices-4.svg" %}
+             src="../jump-links-best-practices-4.svg" %}{% endexample %}
 
 
 
@@ -84,7 +84,7 @@
              width=872,
              class="inline-flex centered",
              alt="Jump links on mobile",
-             src="../jump-links-behavior-mobile.svg" %}
+             src="../jump-links-behavior-mobile.svg" %}{% endexample %}
 
 
 ## Interaction states
@@ -102,5 +102,5 @@
              width=872,
              class="inline-flex centered",
              alt="Jump links tab order",
-             src="../jump-links-tab-order.svg" %}
+             src="../jump-links-tab-order.svg" %}{% endexample %}
 

--- a/elements/rh-navigation-secondary/docs/00-overview.md
+++ b/elements/rh-navigation-secondary/docs/00-overview.md
@@ -5,7 +5,7 @@
 
   {% example palette="light",
       alt="Image of two stacked secondary navigations; one for large breakpoints and the other for small breakpoints",
-      src="./nav-secondary-sample.png" %}
+      src="./nav-secondary-sample.png" %}{% endexample %}
 
 ## Demo
 

--- a/elements/rh-navigation-secondary/docs/10-style.md
+++ b/elements/rh-navigation-secondary/docs/10-style.md
@@ -11,7 +11,7 @@
 
   {% example palette="light",
       alt="Image of a gray secondary navigation background with dotted line boxes that say slot 1, slot 2, and slot 3 from left to right",
-      src="../nav-secondary-style-slots.png" %}
+      src="../nav-secondary-style-slots.png" %}{% endexample %}
 
 ### Using slots
   Slots are defined areas where content can be inserted, each slot includes a specific type of content.
@@ -29,7 +29,7 @@
 
   {% example palette="light",
       alt="Image of four secondary navigations; two large ones and two small ones with dotted line boxes around each slot and labels that say slot 1, slot 2, and slot 3",
-      src="../nav-secondary-style-slots-and-breakpoints.png" %}
+      src="../nav-secondary-style-slots-and-breakpoints.png" %}{% endexample %}
 
 ### Using the expandable menu
   The expandable menu is an area where content can be placed like text, links, calls to action, and more. The menu requires a backdrop so it can separate itself from the page underneath, this helps users focus on the menu content.
@@ -55,7 +55,7 @@
 
   {% example palette="light",
       alt="Image of a light theme secondary navigation",
-      src="../nav-secondary-style-theme-light.png" %}
+      src="../nav-secondary-style-theme-light.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -74,7 +74,7 @@
 
   {% example palette="darkest",
       alt="Image of a dark theme secondary navigation",
-      src="../nav-secondary-style-theme-dark.png" %}
+      src="../nav-secondary-style-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -94,14 +94,14 @@
 
   {% example palette="light",
       alt="Image of a secondary navigation construction; several examples showing details like spacing, alignment, height, width, and more",
-      src="../nav-secondary-style-configuration.png" %}
+      src="../nav-secondary-style-configuration.png" %}{% endexample %}
 
 ### Expandable menu styles
   An expandable menu includes content like text, links, calls to action, and more. The menu tab, panel, and backdrop have the same styles on all breakpoints.
 
   {% example palette="light",
       alt="Image of two stacked secondary navigations with menus expanded; one for large breakpoints and the other for small breakpoints",
-      src="../nav-secondary-style-expandable-menu-styles.png" %}
+      src="../nav-secondary-style-expandable-menu-styles.png" %}{% endexample %}
 
 ### Slot text labels
   Slot 1 and Slot 2 text elements have specific styles applied to them.
@@ -112,7 +112,7 @@
 
   {% example palette="light",
       alt="Image of four stacked secondary navigations; two are light theme and two are dark theme, both with dotted line boxes and labels that say slot 1 and slot 2",
-      src="../nav-secondary-style-text-labels.png" %}
+      src="../nav-secondary-style-text-labels.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -141,13 +141,13 @@
 
   {% example palette="none",
     alt="Image of secondary navigation spacing values on large breakpoints",
-    src="../nav-secondary-space-breakpoints-large.png" %}
+    src="../nav-secondary-space-breakpoints-large.png" %}{% endexample %}
 
 ### Small breakpoints  
 
   {% example palette="none",
     alt="Image of secondary navigation spacing values on small breakpoints",
-    src="../nav-secondary-space-breakpoints-small.png" %}
+    src="../nav-secondary-space-breakpoints-small.png" %}{% endexample %}
 
   {% spacerTokensTable 
     headline="",
@@ -165,11 +165,11 @@
 
   {% example palette="light",
       alt="Image of light theme secondary navigation hover states",
-      src="../nav-secondary-interaction-state-hover-theme-light.png" %}
+      src="../nav-secondary-interaction-state-hover-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
       alt="Image of dark theme secondary navigation hover states",
-      src="../nav-secondary-interaction-state-hover-theme-dark.png" %}
+      src="../nav-secondary-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -193,11 +193,11 @@
 
   {% example palette="light",
       alt="Image of light theme secondary navigation focus states",
-      src="../nav-secondary-interaction-state-focus-theme-light.png" %}
+      src="../nav-secondary-interaction-state-focus-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
       alt="Image of dark theme secondary navigation focus states",
-      src="../nav-secondary-interaction-state-focus-theme-dark.png" %}      
+      src="../nav-secondary-interaction-state-focus-theme-dark.png" %}{% endexample %}      
 
   {% tokensTable %}
 
@@ -217,11 +217,11 @@
 
   {% example palette="light",
       alt="Image of light theme secondary navigation active states",
-      src="../nav-secondary-interaction-state-active-theme-light.png" %}
+      src="../nav-secondary-interaction-state-active-theme-light.png" %}{% endexample %}
 
   {% example palette="darkest",
       alt="Image of dark theme secondary navigation active states",
-      src="../nav-secondary-interaction-state-active-theme-dark.png" %}
+      src="../nav-secondary-interaction-state-active-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 

--- a/elements/rh-navigation-secondary/docs/20-guidelines.md
+++ b/elements/rh-navigation-secondary/docs/20-guidelines.md
@@ -10,7 +10,7 @@
 
   {% example palette="light",
       alt="Image of a primary navigation stacked on top of a secondary navigation",
-      src="../nav-secondary-usage-vs-primary.png" %}
+      src="../nav-secondary-usage-vs-primary.png" %}{% endexample %}
 
 ## Writing content
 ### Slot 1 text 
@@ -21,7 +21,7 @@
 
   {% example palette="none",
     alt="Image of four secondary navigations showing how stacked product name text offers more space",
-    src="../nav-secondary-guidelines-slot-1-text.png" %}
+    src="../nav-secondary-guidelines-slot-1-text.png" %}{% endexample %}
 
 ### Slot 2 text
   Slot 2 includes inline links, menus, and sometimes external links. The order of elements is decided by content strategists. When writing content for Slot 2, consider the following:
@@ -33,7 +33,7 @@
 
   {% example palette="none",
     alt="Image of two secondary navigations comparing an acceptable amount of links and menus",
-    src="../nav-secondary-guidelines-slot-2-text.png" %}
+    src="../nav-secondary-guidelines-slot-2-text.png" %}{% endexample %}
 
 ### Slot 3 text
   Slot 3 is optional, but it can include interactive elements like a call to action. When writing content for Slot 3, consider the following:
@@ -45,7 +45,7 @@
 
   {% example palette="none",
     alt="Image of two secondary navigations comparing the character counts of a call to action",
-    src="../nav-secondary-guidelines-slot-3-text.png" %}
+    src="../nav-secondary-guidelines-slot-3-text.png" %}{% endexample %}
 
 ### Maximum uses and character count
   If there are fewer links and menus in Slot 2, text labels can be longer. If there are more links and menus, text labels need to be shorter to avoid cluttering.
@@ -67,13 +67,13 @@
 
   {% example palette="none",
     alt="Image of a secondary navigation with four columns of links",
-    src="../nav-secondary-usage-expandable-menu-columns-4.png" %}
+    src="../nav-secondary-usage-expandable-menu-columns-4.png" %}{% endexample %}
 
   If content is organized in two columns, they will stretch to fill the empty space.
 
   {% example palette="none",
     alt="Image of a secondary navigation with two columns of links",
-    src="../nav-secondary-usage-expandable-menu-columns-2.png" %}
+    src="../nav-secondary-usage-expandable-menu-columns-2.png" %}{% endexample %}
 
 ### Expandable menu content 
   The expandable menu includes content like text, links, calls to action, and more. When adding content to an expandable menu, follow these guidelines:
@@ -93,14 +93,14 @@
 
   {% example palette="none",
     alt="Image of two secondary navigations with red bars on top of different menus",
-    src="../nav-secondary-guidelines-current-page-indicator.png" %}
+    src="../nav-secondary-guidelines-current-page-indicator.png" %}{% endexample %}
 
 ### Scrolling with primary navigation
   A secondary navigation is positioned below the primary navigation when the page loads. When a user scrolls down, the primary navigation disappears and the secondary navigation becomes fixed to the top of the browser window. When a user scrolls back up to the top, the secondary navigation is positioned under the primary navigation again.
 
   {% example palette="none",
     alt="Image of primary and secondary navigations and their behaviors when scrolling",
-    src="../nav-secondary-guidelines-scrolling-primary-nav.png" %}
+    src="../nav-secondary-guidelines-scrolling-primary-nav.png" %}{% endexample %}
 
 ### Navigating between menus
   Only one menu can be expanded at a time and there is no animation when navigating from one menu to the next.
@@ -111,20 +111,20 @@
 
   {% example palette="light",
     alt="Image of three secondary navigations with different menus selected",
-    src="../nav-secondary-guidelines-navigating-menus.png" %}
+    src="../nav-secondary-guidelines-navigating-menus.png" %}{% endexample %}
 
 ### Scrolling with menu expanded 
   If the height of the menu is **shorter** than the viewport height, content should scroll underneath the backdrop.
 
   {% example palette="none",
     alt="Image of secondary navigation showing the scrolling behavior when the menu panel is shorter than the viewport height",
-    src="../nav-secondary-guidelines-scrolling-menu-expanded-a.png" %}
+    src="../nav-secondary-guidelines-scrolling-menu-expanded-a.png" %}{% endexample %}
 
   If the height of the menu is **taller** than the viewport height, scroll is trapped within the panel until the menu is collapsed.
 
   {% example palette="none",
     alt="Image of secondary navigation showing the scrolling behavior when the menu panel is taller than the viewport height",
-    src="../nav-secondary-guidelines-scrolling-menu-expanded-b.png" %}
+    src="../nav-secondary-guidelines-scrolling-menu-expanded-b.png" %}{% endexample %}
 
 
 
@@ -135,13 +135,13 @@
 
   {% example palette="none",
     alt="Image of secondary navigations; one has a menu collapsed and the other has a menu expanded, but both have slot 2 visible on large breakpoints",
-    src="../nav-secondary-guidelines-responsive-slot-2-visible.png" %}
+    src="../nav-secondary-guidelines-responsive-slot-2-visible.png" %}{% endexample %}
 
 ### Slot 2 hidden 
 
   {% example palette="none",
     alt="Image of secondary navigations; slot 2 on small breakpoints is not visible unless the menu is expanded",
-    src="../nav-secondary-guidelines-responsive-slot-2-hidden.png" %}
+    src="../nav-secondary-guidelines-responsive-slot-2-hidden.png" %}{% endexample %}
 
 ### Breakpoints
 
@@ -166,40 +166,40 @@
 
   {% example palette="none",
     alt="Image of a secondary navigation on top of a primary navigation which is incorrect usage",
-    src="../nav-secondary-best-practice-1.png" %}
+    src="../nav-secondary-best-practice-1.png" %}{% endexample %}
 
 ### Theme mismatch
   Do not use a dark theme secondary navigation in light environments and vice versa.
 
   {% example palette="none",
     alt="Image of a dark theme secondary navigation in a light theme environment which is incorrect usage",
-    src="../nav-secondary-best-practice-2.png" %}
+    src="../nav-secondary-best-practice-2.png" %}{% endexample %}
 
 ### Content overload
   Do not use too many links or menus in Slot 2.
 
   {% example palette="none",
     alt="Image of a secondary navigation with way more than five links and menus which is incorrect usage",
-    src="../nav-secondary-best-practice-3.png" %}
+    src="../nav-secondary-best-practice-3.png" %}{% endexample %}
 
 ### Adding slots
   Do not add more slots than provided, three is the maximum.
 
   {% example palette="none",
     alt="Image of a secondary navigation with four dotted line boxes for slots which is incorrect usage",
-    src="../nav-secondary-best-practice-4.png" %}
+    src="../nav-secondary-best-practice-4.png" %}{% endexample %}
   
 ### Slot 1 text
   Slot 1 text should never break to three lines.
 
   {% example palette="none",
     alt="Image of a secondary navigation, but the product name logo in slot 1 is three lines which is incorrect usage",
-    src="../nav-secondary-best-practice-5.png" %}
+    src="../nav-secondary-best-practice-5.png" %}{% endexample %}
   
 ### Missing navigation
   At least one link or menu in Slot 2 must be visible.
 
   {% example palette="none",
     alt="Image of a secondary navigation with no links or menus in slot 2 which is incorrect usage",
-    src="../nav-secondary-best-practice-6.png" %}
+    src="../nav-secondary-best-practice-6.png" %}{% endexample %}
 

--- a/elements/rh-navigation-secondary/docs/40-accessibility.md
+++ b/elements/rh-navigation-secondary/docs/40-accessibility.md
@@ -6,7 +6,7 @@
 
   {% example palette="light",
       alt="Image of secondary navigations with diagrams of what happens when Tab or Enter keys are pressed",
-      src="../nav-secondary-a11y-keyboard-interactions.png" %}
+      src="../nav-secondary-a11y-keyboard-interactions.png" %}{% endexample %}
 
 ### Keyboard events
 

--- a/elements/rh-pagination/docs/00-overview.md
+++ b/elements/rh-pagination/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 {% example palette="light",
            alt="Image of two paginations; one is full size showing double truncation and a page input field and the other one is compact size showing only a page field input.",
-           src="./pagination-sample.png" %}
+           src="./pagination-sample.png" %}{% endexample %}
 
 
 

--- a/elements/rh-pagination/docs/10-style.md
+++ b/elements/rh-pagination/docs/10-style.md
@@ -8,7 +8,7 @@ Pagination is a horizontal row of square containers that include a control butto
 
 {% example palette="light",
            alt="Image of pagination anatomy with lots of annotations",
-           src="../pagination-anatomy.png" %}
+           src="../pagination-anatomy.png" %}{% endexample %}
 
 1. First page
 2. Previous page
@@ -34,7 +34,7 @@ The Compact size always includes the page input field.
 
 {% example palette="light",
            alt="Image of three paginations; full size, full size with page input field, and compact size",
-           src="../pagination-style-sizes.png" %}
+           src="../pagination-style-sizes.png" %}{% endexample %}
 
 
 
@@ -46,13 +46,13 @@ Pagination is available in both light and dark themes.
 
 {% example palette="light",
            alt="Image of light theme pagination",
-           src="../pagination-theme-light.png" %}
+           src="../pagination-theme-light.png" %}{% endexample %}
 
 ### Dark theme
 
 {% example palette="darkest",
            alt="Image of dark theme pagination",
-           src="../pagination-theme-dark.png" %}
+           src="../pagination-theme-dark.png" %}{% endexample %}
 
 
 
@@ -62,7 +62,7 @@ Pagination is a collection of navigation elements including controls, page numbe
 
 {% example palette="light",
            alt="Image of pagination construction; several pagination examples showing details like alignment, height, width, and more",
-           src="../pagination-configuration.png" %}
+           src="../pagination-configuration.png" %}{% endexample %}
 
 ### Active page
 
@@ -74,11 +74,11 @@ Active page styles do not apply to the Compact size because there are no page nu
 
 {% example palette="light",
            alt="Image of two light theme paginations; one is showing an active page of 4 and the other one is showing an active page of 25",
-           src="../pagination-active-page-theme-light.png" %}
+           src="../pagination-active-page-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Image of two dark theme paginations; one is showing an active page of 4 and the other one is showing an active page of 25",
-           src="../pagination-active-page-theme-dark.png" %}
+           src="../pagination-active-page-theme-dark.png" %}{% endexample %}
 
 
 
@@ -88,7 +88,7 @@ Space values between elements are the same for both sizes and on all breakpoints
 
 {% example palette="light",
            alt="Image of pagination spacing for all sizes and orientations",
-           src="../pagination-space.png" %}
+           src="../pagination-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
     caption='',
@@ -108,11 +108,11 @@ Control and inactive page number buttons have the same hover state. Truncation i
 
 {% example palette="light",
            alt="Image of light theme pagination hover states",
-           src="../pagination-interaction-state-hover-theme-light.png" %}
+           src="../pagination-interaction-state-hover-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Image of dark theme pagination hover states",
-           src="../pagination-interaction-state-hover-theme-dark.png" %}
+           src="../pagination-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -130,11 +130,11 @@ Control and inactive page number buttons have the same hover state. Truncation i
 
 {% example palette="light",
            alt="Image of light theme pagination focus states",
-           src="../pagination-interaction-state-focus-theme-light.png" %}
+           src="../pagination-interaction-state-focus-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Image of dark theme pagination focus states",
-           src="../pagination-interaction-state-focus-theme-dark.png" %}
+           src="../pagination-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
 
 {% tokensTable %}
@@ -154,11 +154,11 @@ Control and inactive page number buttons have the same hover state. Truncation i
 
 {% example palette="light",
            alt="Image of light theme pagination active states",
-           src="../pagination-interaction-state-active-theme-light.png" %}
+           src="../pagination-interaction-state-active-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
            alt="Image of dark theme pagination active states",
-           src="../pagination-interaction-state-active-theme-dark.png" %}
+           src="../pagination-interaction-state-active-theme-dark.png" %}{% endexample %}
 
 {% tokensTable %}
 

--- a/elements/rh-pagination/docs/20-guidelines.md
+++ b/elements/rh-pagination/docs/20-guidelines.md
@@ -22,7 +22,7 @@ Use the Full size for all applications and the Compact size for when breakpoints
 
 {% example palette="light",
            alt="Image of pagination sizes and how to use them",
-           src="../pagination-usage-sizes.png" %}
+           src="../pagination-usage-sizes.png" %}{% endexample %}
 
 ### Compact size
 
@@ -30,7 +30,7 @@ The page input field must **always** be visible if using the Compact size so tha
 
 {% example palette="light",
            alt="Image of compact size paginations with page input field on the right and below",
-           src="../pagination-compact-size.png" %}
+           src="../pagination-compact-size.png" %}{% endexample %}
 
 ### Page input field orientation
 
@@ -38,11 +38,11 @@ The page input field can be oriented on the right or below pagination. If used b
 
 {% example palette="light",
            alt="Image of two full size paginations; one has a page input field on the right and the other has one below",
-           src="../pagination-pif-orientation-a.png" %}
+           src="../pagination-pif-orientation-a.png" %}{% endexample %}
 
 {% example palette="light",
            alt="Image of full size and compact size pagination; one has a page input field on the right and the other has one below",
-           src="../pagination-pif-orientation-b.png" %}  
+           src="../pagination-pif-orientation-b.png" %}{% endexample %}  
 
 
 
@@ -58,7 +58,7 @@ If there are more than seven pages, the page input field must be visible.
 
 {% example palette="light",
            alt="Image of two groups of pagination; one group shows full sizes with different page locations and the other group shows compact sizes with different page locations",
-           src="../pagination-behavior-pif.png" %}
+           src="../pagination-behavior-pif.png" %}{% endexample %}
 
 ### Low page count
 
@@ -70,7 +70,7 @@ Pagination will not be displayed if a search returns zero results or if there is
 
 {% example palette="light",
            alt="Image of groups of paginations with low page counts; first pagination group shows only 1 page and the second group shows only 3 pages",
-           src="../pagination-behavior-low-page-count.png" %}
+           src="../pagination-behavior-low-page-count.png" %}{% endexample %}
 
 ### Disabled butons
 
@@ -78,7 +78,7 @@ When the beginning or end of the pagination range is reached, certain control bu
 
 {% example palette="light",
            alt="Image of paginations with a variety of disabled control buttons",
-           src="../pagination-behavior-disabled-buttons.png" %}
+           src="../pagination-behavior-disabled-buttons.png" %}{% endexample %}
 
 ### Truncation
 
@@ -90,7 +90,7 @@ Truncation does not apply to the Compact size because it does not display page n
 
 {% example palette="light",
            alt="Image of paginations with a variety of truncation examples",
-           src="../pagination-behavior-truncation.png" %}
+           src="../pagination-behavior-truncation.png" %}{% endexample %}
 
 
 
@@ -102,19 +102,19 @@ Both pagination sizes and orientations are horizontally centered below content b
 
 {% example palette="none",
            alt="Image of full size pagination with the page input field on the right",
-           src="../pagination-alignment-pif-right-a.png" %}
+           src="../pagination-alignment-pif-right-a.png" %}{% endexample %}
 
 {% example palette="none",
            alt="Image of compact size pagination with the page input field on the right",
-           src="../pagination-alignment-pif-right-b.png" %}
+           src="../pagination-alignment-pif-right-b.png" %}{% endexample %}
 
 {% example palette="none",
            alt="Image of full size pagination with the page input field below",
-           src="../pagination-alignment-pif-below-a.png" %}
+           src="../pagination-alignment-pif-below-a.png" %}{% endexample %}
 
 {% example palette="none",
            alt="Image of compact size pagination with the page input field below",
-           src="../pagination-alignment-pif-below-b.png" %}
+           src="../pagination-alignment-pif-below-b.png" %}{% endexample %}
 
 
 
@@ -126,13 +126,13 @@ As breakpoints get smaller, pagination will switch sizes to accommodate the page
 
 {% example palette="none",
            alt="Images of pagination with the page input field on the right",
-           src="../pagination-page-input-field-right.png" %}
+           src="../pagination-page-input-field-right.png" %}{% endexample %}
 
 If the page input field is used below, pagination will not switch sizes as quickly.
 
 {% example palette="none",
            alt="Images of pagination with the page input field below",
-           src="../pagination-page-input-field-below.png" %}
+           src="../pagination-page-input-field-below.png" %}{% endexample %}
 
 ### Without page input field
 
@@ -140,7 +140,7 @@ When the page input field is not visible, it will become visible when the Full s
 
 {% example palette="none",
            alt="Image of pagination without page input field",
-           src="../pagination-without-page-input-field.png" %}
+           src="../pagination-without-page-input-field.png" %}{% endexample %}
 
 ## Best practices
 
@@ -150,7 +150,7 @@ Do not use the Compact size without including the page input field.
 
 {% example palette="wrong",
            alt="Image of compact size pagination with no page input field is incorrect usage",
-           src="../pagination-best-practice-1.png" %}
+           src="../pagination-best-practice-1.png" %}{% endexample %}
 
 ### No input field
 
@@ -158,7 +158,7 @@ The page input field needs to be visible if there is truncation.
 
 {% example palette="wrong",
            alt="Image of pagination with truncation but no page input field is incorrect usage",
-           src="../pagination-best-practice-2.png" %}
+           src="../pagination-best-practice-2.png" %}{% endexample %}
 
 ### Truncation
 
@@ -166,7 +166,7 @@ Do not truncate pagination if there is less than seven pages.
 
 {% example palette="wrong",
            alt="Image of pagination that is truncating only four pages is incorrect usage",
-           src="../pagination-best-practice-3.png" %}
+           src="../pagination-best-practice-3.png" %}{% endexample %}
 
 ### Order or alignment
 
@@ -174,5 +174,5 @@ Do not change the order or alignment of the page input field.
 
 {% example palette="wrong",
            alt="Image of paginations with page input fields; one group shows incorrect order and the other group shows incorrect alignment",
-           src="../pagination-best-practice-4.png" %}
+           src="../pagination-best-practice-4.png" %}{% endexample %}
 

--- a/elements/rh-pagination/docs/40-accessibility.md
+++ b/elements/rh-pagination/docs/40-accessibility.md
@@ -4,7 +4,7 @@ The buttons, page input field, and last page link all have keyboard interactions
 
 {% example palette="light",
            alt="Image of paginations with diagrams of what happens when Tab or Enter keys are pressed",
-           src="../pagination-a11y-keyboard-interactions.png" %} 
+           src="../pagination-a11y-keyboard-interactions.png" %}{% endexample %} 
 
 | Key                                     | Result                                                  |
 | --------------------------------------- | ------------------------------------------------------- |
@@ -21,7 +21,7 @@ The buttons, page input field, and last page link all have keyboard interactions
 
 {% example palette="light",
            alt="Image of paginations showing the focus order from left to right and top to bottom",
-           src="../pagination-a11y-focus-order.png" %}  
+           src="../pagination-a11y-focus-order.png" %}{% endexample %}  
 
 
 ## Touch targets
@@ -29,7 +29,7 @@ Buttons, page field input, and last page link are adequately spaced for optimal 
 
 {% example palette="light",
            alt="Image of paginations with elements showing adequate touch target spacing",
-           src="../pagination-a11y-touch-targets.png" %}  
+           src="../pagination-a11y-touch-targets.png" %}{% endexample %}  
 
 
 

--- a/elements/rh-popover/docs/10-style.md
+++ b/elements/rh-popover/docs/10-style.md
@@ -7,7 +7,7 @@
   {% example palette="lightest",
              width=538,
              alt="Popover component blueprint",
-             src="../popover-style.svg" %}
+             src="../popover-style.svg" %}{% endexample %}
 
 ### Variants
 
@@ -64,14 +64,14 @@
   {% example palette="lightest",
              width=392,
              alt="Popover component, light theme",
-             src="../popover-theme-light.svg" %}
+             src="../popover-theme-light.svg" %}{% endexample %}
 
 ### White (dark backgrounds)
 
   {% example palette="darkest",
              width=392,
              alt="Popover component, dark theme",
-             src="../popover-theme-dark.svg" %}
+             src="../popover-theme-dark.svg" %}{% endexample %}
 
 
 ## Responsive design
@@ -102,5 +102,5 @@
   {% example palette="lightest",
              width=392,
              alt="Popover component spacing",
-             src="../popover-spacing.svg" %}
+             src="../popover-spacing.svg" %}{% endexample %}
 

--- a/elements/rh-popover/docs/20-guidelines.md
+++ b/elements/rh-popover/docs/20-guidelines.md
@@ -30,7 +30,7 @@
   {% example palette="lightest",
              width=832,
              alt="Popover component usage, content",
-             src="../popover-usage-content.svg" %}
+             src="../popover-usage-content.svg" %}{% endexample %}
 
 ### Character count
 
@@ -59,7 +59,7 @@
   {% example palette="lightest",
              width=844,
              alt="Popover component usage, orientation",
-             src="../popover-usage-orientation.svg" %}
+             src="../popover-usage-orientation.svg" %}{% endexample %}
 
 ### Black on black
 
@@ -69,7 +69,7 @@
   {% example palette="darkest",
              width=392,
              alt="Popover component usage, black on black",
-             src="../popover-usage-black.svg" %}
+             src="../popover-usage-black.svg" %}{% endexample %}
 
 ### White on white
 
@@ -79,7 +79,7 @@
   {% example palette="lightest",
              width=392,
              alt="Popover component usage, white on white",
-             src="../popover-usage-white.svg" %}
+             src="../popover-usage-white.svg" %}{% endexample %}
 
 
 
@@ -95,7 +95,7 @@
   {% example palette="lightest",
              width=832,
              alt="Popover component behavior, trigger",
-             src="../popover-behavior-trigger.svg" %}
+             src="../popover-behavior-trigger.svg" %}{% endexample %}
 
 ### Form
 
@@ -106,7 +106,7 @@
   {% example palette="lightest",
              width=832,
              alt=" Popover component behavior, form",
-             src="../popover-behavior-form.svg" %}
+             src="../popover-behavior-form.svg" %}{% endexample %}
 
 ### Mobile
 
@@ -116,7 +116,7 @@
   {% example palette="lightest",
              width=772,
              alt=" Popover component behavior, mobile",
-             src="../popover-behavior-mobile.svg" %}
+             src="../popover-behavior-mobile.svg" %}{% endexample %}
 
 
 ## Interaction states
@@ -169,7 +169,7 @@
   {% example palette="lightest",
              width=392,
              alt=" Popover component accesssibility",
-             src="../popover-accessibility.svg" %}
+             src="../popover-accessibility.svg" %}{% endexample %}
 
   | Key          | Action                                                       |
   |--------------|--------------------------------------------------------------|
@@ -188,7 +188,7 @@
   {% example palette="wrong",
              width=479,
              alt="Popover component best practice 1",
-             src="../popover-best-practice-1.svg" %}
+             src="../popover-best-practice-1.svg" %}{% endexample %}
 
 ### Too much content
 
@@ -197,7 +197,7 @@
   {% example palette="wrong",
              width=432,
              alt="Popover component best practice 2",
-             src="../popover-best-practice-2.svg" %}
+             src="../popover-best-practice-2.svg" %}{% endexample %}
 
 ### No close button
 
@@ -206,5 +206,5 @@
   {% example palette="wrong",
              width=392,
              alt="Popover component best practice 3",
-             src="../popover-best-practice-3.svg" %}
+             src="../popover-best-practice-3.svg" %}{% endexample %}
 

--- a/elements/rh-progress-steps/docs/10-style.md
+++ b/elements/rh-progress-steps/docs/10-style.md
@@ -8,7 +8,7 @@
   {% example palette="lightest",
              width=699,
              alt="Progress steps component blueprint",
-             src="../progress-steps-blueprint.svg" %}
+             src="../progress-steps-blueprint.svg" %}{% endexample %}
 
 ### Visual elements
 
@@ -30,7 +30,7 @@
   {% example palette="lightest",
              width=385,
              alt="Progress steps component visual elements",
-             src="../progress-steps-visual-elements.svg" %}
+             src="../progress-steps-visual-elements.svg" %}{% endexample %}
 
 ### Text labels
 
@@ -47,7 +47,7 @@
   {% example palette="lightest",
              width=687,
              alt="Progress steps component text labels",
-             src="../progress-steps-text-labels.svg" %}
+             src="../progress-steps-text-labels.svg" %}{% endexample %}
 
 
 ## Orientation
@@ -66,7 +66,7 @@
   {% example palette="lightest",
              width=687,
              alt="Progress steps component horizontal orientation",
-             src="../progress-steps-horizontal-orientation.svg" %}
+             src="../progress-steps-horizontal-orientation.svg" %}{% endexample %}
 
 ### Vertical
 
@@ -83,7 +83,7 @@
   {% example palette="lightest",
              width=872,
              alt="Progress steps component vertical orientation",
-             src="../progress-steps-vertical-orientation.svg" %}
+             src="../progress-steps-vertical-orientation.svg" %}{% endexample %}
 
 
 ## Responsive design
@@ -118,5 +118,5 @@
   {% example palette="lightest",
              width=687,
              alt="Progress steps component spacing",
-             src="../progress-steps-spacing.svg" %}
+             src="../progress-steps-spacing.svg" %}{% endexample %}
 

--- a/elements/rh-progress-steps/docs/20-guidelines.md
+++ b/elements/rh-progress-steps/docs/20-guidelines.md
@@ -18,7 +18,7 @@
   {% example palette="lightest",
              width=360,
              alt="Progress steps component mobile usage",
-             src="../progress-steps-mobile-usage.svg" %}
+             src="../progress-steps-mobile-usage.svg" %}{% endexample %}
 
 ### Progression
 
@@ -35,12 +35,12 @@
   {% example palette="lightest",
              width=691,
              alt="Progress steps component progression, part 1",
-             src="../progress-steps-progression-1.svg" %}
+             src="../progress-steps-progression-1.svg" %}{% endexample %}
 
   {% example palette="lightest",
              width=687,
              alt="Progress steps component progression, part 2",
-             src="../progress-steps-progression-2.svg" %}
+             src="../progress-steps-progression-2.svg" %}{% endexample %}
 
 ### Error validation
 
@@ -53,7 +53,7 @@
   {% example palette="lightest",
              width=687,
              alt="Progress steps component validation",
-             src="../progress-steps-validation.svg" %}
+             src="../progress-steps-validation.svg" %}{% endexample %}
 
 ### Completion
 
@@ -69,7 +69,7 @@
   {% example palette="lightest",
              width=702,
              alt="Progress steps component completion",
-             src="../progress-steps-completion.svg" %}
+             src="../progress-steps-completion.svg" %}{% endexample %}
 
 
 ## Behavior
@@ -84,7 +84,7 @@
   {% example palette="lightest",
              width=728,
              alt="Progress steps component behavior",
-             src="../progress-steps-behavior.svg" %}
+             src="../progress-steps-behavior.svg" %}{% endexample %}
 
 
 ## Interaction states
@@ -96,28 +96,28 @@
   {% example palette="lightest",
              width=738,
              alt="Progress steps component interaction state, link",
-             src="../progress-steps-interaction-states-link.svg" %}
+             src="../progress-steps-interaction-states-link.svg" %}{% endexample %}
 
 ### Hover
 
   {% example palette="lightest",
              width=738,
              alt="Progress steps component interaction state, hover",
-             src="../progress-steps-interaction-states-hover.svg" %}
+             src="../progress-steps-interaction-states-hover.svg" %}{% endexample %}
 
 ### Focus
 
   {% example palette="lightest",
              width=738,
              alt="Progress steps component interaction state, focus",
-             src="../progress-steps-interaction-states-focus.svg" %}
+             src="../progress-steps-interaction-states-focus.svg" %}{% endexample %}
 
 ### Active
 
   {% example palette="lightest",
              width=738,
              alt="Progress steps component interaction state, active",
-             src="../progress-steps-interaction-states-active.svg" %}
+             src="../progress-steps-interaction-states-active.svg" %}{% endexample %}
 
 ### Tab order
 
@@ -128,7 +128,7 @@
   {% example palette="lightest",
              width=738,
              alt="Progress steps component tab order",
-             src="../progress-steps-tab-order.svg" %}
+             src="../progress-steps-tab-order.svg" %}{% endexample %}
 
 
 
@@ -155,7 +155,7 @@
   {% example palette="wrong",
              width=698,
              alt="Progress steps component best practice 1",
-             src="../progress-steps-best-practice-1.svg" %}
+             src="../progress-steps-best-practice-1.svg" %}{% endexample %}
 
 ### Usage on mobile
 
@@ -166,7 +166,7 @@
   {% example palette="wrong",
              width=360,
              alt="Progress steps component best practice 2",
-             src="../progress-steps-best-practice-2.svg" %}
+             src="../progress-steps-best-practice-2.svg" %}{% endexample %}
 
 ### Validation
 
@@ -177,7 +177,7 @@
   {% example palette="wrong",
              width=687,
              alt="Progress steps component best practice 3",
-             src="../progress-steps-best-practice-3.svg" %}
+             src="../progress-steps-best-practice-3.svg" %}{% endexample %}
 
 ### Text labels
 
@@ -188,7 +188,7 @@
   {% example palette="wrong",
              width=687,
              alt="Progress steps component best practice 4",
-             src="../progress-steps-best-practice-4.svg" %}
+             src="../progress-steps-best-practice-4.svg" %}{% endexample %}
 
 ### Carousel
 
@@ -198,7 +198,7 @@
   {% example palette="wrong",
              width=687,
              alt="Progress steps component best practice 5",
-             src="../progress-steps-best-practice-5.svg" %}
+             src="../progress-steps-best-practice-5.svg" %}{% endexample %}
 
 ### Tabs
 
@@ -208,5 +208,5 @@
   {% example palette="wrong",
              width=687,
              alt="Progress steps component best practice 6",
-             src="../progress-steps-best-practice-6.svg" %}
+             src="../progress-steps-best-practice-6.svg" %}{% endexample %}
 

--- a/elements/rh-spinner/docs/00-overview.md
+++ b/elements/rh-spinner/docs/00-overview.md
@@ -3,7 +3,7 @@
 
 {% example palette="light",
            alt="Example of a spinner",
-           src="spinner-sample.png" %}
+           src="spinner-sample.png" %}{% endexample %}
 
 
 

--- a/elements/rh-spinner/docs/10-style.md
+++ b/elements/rh-spinner/docs/10-style.md
@@ -8,7 +8,7 @@ optional text label.
 ### Anatomy
 {% example palette="light",
           alt=" Anatomy of a spinner with annotations; number 1 is pointing to the track, number 2 is pointing to the indicator, and number 3 is pointing to the optional text label",
-          src="../spinner-anatomy.png" %}
+          src="../spinner-anatomy.png" %}{% endexample %}
 
 1) Track
 2) Indicator
@@ -25,7 +25,7 @@ optional text label on the bottom.
 
 {% example palette="light",
           alt=" Small size, medium size, and large size spinners with their text labels below",
-          src="../spinner-sizes.png" %}
+          src="../spinner-sizes.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -47,13 +47,13 @@ A spinner is available in both light and dark themes.
 
 {% example palette="light",
           alt=" Light theme spinner",
-          src="../spinner-theme-light.png" %}
+          src="../spinner-theme-light.png" %}{% endexample %}
 
 ### Dark theme
 
 {% example palette="darkest",
           alt=" Dark theme spinner",
-          src="../spinner-theme-dark.png" %}
+          src="../spinner-theme-dark.png" %}{% endexample %}
 
 
 
@@ -66,7 +66,7 @@ rather than one specific area.
 
 {% example palette="light",
           alt=" Diagram of how a spinner should be horizontally and vertically centered within a container no matter its size or if a text label is included or not",
-          src="../spinner-configuration-container.png" %}
+          src="../spinner-configuration-container.png" %}{% endexample %}
 
 ### Button
 
@@ -75,13 +75,13 @@ left of the text as if it were an icon.
 
 {% example palette="light",
           alt=" Button with a small size spinner icon to the left as if it were an icon",
-          src="../spinner-configuration-button.png" %}
+          src="../spinner-configuration-button.png" %}{% endexample %}
 
 ## Space
 
 {% example palette="light",
           alt=" Spacing between all spinner sizes and their text labels",
-          src="../spinner-space.png" %}
+          src="../spinner-space.png" %}{% endexample %}
 
 {% tokensTable %}
 

--- a/elements/rh-spinner/docs/20-guidelines.md
+++ b/elements/rh-spinner/docs/20-guidelines.md
@@ -25,7 +25,7 @@ occupies, use a spinner size that matches.
 {% example palette="none",
           alt="Spinner usage examples; from top to bottom, an app, a dialog, a card, and a 
 button showing spinners of various sizes with and without text labels",
-          src="../spinner-examples.png" %}
+          src="../spinner-examples.png" %}{% endexample %}
 
 ## Orientation
 
@@ -33,7 +33,7 @@ A spinner is always oriented above the optional text label, if visible.
 
 {% example palette="light",
           alt=" Two spinners; one showing the correct orientation and the other showing an incorrect orientation",
-          src="../spinner-orientation.png" %}
+          src="../spinner-orientation.png" %}{% endexample %}
 
 ## Text label
 
@@ -42,7 +42,7 @@ enough time to read it.
 
 {% example palette="light",
           alt=" Two spinners; one with a short text label, which is acceptable, and one with a very long text label which is not acceptable",
-          src="../spinner-text-label.png" %}
+          src="../spinner-text-label.png" %}{% endexample %}
 
 ## Animation
 
@@ -59,7 +59,7 @@ specific part.
 
 {% example palette="wrong",
           alt=" A spinner not horizontally or vertically centered in a container which is incorrect usage",
-          src="../spinner-best-practice-1.png" %}
+          src="../spinner-best-practice-1.png" %}{% endexample %}
 
 ### Cut off by browser window
 
@@ -68,7 +68,7 @@ it does.
 
 {% example palette="wrong",
           alt=" A small spinner used in a large container which is incorrect usage",
-          src="../spinner-best-practice-2.png" %}
+          src="../spinner-best-practice-2.png" %}{% endexample %}
 
 ### Wrong orientation
 
@@ -77,5 +77,5 @@ text label.
 
 {% example palette="wrong",
           alt=" Two spinners with different orientations which is incorrect usage",
-          src="../spinner-best-practice-3.png" %}
+          src="../spinner-best-practice-3.png" %}{% endexample %}
 

--- a/elements/rh-stat/docs/00-overview.md
+++ b/elements/rh-stat/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 {% example palette="light",
            alt="A vertically aligned stack of elements; includes a small red icon, large red data text showing 80% percent, and two lines of black body text",
-           src="stat-sample-element.png" %}
+           src="stat-sample-element.png" %}{% endexample %}
 
 
 ## Sample element

--- a/elements/rh-stat/docs/10-style.md
+++ b/elements/rh-stat/docs/10-style.md
@@ -10,7 +10,7 @@ additional emphasis or context.
 ### Anatomy
 {% example palette="light",
            alt="Anatomy of a statistic with annotations; number 1 is pointing to an optional icon, number 2 is pointing to optional title text, number 3 is pointing to data text, number 4 is pointing to body text, and number 5 is pointing to an optional call to action",
-           src="../stat-anatomy.png" %}
+           src="../stat-anatomy.png" %}{% endexample %}
 
 1. Optional icon
 2. Optional title text
@@ -25,7 +25,7 @@ elements.
 
 {% example palette="light",
            alt="Default size and Large size statistics both with icons and body text; text under the default size says ‘Default size’ and text under the large size says ‘Large size’",
-           src="../stat-sizes.png" %}
+           src="../stat-sizes.png" %}{% endexample %}
 
 {% tokensTable %}
 
@@ -52,14 +52,14 @@ requirements.
 {% example
    palette="light",
    alt="Light theme statistic with a red icon, red data text, and black body text",
-   src="../stat-theme-light.png" %}
+   src="../stat-theme-light.png" %}{% endexample %}
 
 ### Dark theme
 
 {% example
    palette="darkest",
    alt="Dark theme statistic with a white icon and white text styles to meet accessibility contrast requirements",
-   src="../stat-theme-dark.png" %}
+   src="../stat-theme-dark.png" %}{% endexample %}
 
 ## Configuration
 ### Container
@@ -72,7 +72,7 @@ surrounding content is all left aligned.
 {% example
   palette="light",
   alt="Statistic with a dotted vertical line through it",
-  src="../stat-configuration.png" %}
+  src="../stat-configuration.png" %}{% endexample %}
 
 ### Order
 A statistic was designed to be read from top to bottom. If certain optional 
@@ -81,7 +81,7 @@ elements are included, the order will change.
 {% example
   palette="light",
   alt="Statistic with boxes around each element slot, there are also numbers next to each box arranged 1 to 4 from top to bottom",
-  src="../stat-configuration-order.png" %}
+  src="../stat-configuration-order.png" %}{% endexample %}
 
 1. Icon (always ordered first if included)
 2. Title text and data text (ordered first if there is no icon)
@@ -97,7 +97,7 @@ go to the [Guidelines](../guidelines) page.
 {% example 
   palette="light",
   alt="Default and Large size spacing between all elements",
-  src="../stat-space.png" %}
+  src="../stat-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
     headline='',

--- a/elements/rh-stat/docs/20-guidelines.md
+++ b/elements/rh-stat/docs/20-guidelines.md
@@ -14,7 +14,7 @@ better integrates the data with the rest of the page content.
 {% example 
   palette="light",
   alt="A statistic with a small text footnote underneath",
-  src="../stat-footnote.png" %}
+  src="../stat-footnote.png" %}{% endexample %}
 
 ## Icons
 Use an icon to add visual context and emphasis while helping to explain a 
@@ -23,7 +23,7 @@ statistic further.
 {% example 
   palette="light",
   alt="Two statistics with icons; the left statistic has a fighter jet icon on top whereas the right has a wrench",
-  src="../stat-icon-regular.png" %}
+  src="../stat-icon-regular.png" %}{% endexample %}
 
 ### Large icon
 There are situations where a large icon is used in place of data text and the 
@@ -34,7 +34,7 @@ instead.
 {% example 
   palette="light",
   alt="Three statistics with large icons and body text",
-  src="../stat-icon-large.png" %}
+  src="../stat-icon-large.png" %}{% endexample %}
 
 ## Writing content
 Statistic text is meant to be short so it can have impact especially when 
@@ -76,7 +76,7 @@ grouped.
 {% example 
   palette="light",
   alt="Two statistics, one with title text above the data text and the other with title text below data text",
-  src="../stat-text-slot-title.png" %}
+  src="../stat-text-slot-title.png" %}{% endexample %}
 
 ### Data text
 Data text is the number or percent that represents data.
@@ -84,7 +84,7 @@ Data text is the number or percent that represents data.
 {% example
   palette="light",
   alt="Two statistics with different data text percents",
-  src="../stat-text-slot-data.png" %}
+  src="../stat-text-slot-data.png" %}{% endexample %}
 
 ### Body text
 Body text explains data text. A percent or number means nothing without 
@@ -93,7 +93,7 @@ something that explains the rest of the statistic.
 {% example
   palette="light",
   alt="Two statistics with different body text examples",
-  src="../stat-text-slot-body.png" %}
+  src="../stat-text-slot-body.png" %}{% endexample %}
 
 ### Call to action text
 Use a call to action to entice users to learn more after they read a statistic. 
@@ -103,7 +103,7 @@ call to action.
 {% example
   palette="light",
   alt="Statistic with a call to action",
-  src="../stat-text-slot-cta.png" %}
+  src="../stat-text-slot-cta.png" %}{% endexample %}
 
 ### Internationalization
 Translated text can increase or decrease character counts, line length, and the 
@@ -115,12 +115,12 @@ around them.
 {% example
   palette="light",
   alt="Two statistics with English on top and German on the bottom; the English statistic has two lines of body text whereas the German has three",
-  src="../stat-i18n-a.png" %}
+  src="../stat-i18n-a.png" %}{% endexample %}
 
 {% example
     palette="light",
     alt="Two statistics with English on top and Chinese on the bottom; the English statistic body text is wider whereas the Chinese is thinner",
-    src="../stat-i18n-b.png" %}
+    src="../stat-i18n-b.png" %}{% endexample %}
 
 ## Layout
 
@@ -131,7 +131,7 @@ regardless if they are in a container or not.
 {% example
     palette="light",
     alt="Four statistics arranged evenly-spaced on a 12-column grid",
-    src="../stat-layout-grouping.png" %}
+    src="../stat-layout-grouping.png" %}{% endexample %}
 
 ### Card
 A statistic can be placed in a card if the body text or other text styles are 
@@ -140,7 +140,7 @@ short enough. Otherwise, keep them on the page to avoid readability issues.
 {% example
     palette="light",
     alt="Four statistics placed in cards and arranged evenly-spaced on a 12-column grid",
-    src="../stat-layout-card.png" %}
+    src="../stat-layout-card.png" %}{% endexample %}
 
 ### Alignment
 By default, a statistic is always center aligned. However, a statistic may be 
@@ -149,7 +149,7 @@ left aligned if grouped and if the surrounding content is also left aligned.
 {% example
     palette="light",
     alt="Three statistics left aligned with vertical dashed lines on the left side of each",
-    src="../stat-layout-alignment.png" %}
+    src="../stat-layout-alignment.png" %}{% endexample %}
 
 ### Padding
 The page grid usually determines the space between blocks or containers of 
@@ -159,7 +159,7 @@ breakpoints, the padding is 48px for better vertical rhythm.
 {% example
     palette="light",
     alt="Two groups of statistics; one group has 32px of padding with text underneath that says ‘Large breakpoints’, the other group has 48px of padding with text underneath that says ‘Small breakpoints’",
-    src="../stat-layout-padding.png" %}
+    src="../stat-layout-padding.png" %}{% endexample %}
 
 ## Responsive design
 
@@ -169,7 +169,7 @@ If only one statistic is used, it can span a maximum of six columns.
 {% example
     palette="light",
     alt="Statistic spanning less than six columns with a box around the body copy spanning six columns",
-    src="../stat-breakpoint-large.png" %}
+    src="../stat-breakpoint-large.png" %}{% endexample %}
 
 ### Small breakpoints
 Statistics arranged in a row on large breakpoints will stack on small
@@ -179,7 +179,7 @@ typography scale](https://ux.redhat.com/foundations/typography/).
 {% example
     palette="light",
     alt="Three statistics spanning the width of one column on mobile",
-    src="../stat-breakpoint-small.png" %}
+    src="../stat-breakpoint-small.png" %}{% endexample %}
 
 ## Best practices
 
@@ -189,7 +189,7 @@ Do not duplicate or rearrange any element to create a custom statistic.
 {% example
     palette="wrong",
     alt="Statistic with some elements arranged horizontally and some vertically which is incorrect usage",
-    src="../stat-best-practice-1.png" %}
+    src="../stat-best-practice-1.png" %}{% endexample %}
 
 ### Unrelated icon
 Do not use an icon that is unrelated to the rest of the statistic content.
@@ -197,7 +197,7 @@ Do not use an icon that is unrelated to the rest of the statistic content.
 {% example
     palette="wrong",
     alt="Statistic with a crab icon on top of text which is incorrect usage",
-    src="../stat-best-practice-2.png" %}
+    src="../stat-best-practice-2.png" %}{% endexample %}
 
 ### Inconsistent elements
 Keep statistics consistent when grouping. Either use the same number of elements 
@@ -208,7 +208,7 @@ icon.
 {% example
     palette="wrong",
     alt="Three statistics with different element combinations with is incorrect usage",
-    src="../stat-best-practice-3.png" %}
+    src="../stat-best-practice-3.png" %}{% endexample %}
 
 ### Too much text
 Do not include too much body text, a statistic should clarify a single data 
@@ -217,5 +217,5 @@ point quickly and with impact, not tell a long story.
 {% example
     palette="wrong",
     alt="Statistic with data text and long lines of body text which is incorrect usage",
-    src="../stat-best-practice-4.png" %}
+    src="../stat-best-practice-4.png" %}{% endexample %}
 

--- a/elements/rh-stat/docs/40-accessibility.md
+++ b/elements/rh-stat/docs/40-accessibility.md
@@ -5,7 +5,7 @@ Only the call to action can receive focus if included.
 {% example
     palette="light",
     alt="Statistic keyboard interactions; pressing Tab will focus the call to action if included and pressing Tab again will move focus to the next interactive element",
-    src="../stat-keyboard-interactions.png" %}
+    src="../stat-keyboard-interactions.png" %}{% endexample %}
 
 | Key         | Result                                          |
 | ----------- | ----------------------------------------------- |
@@ -20,7 +20,7 @@ Only the call to action is selectable if included.
 {% example
     palette="light",
     alt="Statistic showing touch target size for call to action if included",
-    src="../stat-a11y-touch-targets.png" %}
+    src="../stat-a11y-touch-targets.png" %}{% endexample %}
 
 {% include 'accessibility/ariaguide.md' %}
 

--- a/elements/rh-subnav/docs/00-overview.md
+++ b/elements/rh-subnav/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 {% example palette="lightest",
            alt="Image of a subnavigation; a horizontal row of links placed on a light gray bar",
-           src="subnav-sample.png" %}
+           src="subnav-sample.png" %}{% endexample %}
 
 ## Sample element
 

--- a/elements/rh-subnav/docs/10-style.md
+++ b/elements/rh-subnav/docs/10-style.md
@@ -8,7 +8,7 @@ except for the active page accent.
 
 {% example palette="lightest",
            alt="Anatomy image showing a subnavigation with various annotation numbers",
-           src="../subnav-anatomy.png" %}
+           src="../subnav-anatomy.png" %}{% endexample %}
 
 1. Active page
 1. Active page accent
@@ -24,7 +24,7 @@ A subnavigation is available in the light theme only right now.
 
 {% example palette="lightest",
            alt="Image of light theme desktop and mobile subnavigations",
-           src="../subnav-theme-light.png" %}
+           src="../subnav-theme-light.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property | Current value               |
@@ -38,7 +38,7 @@ Each link container is the same height as the bar.
 
 {% example palette="lightest",
            alt="Image of desktop and mobile subnavigations with various specs like height, width, and more",
-           src="../subnav-configuration.png" %}
+           src="../subnav-configuration.png" %}{% endexample %}
 
 ## Space
 
@@ -49,7 +49,7 @@ or a heading, go to the Guidelines page.
 
 {% example palette="lightest",
            alt="Image of desktop and mobile subnavigations with spacing values in between",
-           src="../subnav-space.png" %}
+           src="../subnav-space.png" %}{% endexample %}
 
 {% spacerTokensTable headline="",
                     caption='',
@@ -67,7 +67,7 @@ Inactive links and overflow buttons have the same hover state.
 
 {% example palette="lightest",
            alt="Image of light theme hover states",
-           src="../subnav-interaction-state-hover.png" %}
+           src="../subnav-interaction-state-hover.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property | Current value                |
@@ -83,7 +83,7 @@ The Focus state has the same styles as the Hover state.
 
 {% example palette="lightest",
            alt="Image of light theme focus states",
-           src="../subnav-interaction-state-focus.png" %}
+           src="../subnav-interaction-state-focus.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property | Current value                |
@@ -99,7 +99,7 @@ The Active state has the same styles as the Hover state.
 
 {% example palette="lightest",
            alt="Image of light theme active states",
-           src="../subnav-interaction-state-active.png" %}
+           src="../subnav-interaction-state-active.png" %}{% endexample %}
 
 {% tokensTable %}
 | Property | Current value                |

--- a/elements/rh-subnav/docs/20-guidelines.md
+++ b/elements/rh-subnav/docs/20-guidelines.md
@@ -25,7 +25,7 @@ navigation.
 
 {% example palette="lightest",
            alt="Image of the primary navigation, secondary navigation, and subnavigation being compared",
-           src="../subnav-vs-other-navs.png" %}
+           src="../subnav-vs-other-navs.png" %}{% endexample %}
 
 ### Number of links
 
@@ -34,7 +34,7 @@ four or five links.
 
 {% example palette="lightest",
            alt="Image of a subnavigation with five short link text labels",
-           src="../subnav-number-of-links.png" %}
+           src="../subnav-number-of-links.png" %}{% endexample %}
 
 ### Inset
 
@@ -43,7 +43,7 @@ text labels, and overflow buttons.
 
 {% example palette="lightest",
            alt="Image of three desktop and one mobile subnavigations with various inset values",
-           src="../subnav-inset.png" %}
+           src="../subnav-inset.png" %}{% endexample %}
 
 <hgroup>
 
@@ -58,7 +58,7 @@ strategist to shorten them.
 
 {% example palette="lightest",
            alt="Image of two subnavigations; one with short text labels and one with long text labels",
-           src="../subnav-link-text-labels.png" %}
+           src="../subnav-link-text-labels.png" %}{% endexample %}
 
 ### Character count
 
@@ -79,7 +79,7 @@ A subnavigation can be placed below the primary navigation or a heading.
 
 {% example palette="none",
            alt="Image of subnavigations positioned below the primary navigation and a heading",
-           src="../subnav-layout.png" %}
+           src="../subnav-layout.png" %}{% endexample %}
 
 <hgroup>
 
@@ -94,7 +94,7 @@ user moves from page to page.
 
 {% example palette="lightest",
            alt="Image of a desktip and mobile subnavigation showing with the current page indicator visible",
-           src="../subnav-current-page-indicator.png" %}
+           src="../subnav-current-page-indicator.png" %}{% endexample %}
 
 ### Scrolling
 
@@ -108,13 +108,13 @@ positioned under the primary navigation or heading again.
 
 {% example palette="none",
            alt="Image of a subnavigation and how it behaves when scrolling under the primary navigation",
-           src="../subnav-scrolling-primary-nav.png" %}
+           src="../subnav-scrolling-primary-nav.png" %}{% endexample %}
 
 ### With heading
 
 {% example palette="none",
            alt="Image of a subnavigation and how it behaves when scrolling under a heading",
-           src="../subnav-scrolling-heading.png" %}
+           src="../subnav-scrolling-heading.png" %}{% endexample %}
 
 ### Overflow
 
@@ -124,7 +124,7 @@ scroll to reveal hidden links.
 
 {% example palette="lightest",
            alt="Image of a desktop subnavigation with no overflow buttons and two mobile subnavigations with overflow buttons visible",
-           src="../subnav-overflow.png" %}
+           src="../subnav-overflow.png" %}{% endexample %}
 
 ### Navigating overflow links
 
@@ -135,7 +135,7 @@ view.
 
 {% example palette="lightest",
            alt="Image of selecting a cut off link and the list of links shifting to reveal the selected link in full view",
-           src="../subnav-navigating-overflow-links.png" %}
+           src="../subnav-navigating-overflow-links.png" %}{% endexample %}
 
 ## Responsive design
 
@@ -148,13 +148,13 @@ labels.
 
 {% example palette="none",
            alt="Image of subnavigations on large breakpoints",
-           src="../subnav-responsive-breakpoints-large.png" %}
+           src="../subnav-responsive-breakpoints-large.png" %}{% endexample %}
 
 ### Small breakpoints
 
 {% example palette="none",
            alt="Image of subnavigations on small breakpoints",
-           src="../subnav-responsive-breakpoints-small.png" %}
+           src="../subnav-responsive-breakpoints-small.png" %}{% endexample %}
 
 <hgroup>
 
@@ -167,7 +167,7 @@ Do not position the subnavigation above the primary navigation.
 
 {% example palette="wrong",
            alt="Image of a subnavigation above the primary navigation, which is incorrect usage",
-           src="../subnav-best-practice-1.png" %}
+           src="../subnav-best-practice-1.png" %}{% endexample %}
 
 ### Not enough links
 
@@ -175,7 +175,7 @@ There should be at least two links minimum.
 
 {% example palette="wrong",
            alt="Image of a subnavigation with only one link, which is incorrect usage",
-           src="../subnav-best-practice-2.png" %}
+           src="../subnav-best-practice-2.png" %}{% endexample %}
 
 ### Too many links
 
@@ -184,7 +184,7 @@ at large breakpoints.
 
 {% example palette="wrong",
            alt="Image of a subnavigation with seven links and overflow buttons, which is incorrect usage",
-           src="../subnav-best-practice-3.png" %}
+           src="../subnav-best-practice-3.png" %}{% endexample %}
 
 ### Extra spacing
 
@@ -192,7 +192,7 @@ Do not add extra spacing or stretch the width of links.
 
 {% example palette="wrong",
            alt="Image of a subnavigation with stretched links, which is incorrect usage",
-           src="../subnav-best-practice-4.png" %}
+           src="../subnav-best-practice-4.png" %}{% endexample %}
 
 ### Overflow buttons
 
@@ -200,5 +200,5 @@ Overflow buttons should not be visible if all links are visible.
 
 {% example palette="wrong",
            alt="Image of a subnavigation with only two links and overflow buttons, which is incorrect usage",
-           src="../subnav-best-practice-5.png" %}
+           src="../subnav-best-practice-5.png" %}{% endexample %}
 

--- a/elements/rh-subnav/docs/40-accessibility.md
+++ b/elements/rh-subnav/docs/40-accessibility.md
@@ -9,7 +9,7 @@ Overflow buttons do not have focus so there are no keyboard interactions.
 
 {% example palette="lightest",
            alt="Image of desktop and mobile subnavigations with diagrams of what happens when Tab keys are pressed",
-           src="../subnav-a11y-keyboard-interactions.png" %}
+           src="../subnav-a11y-keyboard-interactions.png" %}{% endexample %}
 
 | Key                             | Result                                                  |
 | ------------------------------- | ------------------------------------------------------- |
@@ -27,7 +27,7 @@ element.
 
 {% example palette="lightest",
            alt="Image of desktop and mobile subnavigations showing the focus order from left to right",
-           src="../subnav-a11y-focus-order.png" %}
+           src="../subnav-a11y-focus-order.png" %}{% endexample %}
 
 ## Touch targets
 
@@ -35,7 +35,7 @@ Links are adequately spaced for optimal touch targets.
 
 {% example palette="lightest",
            alt="Image of desktop and mobile subnavigations showing adequate touch target spacing",
-           src="../subnav-a11y-touch-targets.png" %}
+           src="../subnav-a11y-touch-targets.png" %}{% endexample %}
 
 {% include 'accessibility/ariaguide.md' %}
 

--- a/elements/rh-tabs/docs/00-overview.md
+++ b/elements/rh-tabs/docs/00-overview.md
@@ -1,7 +1,7 @@
 ## Overview
   {{ tagName | getElementDescription }}
 
-  {% example palette="light", alt="Image of open tabs, box tabs, and tabs with overflow buttons", src="./tabs-sample.png" %}
+  {% example palette="light", alt="Image of open tabs, box tabs, and tabs with overflow buttons", src="./tabs-sample.png" %}{% endexample %}
 
 ## Sample element
   <rh-tabs>

--- a/elements/rh-tabs/docs/10-style.md
+++ b/elements/rh-tabs/docs/10-style.md
@@ -3,7 +3,7 @@
   Tabs are used to group related content allowing users to navigate a view without leaving the page) Each tab is a text label placed in a visible or invisible container. There are two variants in two orientations and some of the styles and padding shift slightly depending on which variant is used.
 
 ### Anatomy
-  {% example palette="light", alt="Image of tabs anatomy showing horizontal and vertical open tabs and box tabs with lots of annotations", src="../tabs-anatomy.png" %}
+  {% example palette="light", alt="Image of tabs anatomy showing horizontal and vertical open tabs and box tabs with lots of annotations", src="../tabs-anatomy.png" %}{% endexample %}
 
   1) Active tab
   2) Active tab accent
@@ -18,18 +18,18 @@
 ### Variants
   There are two available variants. Open tabs has a more understated style whereas Box tabs has a more traditional style.
 
-  {% example palette="light", alt="Image of open tabs on top and box tabs below", src="../tabs-variations.png" %}
+  {% example palette="light", alt="Image of open tabs on top and box tabs below", src="../tabs-variations.png" %}{% endexample %}
 
 ### Orientations
   There are two available orientations and the only difference is padding.
 
-  {% example palette="light", alt="Image of horizontal, vertical, and tabs with overflow buttons showing padding spacers", src="../tabs-orientation.png" %}
+  {% example palette="light", alt="Image of horizontal, vertical, and tabs with overflow buttons showing padding spacers", src="../tabs-orientation.png" %}{% endexample %}
 
 ## Theme
   Both variants and orientations are available in both light and dark themes.
 ### Light theme
 
-  {% example palette="light", alt="Image of light theme tabs", src="../tabs-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme tabs", src="../tabs-theme-light.png" %}{% endexample %}
 
   | Property {style="width: 50%;"} | Light theme   |
   | ------------------------------ | ------------- |
@@ -46,7 +46,7 @@
 
 ### Dark theme
 
-  {% example palette="darkest", alt="Image of dark theme tabs", src="../tabs-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme tabs", src="../tabs-theme-dark.png" %}{% endexample %}
 
   | Property {style="width: 50%;"} | Dark theme    |
   | ------------------------------ | ------------- |
@@ -64,19 +64,19 @@
 ## Configuration
   The panel for both orientations of tabs does not have a maximum height and should not scroll.
 
-  {% example palette="light", alt="Image of horizontal and vertical tabs construction; several examples showing details like alignment, height, width, and more", src="../tabs-configuration.png" %}
+  {% example palette="light", alt="Image of horizontal and vertical tabs construction; several examples showing details like alignment, height, width, and more", src="../tabs-configuration.png" %}{% endexample %}
 
 ### Overflow buttons
   Overflow buttons are containers with chevron icons that are added to tabs on small breakpoints.
 
-  {% example palette="light", alt="Image of horizontal and vertical tabs with overflow buttons showing padding spacers", src="../tabs-configuration-overflow-buttons.png" %}
+  {% example palette="light", alt="Image of horizontal and vertical tabs with overflow buttons showing padding spacers", src="../tabs-configuration-overflow-buttons.png" %}{% endexample %}
 
 ## Space
   Box tabs are separated by a 1px divider.
 
-  {% example palette="light", alt="Image of open tabs spacing for all sizes and orientations", src="../tabs-space-open.png" %}
+  {% example palette="light", alt="Image of open tabs spacing for all sizes and orientations", src="../tabs-space-open.png" %}{% endexample %}
 
-  {% example palette="light", alt="Image of box tabs spacing for all sizes and orientations", src="../tabs-space-box.png" %}
+  {% example palette="light", alt="Image of box tabs spacing for all sizes and orientations", src="../tabs-space-box.png" %}{% endexample %}
 
   {% spacerTokensTable headline="", caption='', headingLevel="4", tokens="--rh-space-md, --rh-space-lg, --rh-space-2xl" %} {% endspacerTokensTable %}
 
@@ -85,15 +85,15 @@
 ### Hover - Open tabs
   Inactive tabs and overflow buttons have the same hover state.
 
-  {% example palette="light", alt="Image of light theme open tabs hover states", src="../tabs-open-interaction-state-hover-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme open tabs hover states", src="../tabs-open-interaction-state-hover-theme-light.png" %}{% endexample %}
 
-  {% example palette="darkest", alt="Image of dark theme open tabs hover states", src="../tabs-open-interaction-state-hover-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme open tabs hover states", src="../tabs-open-interaction-state-hover-theme-dark.png" %}{% endexample %}
   
 ### Hover - Box tabs
 
-  {% example palette="light", alt="Image of light theme box tabs hover states", src="../tabs-box-interaction-state-hover-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme box tabs hover states", src="../tabs-box-interaction-state-hover-theme-light.png" %}{% endexample %}
 
-  {% example palette="darkest", alt="Image of dark theme box tabs hover states", src="../tabs-box-interaction-state-hover-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme box tabs hover states", src="../tabs-box-interaction-state-hover-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -108,17 +108,17 @@
 
   {% alert state="info", title="Helpful Tip" %} The Focus state has the same styles as the Hover state. {% endalert %}
 
-  {% example palette="light", alt="Image of light theme open tabs focus states", src="../tabs-open-interaction-state-focus-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme open tabs focus states", src="../tabs-open-interaction-state-focus-theme-light.png" %}{% endexample %}
 
-  {% example palette="darkest", alt="Image of dark theme open tabs focus states", src="../tabs-open-interaction-state-focus-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme open tabs focus states", src="../tabs-open-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
 ### Focus - Box tabs
 
   {% alert state="info", title="Helpful Tip" %} The Focus state has the same styles as the Hover state. {% endalert %}
 
-  {% example palette="light", alt="Image of light theme box tabs focus states", src="../tabs-box-interaction-state-focus-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme box tabs focus states", src="../tabs-box-interaction-state-focus-theme-light.png" %}{% endexample %}
 
-  {% example palette="darkest", alt="Image of dark theme box tabs focus states", src="../tabs-box-interaction-state-focus-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme box tabs focus states", src="../tabs-box-interaction-state-focus-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 
@@ -131,16 +131,16 @@
 ### Active - Open tabs
   {% alert state="info", title="Helpful Tip" %} The Active state has the same styles as the Hover state. {% endalert %}
 
-  {% example palette="light", alt="Image of light theme open tabs active states", src="../tabs-open-interaction-state-active-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme open tabs active states", src="../tabs-open-interaction-state-active-theme-light.png" %}{% endexample %}
 
-  {% example palette="darkest", alt="Image of dark theme open tabs active states", src="../tabs-open-interaction-state-active-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme open tabs active states", src="../tabs-open-interaction-state-active-theme-dark.png" %}{% endexample %}
 
 ### Active - Box tabs
   {% alert state="info", title="Helpful Tip" %} The Active state has the same styles as the Hover state. {% endalert %}
 
-  {% example palette="light", alt="Image of light theme box tabs active states", src="../tabs-box-interaction-state-active-theme-light.png" %}
+  {% example palette="light", alt="Image of light theme box tabs active states", src="../tabs-box-interaction-state-active-theme-light.png" %}{% endexample %}
 
-  {% example palette="darkest", alt="Image of dark theme box tabs active states", src="../tabs-box-interaction-state-active-theme-dark.png" %}
+  {% example palette="darkest", alt="Image of dark theme box tabs active states", src="../tabs-box-interaction-state-active-theme-dark.png" %}{% endexample %}
 
   {% tokensTable %}
 

--- a/elements/rh-tabs/docs/20-guidelines.md
+++ b/elements/rh-tabs/docs/20-guidelines.md
@@ -5,64 +5,64 @@ Use tabs to organize lots of information into logical sections. Consider using a
 ### Tabs vs. accordion
 Tabs allow users to click through content one section at a time whereas an accordion allows users to view multiple sections of content simultaneously.
 
-{% example palette="light", alt="Image of tabs on top and an accordion below with two panels expanded", src="../tabs-vs-accordion.png" %}
+{% example palette="light", alt="Image of tabs on top and an accordion below with two panels expanded", src="../tabs-vs-accordion.png" %}{% endexample %}
 
 ### Number of tabs
 To reduce cognitive load and a cluttered user interface, avoid using more than three or four tabs.
 
-{% example palette="light", alt="Image of open tabs with three tabs on top and box tabs with three tabs below", src="../tabs-number-of-tabs.png" %}
+{% example palette="light", alt="Image of open tabs with three tabs on top and box tabs with three tabs below", src="../tabs-number-of-tabs.png" %}{% endexample %}
 
 ## Variants
 When choosing one variation over the other, consider where it is being used. If using tabs multiple times on one page, use one variation only.
 <strong>Open tabs</strong> - use if you want to keep your design clean and maintain a minimal look and feel
 <strong>Box tabs</strong> - use if your design includes a lot of boxes or you want to maintain the classic tabs look and feel
 
-{% example palette="light", alt="Image of open tabs on top and box tabs below", src="../tabs-variations.png" %}
+{% example palette="light", alt="Image of open tabs on top and box tabs below", src="../tabs-variations.png" %}{% endexample %}
 
 ### Orientation
 When choosing one orientation over the other, consider the content in the panel, other elements in the layout, and how you want users to read the content:
 Horizontal tabs are placed in the middle of a container and offer users a <strong>top-to-bottom</strong> reading experience
 Vertical tabs are placed on the left side of a container and offer users a <strong>left-to-right</strong> reading experience
 
-{% example palette="light", alt="Image of horizontal tabs on top and vertical tabs below", src="../tabs-orientation.png" %}
+{% example palette="light", alt="Image of horizontal tabs on top and vertical tabs below", src="../tabs-orientation.png" %}{% endexample %}
 
 ### Alignment
 If using horizontal tabs, the default orientation is left aligned, but center aligned is also an option.
 
-{% example palette="light", alt="Image of open tabs with left and center alignment and box tabs with left and center alignment", src="../tabs-alignment.png" %}
+{% example palette="light", alt="Image of open tabs with left and center alignment and box tabs with left and center alignment", src="../tabs-alignment.png" %}{% endexample %}
 
 ### Inset
 An inset is used to ensure consistent alignment and padding between text labels, overflow buttons, and content in the panel.
 
 {% alert state="info", title="Helpful Tip" %} With horizontal tabs, there are two inset options. With vertical tabs, there is only one. {% endalert %}
 
-{% example palette="light", alt=" Image of open tabs showing detailed inset specs", src="../tabs-inset-open.png" %}
+{% example palette="light", alt=" Image of open tabs showing detailed inset specs", src="../tabs-inset-open.png" %}{% endexample %}
 
-{% example palette="light", alt="Image of box tabs showing detailed inset specs", src="../tabs-inset-box.png" %}
+{% example palette="light", alt="Image of box tabs showing detailed inset specs", src="../tabs-inset-box.png" %}{% endexample %}
 
-{% example palette="light", alt="Image of vertical tabs showing detailed inset specs", src="../tabs-inset-vertical.png" %}
+{% example palette="light", alt="Image of vertical tabs showing detailed inset specs", src="../tabs-inset-vertical.png" %}{% endexample %}
 
 ### Logos
 In certain edge cases, logos can be used instead of text labels.
 
-{% example palette="light", alt="Image of open tabs with small logos in place of text labels", src="../tabs-logos.png" %}
+{% example palette="light", alt="Image of open tabs with small logos in place of text labels", src="../tabs-logos.png" %}{% endexample %}
 
 ## Tab panel
 The panel is below or to the right of tabs. Use this area to place other elements or content like text, links, calls to action, and more. Text blocks should not exceed <code>750px</code> to maintain optimal readability.
 
 {% alert state="warning", title="Warning" %} The Tabs element has no control over the panel in terms of content, layout, spacing, etc. {% endalert %}
 
-{% example palette="light", alt="Image of open tabs with a text block and a card", src="../tabs-tab-panel-1.png" %}
+{% example palette="light", alt="Image of open tabs with a text block and a card", src="../tabs-tab-panel-1.png" %}{% endexample %}
 
-{% example palette="light", alt="Image of open tabs with a title and a wide card", src="../tabs-tab-panel-2.png" %}
+{% example palette="light", alt="Image of open tabs with a title and a wide card", src="../tabs-tab-panel-2.png" %}{% endexample %}
 
-{% example palette="light", alt="Image of open tabs with a text block and a blockquote", src="../tabs-tab-panel-3.png" %}
+{% example palette="light", alt="Image of open tabs with a text block and a blockquote", src="../tabs-tab-panel-3.png" %}{% endexample %}
 
 ## Writing content
 ### Text labels
 Text labels should be concise, scannable, and descriptive of content in the panel. They should not exceed more than two or three short words. If they do, work with a content strategist to shorten them.
 
-{% example palette="light", alt="Image of open tabs with examples of adequate and long text labels", src="../tabs-text-labels.png" %}
+{% example palette="light", alt="Image of open tabs with examples of adequate and long text labels", src="../tabs-text-labels.png" %}{% endexample %}
 
 ### Character count
 In general, tabs should have three or four text labels maximum. However, if text labels are <strong>very short</strong>, more can be added.
@@ -77,17 +77,17 @@ In general, tabs should have three or four text labels maximum. However, if text
 ### Horizontal tabs width
 The divider line can be set to any width or be the same width as the list of tabs.
 
-{% example palette="light", alt="Image of open tabs with a stretched divider line on top and box tabs with a divider line constrained to the width of text labels below", src="../tabs-layout-horizontal-width.png" %}
+{% example palette="light", alt="Image of open tabs with a stretched divider line on top and box tabs with a divider line constrained to the width of text labels below", src="../tabs-layout-horizontal-width.png" %}{% endexample %}
 
 ### Vertical tabs height
 The divider line will become taller if the height of content in the panel exceeds the height of vertical tabs.
 
-{% example palette="light", alt="Image of vertical tabs with a short amount of content in the panel on top and vertical tabs with a long amount of content in the panel below", src="../tabs-layout-vertical-height.png" %}
+{% example palette="light", alt="Image of vertical tabs with a short amount of content in the panel on top and vertical tabs with a long amount of content in the panel below", src="../tabs-layout-vertical-height.png" %}{% endexample %}
 
 ### Card
 Tabs can be used in a card if the layout is wide enough and there are fewer tabs.
 
-{% example palette="light", alt="Image of open tabs in a card with only two tabs", src="../tabs-layout-card.png" %}
+{% example palette="light", alt="Image of open tabs in a card with only two tabs", src="../tabs-layout-card.png" %}{% endexample %}
 
 ## Behavior
 ### Overflow
@@ -95,40 +95,40 @@ If the number of tabs exceeds the container width or breakpoint, overflow button
 
 {% alert state="warning", title="Warning" %} Long text labels will make overflow buttons appear sooner, try and write text labels as short as possible. {% endalert %}
 
-{% example palette="light", alt="Image of open tabs at various widths showing overflow buttons on top and box tabs at various widths showing overflow buttons below", src="../tabs-behavior-overflow.png" %}
+{% example palette="light", alt="Image of open tabs at various widths showing overflow buttons on top and box tabs at various widths showing overflow buttons below", src="../tabs-behavior-overflow.png" %}{% endexample %}
 
 ### Navigating overflow tabs
 When the first tab is active, the left overflow button is disabled. When the last tab is active, the right overflow button is disabled. When a tab that is cut off is selected, the list of tabs shifts so the selected tab is in full view.
 
-{% example palette="light", alt="Image of selecting a cut off tab and the list of tabs shifting to reveal the selected tab in full vie", src="../tabs-behavior-navigating-overflow-tabs.png" %}
+{% example palette="light", alt="Image of selecting a cut off tab and the list of tabs shifting to reveal the selected tab in full vie", src="../tabs-behavior-navigating-overflow-tabs.png" %}{% endexample %}
 
 ## Responsive design
 ### Large breakpoints
 
-{% example palette="light", alt="Image of horizontal and vertical tabs on desktop and tablet breakpoints", src="../tabs-responsive-design-breakpoints-large.png" %}
+{% example palette="light", alt="Image of horizontal and vertical tabs on desktop and tablet breakpoints", src="../tabs-responsive-design-breakpoints-large.png" %}{% endexample %}
 
 ### Small breakpoints
 Vertical tabs switch to horizontal tabs with overflow buttons on small breakpoints.
 
-{% example palette="light", alt="Image of tabs with overflow buttons on small breakpoints", src="../tabs-responsive-design-breakpoints-small.png" %}
+{% example palette="light", alt="Image of tabs with overflow buttons on small breakpoints", src="../tabs-responsive-design-breakpoints-small.png" %}{% endexample %}
 
 ## Best practices
 ### Not enough tabs
 There should be at least two tabs minimum.
 
-{% example palette="light", alt="Image of horizontal open and box tabs with one tab each which is incorrect usage", src="../tabs-best-practice-1.png" %}
+{% example palette="light", alt="Image of horizontal open and box tabs with one tab each which is incorrect usage", src="../tabs-best-practice-1.png" %}{% endexample %}
 
 ### Too many tabs
 Be careful about displaying too many tabs, some of them will become hidden even at large breakpoints.
 
-{% example palette="light", alt="Image of horizontal tabs with five tabs and overflow buttons which is incorrect usage", src="../tabs-best-practice-2.png" %}
+{% example palette="light", alt="Image of horizontal tabs with five tabs and overflow buttons which is incorrect usage", src="../tabs-best-practice-2.png" %}{% endexample %}
 
 ### Extra spacing
 Do not add extra spacing or stretch the width of tabs.
 
-{% example palette="light", alt="Image of horizontal tabs with three tabs that are stretched which is incorrect usage", src="../tabs-best-practice-3.png" %}
+{% example palette="light", alt="Image of horizontal tabs with three tabs that are stretched which is incorrect usage", src="../tabs-best-practice-3.png" %}{% endexample %}
 
 ### Overflow buttons
 Overflow buttons should not be visible if all tabs are visible.
 
-{% example palette="light", alt="Image of horizontal tabs with three visible tabs and overflow buttons which is incorrect usage", src="../tabs-best-practice-4.png" %}
+{% example palette="light", alt="Image of horizontal tabs with three visible tabs and overflow buttons which is incorrect usage", src="../tabs-best-practice-4.png" %}{% endexample %}

--- a/elements/rh-tabs/docs/40-accessibility.md
+++ b/elements/rh-tabs/docs/40-accessibility.md
@@ -4,7 +4,7 @@
 
   {% alert state="info", title="Helpful tip" %}Overflow buttons do not have focus so there are no keyboard interactions.{% endalert %}
 
-  {% example palette="light", alt="Image of horizontal tabs with diagrams of what happens when Arrow or Tab keys are pressed", src="../tabs-a11y-keyboard-interactions.png" %}
+  {% example palette="light", alt="Image of horizontal tabs with diagrams of what happens when Arrow or Tab keys are pressed", src="../tabs-a11y-keyboard-interactions.png" %}{% endexample %}
 
   | Key         | Result { style="width: 66%;" } |
   | ----------- | ------------------------------- |
@@ -18,12 +18,12 @@
 ## Focus order
   A logical focus order helps keyboard users operate our websites. Elements need to receive focus in an order that preserves meaning, therefore the focus order should make sense and not jump around randomly. For both sizes and orientations, the focus order is from left to right and top to bottom. Disabled buttons are not included in the focus order.
 
-  {% example palette="light", alt="Image of horizontal, vertical, and tabs with overflow buttons showing the focus order from left to right and top to bottom", src="../tabs-a11y-focus-order.png" %}
+  {% example palette="light", alt="Image of horizontal, vertical, and tabs with overflow buttons showing the focus order from left to right and top to bottom", src="../tabs-a11y-focus-order.png" %}{% endexample %}
 
 ### Touch targets
   Tabs are adequately spaced for optimal touch targets.
 
-  {% example palette="light", alt="Image of open, box, and tabs with overflow buttons showing adequate touch target spacing", src="../tabs-a11y-touch-targets.png" %}
+  {% example palette="light", alt="Image of open, box, and tabs with overflow buttons showing adequate touch target spacing", src="../tabs-a11y-touch-targets.png" %}{% endexample %}
 
 ## Additional guidelines
   - Tabs must communicate to users which tab in the list is currently selected and the total number of tabs available

--- a/elements/rh-tag/docs/00-overview.md
+++ b/elements/rh-tag/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 {% example palette="light",
            alt="Two rows of tags; the top row is ‘Filled’ tags and the bottom row is ‘Unfilled’ tags; from left to right, both rows of tags include red, orange, green, cyan, blue, purple, and gray colors",
-           src="tag-sample-element.png" %}
+           src="tag-sample-element.png" %}{% endexample %}
 
 
 

--- a/elements/rh-tag/docs/10-style.md
+++ b/elements/rh-tag/docs/10-style.md
@@ -11,7 +11,7 @@ border.
 ### Anatomy
 {% example palette="light",
            alt="Anatomy of a tag with annotations; number 1 is pointing to the container, number 2 is pointing to the text label, and number 3 is pointing to an optional icon",
-           src="../tag-anatomy.png" %}
+           src="../tag-anatomy.png" %}{% endexample %}
  
 1. Container and border
 2. Text label
@@ -26,7 +26,7 @@ the left of the text label.
 
 {% example palette="light",
            alt="Tags with text describing each variant",
-           src="../tag-variants.png" %}
+           src="../tag-variants.png" %}{% endexample %}
 
 ## Theme
 
@@ -37,12 +37,12 @@ available in the dark theme if necessary.
     
 {% example palette="light",
         alt="Light theme tag examples",
-        src="../tag-theme-light.png" %}
+        src="../tag-theme-light.png" %}{% endexample %}
 
 ### Dark theme
 {% example palette="darkest",
         alt="Dark theme tag examples",
-        src="../tag-theme-dark.png" %}
+        src="../tag-theme-dark.png" %}{% endexample %}
 
 ## Configuration
 
@@ -50,17 +50,17 @@ Both variants have the same height and border radius.
 
 {% example palette="light",
         alt="How a tag is constructed showing border radius, icon, and height details",
-        src="../tag-configuration.png" %}
+        src="../tag-configuration.png" %}{% endexample %}
 
 ## Space
 
 {% example palette="light",
         alt="Light theme tag spacing within the element and when grouped",
-        src="../tag-space-theme-light.png" %}
+        src="../tag-space-theme-light.png" %}{% endexample %}
 
 {% example palette="darkest",
         alt="Light theme tag spacing within the element",
-        src="../tag-space-theme-dark.png" %}
+        src="../tag-space-theme-dark.png" %}{% endexample %}
 
 {% spacerTokensTable 
     headline='',

--- a/elements/rh-tag/docs/20-guidelines.md
+++ b/elements/rh-tag/docs/20-guidelines.md
@@ -26,7 +26,7 @@ many users. Learn more in the [Accessibility](/accessibility) section.
         width=404,
         alt="A row of filled tags with text ‘Filled tags’ underneath and a row 
         of unfilled tags with text ‘Unfilled tags’ underneath",
-        src="../tag-variants-colors.png" %}
+        src="../tag-variants-colors.png" %}{% endexample %}
 
 ## Icons
 
@@ -40,7 +40,7 @@ tags of the same color.
 
 {% example palette="light",
         alt="A row of tags showing examples of optional icons",
-        src="../tag-icons.png" %}
+        src="../tag-icons.png" %}{% endexample %}
 
 ## White tag
 
@@ -65,7 +65,7 @@ tags because they are more visually prominent.
 
 {% example palette="light",
         alt="A row of filled tags with examples of unique status text labels per each color",
-        src="../tag-status-color.png" %}
+        src="../tag-status-color.png" %}{% endexample %}
 
 ### Text
 
@@ -74,7 +74,7 @@ color that makes sense.
 
 {% example palette="light",
         alt="Two groups of two tags with examples of correct status text labels",
-        src="../tag-status-text.png" %}
+        src="../tag-status-text.png" %}{% endexample %}
 
 
 
@@ -89,7 +89,7 @@ instead.
 
 {% example palette="light",
         alt="Two groups of two tags with examples of correct and incorrect text labels",
-        src="../tag-text-labels.png" %}
+        src="../tag-text-labels.png" %}{% endexample %}
 
 | Element    | Character count |
 | ---------- | --------------- |
@@ -104,7 +104,7 @@ in one row, a new row will appear.
 
 {% example palette="light",
         alt="Two groups of two tags, one group is three tags in one row and the other group is two tags in one row and one tag in a second row",
-        src="../tag-grouping.png" %}
+        src="../tag-grouping.png" %}{% endexample %}
 
 ## Best practices
 
@@ -115,7 +115,7 @@ container.
 
 {% example palette="light",
         alt="Two rows of tags; the first row shows a mix of variants and the second row shows a mix of tags with and without icons, both are incorrect usage",
-        src="../tag-best-practice-1.png" %}
+        src="../tag-best-practice-1.png" %}{% endexample %}
 
 ### Dark theme tags
 
@@ -124,7 +124,7 @@ dark theme tags.
 
 {% example palette="darkest",
         alt="Light theme tags used on a dark background which is incorrect usage",
-        src="../tag-best-practice-2.png" %}
+        src="../tag-best-practice-2.png" %}{% endexample %}
 
 ### Custom tags
 
@@ -133,7 +133,7 @@ Do not make your own custom tags. If you need a custom set of tags designed,
 
 {% example palette="light",
         alt="Three tags with custom colors which is incorrect usage",
-        src="../tag-best-practice-3.png" %}
+        src="../tag-best-practice-3.png" %}{% endexample %}
 
 
 

--- a/elements/rh-tag/docs/40-accessibility.md
+++ b/elements/rh-tag/docs/40-accessibility.md
@@ -16,12 +16,12 @@ Compare Figure 1 to Figure 2. Both figures include a blue informational tag, a r
 ### Figure 1
 {% example palette="darkest",
         alt="A row of three gray tags that all look the same",
-        src="../tag-a11y-figure-1.png" %}
+        src="../tag-a11y-figure-1.png" %}{% endexample %}
 
 ### Figure 2
 {% example palette="darkest",
         alt="A row of three gray tags all with a unique icon and a unique text label",
-        src="../tag-a11y-figure-2.png" %}
+        src="../tag-a11y-figure-2.png" %}{% endexample %}
 
 {% include 'accessibility/ariaguide.md' %}
 

--- a/elements/rh-tooltip/docs/00-overview.md
+++ b/elements/rh-tooltip/docs/00-overview.md
@@ -5,7 +5,7 @@
           class="inline-flex centered",
           style="margin-block:var(--rh-space-2xl);width:auto",
           alt=" A black tooltip on top of a gray disabled button",
-          src="./tooltip-sample-element.png" %}
+          src="./tooltip-sample-element.png" %}{% endexample %}
 
 ## Sample component
   <p>

--- a/elements/rh-tooltip/docs/10-style.md
+++ b/elements/rh-tooltip/docs/10-style.md
@@ -3,7 +3,7 @@ A tooltip is a container with text that includes an arrow and sometimes a drop s
 ### Anatomy 
 {% example palette="light",
           alt="Anatomy of a tooltip with annotations; number 1 is pointing to the container, number 2 is pointing to the text, number 3 is pointing to the arrow, and number 4 is pointing to the trigger",
-          src="../tooltip-anatomy.png" %}
+          src="../tooltip-anatomy.png" %}{% endexample %}
 
 1) Container
 2) Text
@@ -16,24 +16,24 @@ A tooltip is available in both light and dark themes. The dark theme tooltip con
 ### Light theme 
 {% example palette="light",
           alt="Light theme tooltip which is black",
-          src="../tooltip-theme-light.png" %}
+          src="../tooltip-theme-light.png" %}{% endexample %}
 
 ### Dark theme 
 {% example palette="darkest",
           alt="Dark theme tooltip which is white",
-          src="../tooltip-theme-dark.png" %}
+          src="../tooltip-theme-dark.png" %}{% endexample %}
 
 ## Configuration 
 All badges have the same height and border radius.
 
 {% example palette="light",
           alt="How a tooltip is constructed showing alignment, border radius, and arrow details",
-          src="../tooltip-configuration.png" %}
+          src="../tooltip-configuration.png" %}{% endexample %}
 
 ## Space 
 {% example palette="light",
           alt="Tooltip spacing both within the element and in between the element and trigger",
-          src="../tooltip-space.png" %}
+          src="../tooltip-space.png" %}{% endexample %}
 
 {% spacerTokensTable 
   headline="",
@@ -49,4 +49,4 @@ A tooltip appears near an icon or element on hover, focus, or when tapped. A too
 
 {% example palette="light",
           alt="Tooltip trigger interaction states",
-          src="../tooltip-interaction-states.png" %}
+          src="../tooltip-interaction-states.png" %}{% endexample %}

--- a/elements/rh-tooltip/docs/20-guidelines.md
+++ b/elements/rh-tooltip/docs/20-guidelines.md
@@ -11,28 +11,28 @@ Content in a tooltip is limited to text only. Consider the following when writin
 
 {% example palette="light",
           alt="Various text examples; from left to right, the text length starts very short, but gets longer and longer",
-          src="../tooltip-content.png" %}
+          src="../tooltip-content.png" %}{% endexample %}
 
 ## Orientation 
 The correct orientation of a tooltip depends on the amount of content and browser window. If a tooltip covers up important information or gets cut off, choose a different orientation.
 
 {% example palette="light",
           alt="Various orientation examples; from left to right and top to bottom, top, right, bottom, and left",
-          src="../tooltip-orientation.png" %}
+          src="../tooltip-orientation.png" %}{% endexample %}
 
 ## Behavior 
 When a cursor or focus is moved, the tooltip disappears. On mobile devices, users must tap to trigger a tooltip and then tap again to make it disappear.
 
 {% example palette="light",
           alt="Various behavior examples; from top to bottom, how a tooltip behaves when the trigger is hovered, focused, and tapped",
-          src="../tooltip-behavior.png" %}
+          src="../tooltip-behavior.png" %}{% endexample %}
 
 ## Responsive design 
 A tooltip can generally be used on both large and small breakpoints if the content is not too long.
 
 {% example palette="none",
           alt="Examples of a tooltip used on large and small breakpoints",
-          src="../tooltip-responsive-design.png" %}
+          src="../tooltip-responsive-design.png" %}{% endexample %}
 
 ## Best practices 
 ### White on white 
@@ -40,18 +40,18 @@ Do not use a dark theme tooltip in light theme environments.
 
 {% example palette="wrong",
           alt="A dark theme or white tooltip used on a white background is incorrect usage",
-          src="../tooltip-best-practice-1.png" %}
+          src="../tooltip-best-practice-1.png" %}{% endexample %}
 
 ### Cut off by browser window 
 A tooltip should not be cut off by the browser window. Change the orientation if it does.
 
 {% example palette="wrong",
           alt="If using the top orientation will cause the tooltip to get cut off, that is incorrect usage",
-          src="../tooltip-best-practice-2.png" %}
+          src="../tooltip-best-practice-2.png" %}{% endexample %}
 
 ### Unnecessary pairing 
 Do not add a tooltip to interface elements or actions that do not require further explanation.
 
 {% example palette="wrong",
           alt="Pairing a tooltip with an element that already has adequate descriptive text is incorrect usage",
-          src="../tooltip-best-practice-3.png" %}
+          src="../tooltip-best-practice-3.png" %}{% endexample %}

--- a/elements/rh-tooltip/docs/40-accessibility.md
+++ b/elements/rh-tooltip/docs/40-accessibility.md
@@ -3,7 +3,7 @@ A tooltip will appear when the trigger receives focus and disappear when moving 
 
 {% example palette="light",
           alt="Tooltip keyboard interactions; pressing tab to focus the trigger will show the tooltip, but pressing tab again will hide the tooltip",
-          src="../tooltip-keyboard-interactions.png" %}
+          src="../tooltip-keyboard-interactions.png" %}{% endexample %}
 
 | Key {style="width: 50%" } | Result                                                       |
 | ------------------------- | ------------------------------------------------------------ |


### PR DESCRIPTION
## What I did

1. Timestamp docs necessitated that the example shortcode not only work images, but live elements as well. I'm converting the example shortcode into a paired shortcode as a result.

## Testing Instructions

1. Verify that existing shortcode usage wasn't impacted by the conversion
