### PR TITLE
fix: token migration errors

### DIFF
--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -11,8 +11,8 @@
 
 footer,
 .global-base {
-  --_icon-color: var(--rh-footer-icon-color, var(--rh-color-gray-30, #c7c7c7));
-  --_icon-color-hover: var(--rh-footer-icon-color-hover, var(--rh-color-gray-20, #e0e0e0));
+  --_icon-color: var(--rh-footer-icon-color, var(--rh-color-gray-40, #a3a3a3));
+  --_icon-color-hover: var(--rh-footer-icon-color-hover, var(--rh-color-gray-30, #c7c7c7));
   --_border-color: var(--rh-footer-border-color, var(--rh-color-border-subtle-on-dark, #707070));
   --_accent-color: var(--rh-footer-accent-color, var(--rh-color-accent-brand-on-light, #ee0000));
   --_section-side-gap: var(--rh-footer-section-side-gap, var(--rh-space-lg, 16px));

--- a/elements/rh-pagination/rh-pagination-lightdom.css
+++ b/elements/rh-pagination/rh-pagination-lightdom.css
@@ -77,7 +77,7 @@ rh-pagination li a[aria-current="page"]:is(:focus, :focus-within, :focus-visible
 }
 
 rh-pagination li a:hover {
-  --_border-accent-color: var(--rh-color-gray-40, #a3a3a3);
+  --_border-accent-color: var(--rh-color-gray-50, #707070);
 }
 
 rh-pagination li a:is([aria-current="page"], :hover) {
@@ -120,7 +120,7 @@ rh-pagination:is([overflow="start"], [overflow="both"]) li:first-child:after {
   display: flex;
   align-items: center;
   font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-  color: var(--rh-color-gray-30, #c7c7c7);
+  color: var(--rh-color-gray-40, #a3a3a3);
   justify-content: center;
   background: var(--rh-color-surface-lightest, #ffffff);
   align-self: start;

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -52,7 +52,7 @@ svg {
 
 .stepper[inert] {
   pointer-events: none;
-  color: var(--rh-pagination-background-focused, var(--rh-color-gray-20, #e0e0e0));
+  color: var(--rh-pagination-background-focused, var(--rh-color-gray-30, #c7c7c7));
 }
 
 /* MOBILE styles */

--- a/elements/rh-spinner/rh-spinner.css
+++ b/elements/rh-spinner/rh-spinner.css
@@ -83,7 +83,7 @@ circle.dash.dark {
 }
 
 circle.track.dark {
-  stroke: var(--rh-color-gray-60, #4d4d4d);
+  stroke: var(--rh-color-gray-70, #383838);
 }
 
 @keyframes rh-spinner-animation-dash {

--- a/elements/rh-table/rh-table.css
+++ b/elements/rh-table/rh-table.css
@@ -11,7 +11,7 @@
   scrollbar-color: var(--_scrollbar-track-color) var(--_scrollbar-thum-color);
 
   --_scrollbar-size: calc(10 / 16 * 1rem);
-  --_scrollbar-thumb-color: var(--rh-color-gray-40, #a3a3a3);
+  --_scrollbar-thumb-color: var(--rh-color-gray-50, #707070);
   --_scrollbar-track-color: var(--rh-color-border-subtle-on-light, #c7c7c7);
 }
 

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -18,7 +18,7 @@
   --_border-color: var(--rh-tabs-border-color, var(--rh-color-border-subtle-on-dark, #707070));
   --_arrow-color: var(--rh-color-accent-base-on-dark, #92c5f9);
   --_overflow-button-text-color: var(--rh-color-text-secondary-on-dark, #c7c7c7);
-  --_overflow-button-disabled-text-color: var(--rh-color-gray-40, #a3a3a3);
+  --_overflow-button-disabled-text-color: var(--rh-color-gray-50, #707070);
   --_overflow-button-hover-text-color: var(--rh-color-text-primary-on-dark, #ffffff);
 }
 


### PR DESCRIPTION
## What I did

I checked CSS of elements that use crayon color tokens to make sure that the stylelint migration rules updated them correctly. I found that the linter changed the fallback hex value for gray tokens, instead of the token names. Checked what the colors were in RHDS 1.2.0 to correct the token names and values.

## Testing Instructions

1. Check gray tokens in the demos for footer, pagination, spinner, table, and tabs 

## Notes to Reviewers

No need for all three of you to review. Just tagged you all to see who's able to do it first. :)