### PR TITLE
fix(tabs): static instances

### DIFF
--- a/.changeset/angry-lemons-shop.md
+++ b/.changeset/angry-lemons-shop.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tabs>`: fixed issue that stop tabs from correctly resizing on mobile

--- a/elements/rh-tabs/rh-tabs.ts
+++ b/elements/rh-tabs/rh-tabs.ts
@@ -73,7 +73,7 @@ export class RhTabs extends LitElement {
   static {
     // on resize check for overflows to add or remove scroll buttons
     window.addEventListener('resize', () => {
-      for (const instance of this.instances) {
+      for (const instance of RhTabs.instances) {
         instance.#overflow.onScroll();
       }
     }, { capture: false });


### PR DESCRIPTION
## What I did

1. Fixed call to static issues, should be targeting a class static method not instance static method.  This bug stops the component from correctly resizing to mobile horizontal scrolling.

Closes #1466 


## Testing Instructions

1. View [Tabs demo](https://deploy-preview-1467--red-hat-design-system.netlify.app/elements/tabs/demo/)

## Notes to Reviewers

To test this you need to first remove the `display: grid` from the `main` element in the demo via the inspector 👎  
