### PR TITLE
docs: fix tokens icon samp element size

### DIFF
--- a/docs/assets/tokens/tokens.css
+++ b/docs/assets/tokens/tokens.css
@@ -332,7 +332,7 @@ tr:is(:hover, :focus-within).on-dark .copy-cell .copy-button {
 .icon:not(.color) samp {
   aspect-ratio: 1;
   display: block;
-  width: var(--icon-size);
+  width: var(--icon);
   border: var(--rh-border-width-md) dotted var(--rh-color-border-strong-on-light);
 }
 


### PR DESCRIPTION
## What I did

1. Fix token icon `<samp>` size 

Closes #1199


## Testing Instructions

1. View [deploy preview](https://deploy-preview-1202--red-hat-design-system.netlify.app/tokens/icon/)
## Notes to Reviewers


