### PR TITLE
fix(table): change blue crayon token for the hover state's column background color

### DIFF
--- a/elements/rh-table/rh-table-lightdom.css
+++ b/elements/rh-table/rh-table-lightdom.css
@@ -14,7 +14,7 @@
     rgb(
         var(--rh-color-gray-10-rgb, 242 242 242) / var(--rh-opacity-40, 40%)
       );
-  --rh-table-column-background-color: rgb(var(--rh-color-blue-50-rgb, 0 102 204));
+  --rh-table-column-background-color: rgb(var(--rh-color-blue-10-rgb, 224 240 255));
 }
 
 :is(rh-table) thead th {


### PR DESCRIPTION
## What I did

1. The previous token was `--rh-color-blue-50-rgb`, which now shows as a darker blue in Tokens 2.0. I changed it to `--rh-color-blue-10-rgb`. Looks like the stylelint didn't change it because it was an existing token name.


## Testing Instructions

Verify that the sample table in the UX dot DP and the `<rh-table>` demo look like the `After` image.

**Before:**
![Screenshot 2023-12-14 at 10 48 36 AM](https://github.com/RedHat-UX/red-hat-design-system/assets/95588923/04445b9e-a442-4394-9ae2-e2060dde209c)

**After:**
![Screenshot 2023-12-14 at 11 23 12 AM](https://github.com/RedHat-UX/red-hat-design-system/assets/95588923/18c83215-1826-443b-8dbe-e0dc9dc2dca5)

## Notes to Reviewers
