### PR TITLE
fix(tooltip): fixing content display issues before upgraded

### DIFF
--- a/.changeset/healthy-onions-work.md
+++ b/.changeset/healthy-onions-work.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+rh-tooltip: fixing issue where content would take up unwanted space before floating-ui initialization

--- a/elements/rh-tooltip/rh-tooltip.css
+++ b/elements/rh-tooltip/rh-tooltip.css
@@ -56,6 +56,10 @@
     var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-darkest, #151515)));
 }
 
+:not(.initialized) #tooltip {
+  display: none;
+}
+
 #tooltip:after {
   display: block;
   content: "";

--- a/elements/rh-tooltip/rh-tooltip.ts
+++ b/elements/rh-tooltip/rh-tooltip.ts
@@ -43,8 +43,6 @@ export class RhTooltip extends LitElement {
 
   static readonly styles = [styles];
 
-  #initialized = false;
-
   /** The position of the tooltip, relative to the invoking content */
   @property() position: Placement = 'top';
 
@@ -56,6 +54,8 @@ export class RhTooltip extends LitElement {
   #float = new FloatingDOMController(this, {
     content: (): HTMLElement | undefined | null => this.shadowRoot?.querySelector('#tooltip'),
   });
+
+  #initialized = false;
 
   override connectedCallback(): void {
     super.connectedCallback();

--- a/elements/rh-tooltip/rh-tooltip.ts
+++ b/elements/rh-tooltip/rh-tooltip.ts
@@ -43,6 +43,8 @@ export class RhTooltip extends LitElement {
 
   static readonly styles = [styles];
 
+  #initialized = false;
+
   /** The position of the tooltip, relative to the invoking content */
   @property() position: Placement = 'top';
 
@@ -70,6 +72,7 @@ export class RhTooltip extends LitElement {
       <div id="container"
            style="${styleMap(styles)}"
            class="${classMap({ open,
+                              'initialized': !!this.#initialized,
                                [on]: !!on,
                                [anchor]: !!anchor,
                                [alignment]: !!alignment })}">
@@ -89,6 +92,7 @@ export class RhTooltip extends LitElement {
         !placement?.match(/top|bottom/) ? 15
       : { mainAxis: 15, alignmentAxis: -4 };
     await this.#float.show({ offset, placement });
+    this.#initialized = true;
   }
 
   /** Hide the tooltip */


### PR DESCRIPTION
Issue: On [Red Hat Product Trials](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/server/trial) and on **mobile** when the tooltip is on the page but not yet upgraded by @floating-ui (ie not yet interacted with to get the coordinates) the content ends up causing the screen to scroll too far to the right and creates a layout error like below:

![image](https://github.com/RedHat-UX/red-hat-design-system/assets/9708152/591f54c8-60ad-4242-8860-2f1180a0d233)

To fix this,

## What I did

1.  Added an `initialized` private property to tooltip. 
2. Updating `initialized` to true when `show` function is called.
3. CSS is set to `display: none` on the tooltip content until the show function is called, then it is set to show permanently. 