### PR TITLE
bug(tile): z-index issue with headline link

### DIFF
--- a/.changeset/late-shrimps-shake.md
+++ b/.changeset/late-shrimps-shake.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tile>`: fixed issue with click target area of tile

--- a/docs/elements/elements.html
+++ b/docs/elements/elements.html
@@ -11,6 +11,7 @@ stylesheets:
   - /assets/packages/@rhds/elements/elements/rh-subnav/rh-subnav-lightdom.css
   - /assets/packages/@rhds/elements/elements/rh-pagination/rh-pagination-lightdom.css
   - /assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css
+  - /assets/packages/@rhds/elements/elements/rh-tile/rh-tile-lightdom.css
 eleventyComputed:
   title: "{{ doc.pageTitle }} | {{ doc.slug | deslugify }}"
   importElements:

--- a/elements/rh-tile/rh-tile-lightdom.css
+++ b/elements/rh-tile/rh-tile-lightdom.css
@@ -41,7 +41,6 @@ rh-tile a[slot="headline"]:after {
   z-index: 3;
 }
 
-
 rh-tile a[slot="image"] > :is(img, svg),
 rh-tile [slot="image"]:is(img, svg) {
   width: 100%;

--- a/elements/rh-tile/rh-tile-lightdom.css
+++ b/elements/rh-tile/rh-tile-lightdom.css
@@ -13,10 +13,6 @@ rh-tile a:not([slot="image"], [slot="headline"]) {
   position: relative !important;
 }
 
-rh-tile [slot="headline"] {
-  z-index: 3;
-}
-
 rh-tile[aria-disabled="true"] a {
   color:
     var(
@@ -39,6 +35,12 @@ rh-tile a:is([slot="image"], [slot="headline"]):after {
   inset: 0;
   display: var(--rh-tile-link-after-display);
 }
+
+rh-tile [slot="headline"] a:after,
+rh-tile a[slot="headline"]:after {
+  z-index: 3;
+}
+
 
 rh-tile a[slot="image"] > :is(img, svg),
 rh-tile [slot="image"]:is(img, svg) {

--- a/elements/rh-tile/rh-tile-lightdom.css
+++ b/elements/rh-tile/rh-tile-lightdom.css
@@ -13,6 +13,10 @@ rh-tile a:not([slot="image"], [slot="headline"]) {
   position: relative !important;
 }
 
+rh-tile [slot="headline"] {
+  z-index: 3;
+}
+
 rh-tile[aria-disabled="true"] a {
   color:
     var(


### PR DESCRIPTION
## What I did

1. Updated the lightDOM CSS for tile so that headline links have the highest z-index.


## Testing Instructions

1. Go to [DP Tile docs](https://deploy-preview-1471--red-hat-design-system.netlify.app/elements/tile/).
2. Ensure that every tile example has a headline link click target that covers the entire card.

## Notes to Reviewers
