### PR TITLE
docs: clean up feedback/discussion link

### DIFF
--- a/docs/index.njk
+++ b/docs/index.njk
@@ -97,7 +97,7 @@ title: Home
 <div class="centered">
   <div class="margin-top--6">
     <rh-cta variant="secondary">
-      <a href="/get-started#feedback">Submit feedback</a>
+      <a href="https://github.com/RedHat-UX/red-hat-design-system/discussions">Join the discussion</a>
     </rh-cta>
   </div>
 </div>


### PR DESCRIPTION
## What I did

1. To fix #1201 , I replaced the redundant "Submit feedback" link text in the main Contribute section of the homepage with "Join the discussion." There is already another interactive element with "Submit feedback" text in the navigation section of the site.
2. Changed the link destination, so that instead of pointing to our Get Started page, it points directly to the GitHub discussions page. This basically saves users a step, since that Get started page's feedback section is already little more than a link to the discussions page.

## Testing Instructions

1. Go to the [Contribute section](https://deploy-preview-1375--red-hat-design-system.netlify.app/#contribute) of the deploy preview RHDS homepage (just before the footer).
2. In this section, confirm that the text of its sole link now reads "Join the discussion" and that the link itself points to the [RHDS discussion page](https://github.com/orgs/RedHat-UX/discussions) at Github.
