### PR TITLE
fix(lib): picker scope

### DIFF
--- a/lib/elements/rh-context-picker/rh-context-picker.ts
+++ b/lib/elements/rh-context-picker/rh-context-picker.ts
@@ -25,7 +25,7 @@ import style from './rh-context-picker.css';
 
 export class ContextChangeEvent extends Event {
   constructor(public colorPalette: ColorPalette) {
-    super('change', { bubbles: true });
+    super('change', { bubbles: true, cancelable: true });
   }
 }
 
@@ -113,6 +113,7 @@ export class RhContextPicker extends LitElement {
   }
 
   firstUpdated() {
+    const oldTarget = this.#target;
     if (this.target) {
       const root = this.getRootNode() as Document | ShadowRoot;
       this.#target = root.getElementById(this.target);
@@ -120,6 +121,12 @@ export class RhContextPicker extends LitElement {
     } else {
       this.#target = this.closest('rh-context-provider');
     }
+    oldTarget?.removeEventListener('change', this.#onChange);
+    this.#target?.addEventListener('change', this.#onChange);
+  }
+
+  #onChange(event: Event) {
+    if (event instanceof ContextChangeEvent) { event.stopPropagation(); }
   }
 
   #onInput(event: Event) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "🐒-DEV": "❓ Development aids",
     "start": "wireit",
     "dev": "wireit",
+    "serve": "wireit",
     "new": "npm init @patternfly/element",
     "🚧-BUILD": "❓ Make packages and artifacts",
     "build": "wireit",
@@ -86,6 +87,15 @@
     "dev": {
       "service": true,
       "command": "web-dev-server --watch",
+      "dependencies": [
+        "analyze",
+        "compile",
+        "watch:compile"
+      ]
+    },
+    "serve": {
+      "service": true,
+      "command": "eleventy --serve",
       "dependencies": [
         "analyze",
         "compile",


### PR DESCRIPTION
## What I did

1. fix context picker so that it's change event stops at its target.
2. add `npm run serve` command to spin up 11ty dev serve only (without wds)
## Testing Instructions

1. check this out on the context branch in the cards demo on that page. changing the nested context shouldnt' change the parent context.
