### PR TITLE
docs: fixing side nav in about section

### DIFF
--- a/docs/_includes/component/header.njk
+++ b/docs/_includes/component/header.njk
@@ -35,7 +35,7 @@
             <summary class="heading">About</summary>
             <ul class="sub-menu">
               <li class="item">
-                <a class="link {{ 'active' if page.url.startsWith('/about/') }}"
+                <a class="link {{ 'active' if page.url === '/about/' }}"
                    href="{{ '/about/' | url }}">About this website</a>
               </li>
               {%- for link in collections.about -%}


### PR DESCRIPTION
Closes #1444 

## What I did

1.  Fixed the header template to only show active when it's on the top level of the about section


## Testing Instructions

1.  Should not double highlight rows on the side-nav in the about section anymore