### PR TITLE
fix(tabs): remove color provider from `rh-tab-panel`

### DIFF
--- a/.changeset/itchy-dogs-matter.md
+++ b/.changeset/itchy-dogs-matter.md
@@ -1,5 +1,5 @@
 ---
-"@rhds/elements": minor
+"@rhds/elements": patch
 ---
 
-`<rh-tab-panel>`: removed color-palette attribute`
+`<rh-tab-panel>`: removed unused color-palette attribute

--- a/.changeset/itchy-dogs-matter.md
+++ b/.changeset/itchy-dogs-matter.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-tab-panel>`: removed color-palette attribute`

--- a/elements/rh-tabs/rh-tab-panel.ts
+++ b/elements/rh-tabs/rh-tab-panel.ts
@@ -7,7 +7,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { BaseTabPanel } from '@patternfly/elements/pf-tabs/BaseTabPanel.js';
 
 import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
-import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
 
 import styles from './rh-tab-panel.css';
 
@@ -27,12 +26,6 @@ export class RhTabPanel extends BaseTabPanel {
    * Sets color theme based on parent context
    */
   @colorContextConsumer() private on?: ColorTheme;
-
-  /**
-   * Sets color context for child components, overrides parent context
-   */
-  @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette?: ColorPalette;
 
   render() {
     const { on = '' } = this;


### PR DESCRIPTION
## What I did

1. removed `color-palette` attribute


## Testing Instructions

1.

## Notes to Reviewers

`color-palette` in the case of panels was never wired up.  Using it would not provide any change to the component.  My assumption is is a minor but maybe we can get away with a patch change?  Discussion on this is in the issue [#1353 ](https://github.com/RedHat-UX/red-hat-design-system/issues/1353) In the future we'd suggest using `<rh-surface>` inside of the panel.
