### PR TITLE
docs: don't render repo status table

### DIFF
--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -5,6 +5,9 @@ const fs = require('fs');
  * @this {EleventyContext}
  */
 function repoStatus({ heading = 'Repo status', type = 'Pattern', level = 2 } = {}) {
+  return '';
+  // https://github.com/RedHat-UX/red-hat-design-system/issues/1174
+  // eslint-disable-next-line no-unreachable
   const headingLevel = Array.from({ length: level }, () => '#').join('');
   const checkSVG = fs.readFileSync('node_modules/@patternfly/icons/fas/check.svg', 'utf8');
   /** @type {string[][]} */


### PR DESCRIPTION
## What I did

1. Returning an empty string instead of the repo status table until we find a better [solution](https://github.com/orgs/RedHat-UX/discussions/1173) for maintaining the data. 


## Testing Instructions

1. Go to all the pattern and element overviews and verify that the repo status table is hidden.

## Notes to Reviewers

I tried commenting them out in the MD files, but the comment was prematurely closed from the HTML comments in the shortcode code. 

Closes https://github.com/RedHat-UX/red-hat-design-system/issues/1174