### PR TITLE
docs: fix partial template

### DIFF
--- a/docs/_includes/feedback.html
+++ b/docs/_includes/feedback.html
@@ -10,11 +10,11 @@
         </li>{% endfor %}
       </ul>
     {% elseif title === 'Patterns' %}
-      <h2>Elements</h2>
-      <p>To learn how to use our elements in your designs, visit the <a href="{{ '/elements/' | url }}">Elements</a> section.</p>
-    {% else %}
       <h2>Patterns</h2>
       <p>To learn how to use our patterns in your designs, visit the <a href="{{ '/patterns/' | url }}">Patterns</a> section.</p>
+    {% else %}
+      <h2>Elements</h2>
+      <p>To learn how to use our elements in your designs, visit the <a href="{{ '/elements/' | url }}">Elements</a> section.</p>
     {% endif %}
   {% endsection %}
 


### PR DESCRIPTION
## What I did

1. Fixed a typo in the feedback partial

## Testing Instructions

1. Verify that the feedback section for pages under `Patterns` uses the correct markup
2. Verify that the feedback section for pages under `Elements` uses the correct markup
