### PR TITLE
fix(navigation-secondary): initialization state of current page indicator

### DIFF
--- a/.changeset/wet-flowers-double.md
+++ b/.changeset/wet-flowers-double.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-secondary>`: Fixed initialization of current page indicator

--- a/.changeset/wet-flowers-double.md
+++ b/.changeset/wet-flowers-double.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-navigation-secondary>`: Fixed initialization of current page indicator
+`<rh-navigation-secondary>`: fixed initialization of current page indicator

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
@@ -76,6 +76,7 @@ export class RhNavigationSecondaryDropdown extends LitElement {
     link.addEventListener('click', this._clickHandler);
 
     this.#mo.observe(this, { attributeFilter: ['aria-current'], childList: true, subtree: true });
+    this.#mutationsCallback();
   }
 
   render() {


### PR DESCRIPTION
## What I did

1. Fixed initialization of current page indicator.  Should load initial state after setting up the mutation observer.


Closes #1334


## Testing Instructions

1.

## Notes to Reviewers
