### PR TITLE
docs: add subsystems to Designers page

### DIFF
--- a/docs/get-started/designers.md
+++ b/docs/get-started/designers.md
@@ -70,7 +70,7 @@ The RHDS library is our core library that includes our foundational styles, elem
 | ------------ | -------- |
 | RHDS         | Our core library for creating Red Hat digital experiences. |
 | <a href="https://www.patternfly.org/">PatternFly</a> | A library for creating application interfaces. |
-| Tier 1 events | A library for tier 1 events, like Summit and Ansiblefest. |
+| Tier 1 Events | A library for tier 1 events, like Summit and AnsibleFest. |
 | Brand media |  A library for Red Hat original media like podcasts and video series. |
 | Page builder | A library with a boilerplate template and components specific to Drupal's page builder. |
 

--- a/docs/get-started/designers.md
+++ b/docs/get-started/designers.md
@@ -70,7 +70,9 @@ The RHDS library is our core library that includes our foundational styles, elem
 | ------------ | -------- |
 | RHDS         | Our core library for creating Red Hat digital experiences. |
 | <a href="https://www.patternfly.org/">PatternFly</a> | A library for creating application interfaces. |
-
+| Tier 1 events | A library for tier 1 events, like Summit and Ansiblefest. |
+| Brand media |  A library for Red Hat original media like podcasts and video series. |
+| Page builder | A library with a boilerplate template and components specific to Drupal's page builder. |
 
 ## Work in Figma
 


### PR DESCRIPTION
## What I did

1. Added descriptions for tier 1 events, brand media, and page builder libraries


## Testing Instructions

1. Check page in [DP](https://deploy-preview-1463--red-hat-design-system.netlify.app/get-started/designers)

## Notes to Reviewers
