### PR TITLE
Updating Bulbasaur release notes

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -15,7 +15,7 @@ Check out [our scrum board on GitHub](https://github.com/orgs/RedHat-UX/projects
 <nav class="releases-links">
   <rh-block id="roadmap-block">
     <a href="https://github.com/orgs/RedHat-UX/projects/7/">
-      <h2>Roadmap</h2>
+      Roadmap
     </a>
   </rh-block>
 </nav>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,12 +11,32 @@ We are continually making changes in order to improve and grow the Red Hat Desig
 <nav class="releases-links">
   <rh-block id="changelog-block">
     <a href="https://github.com/RedHat-UX/red-hat-design-system/releases">
-      <h2>Changelog</h2>
+      Changelog
     </a>
   </rh-block>
 </nav>
 
 <section class="release-versions">
+<section class="section release-version">
+
+## Version 1.2.0
+Released October 16, 2023
+
+### Highlights
+
+| Change                         | Notes {style="width: 70%" } |
+| ------------------------------ | --------------------------------- |
+| Added `<rh-table>`             | A table is a container for displaying information. It allows a user to scan, examine, and compare large amounts of data. |
+| Added `<rh-tile>`              | A tile is a flexible layout with a clickable and contained surface. |
+| Added `<rh-timestamp>`         | Provides consistent formats for displaying date and time values. |
+| Added `<rh-navigation-secondary>` current page indicator support | Updated support for a current page indicator using `aria-current="page"`. |
+| Fixed `<rh-card>` `header` slot | Card's header slot now displays items vertically instead of stacking, allowing for more than one item to display in the header. |
+| Fixed `<rh-cta>` `brick` variant | Brick variants of calls-to-action (CTAs) are now full width. |
+
+
+<rh-cta><a href="https://github.com/RedHat-UX/red-hat-design-system/releases/tag/v1.2.0">View version 1.2 release notes</a></rh-cta>
+
+</section>
 <section class="section release-version">
 
 ## Version 1.1.0

--- a/docs/scss/styles.scss
+++ b/docs/scss/styles.scss
@@ -100,6 +100,7 @@ rh-block a {
   border: 1px solid var(--rh-color-border-subtle-on-light);
   border-radius: var(--rh-border-radius-default);
   text-decoration: none;
+  font-weight: bold;
 }
 
 rh-block a:hover {


### PR DESCRIPTION
## What I did

1. Updated Bulbasaur's release notes page.
2. Fixed the heading level (nested H2s) / link style issue in the Changelog section and GitHub link (i.e. `rh-block`).
3. Made the GitHub `rh-block` on the Roadmap page consistent.


## Testing Instructions

1. Check out the Release Notes page, and proof highlights, etc.
2. Compare GitHub block link with Roadmap page too

