### PR TITLE
docs: fix PF and PFE links

### DIFF
--- a/docs/about/how-we-build.njk
+++ b/docs/about/how-we-build.njk
@@ -11,7 +11,7 @@ tags:
 
 {% call about.section("Building experiences for the web") -%}
 
-  <p>The <strong>Red Hat Design System</strong> (RHDS) allows designers and developers across different teams to build branded experiences consistently. Based on the foundations of <a href="https://www.patternfly.org/v4/" target="_blank">PatternFly</a> and the <a href="https://www.redhat.com/en/about/brand/standards" target="_blank">Red Hat Brand Standards</a>, our design system reflects the Red&nbsp;Hat brand digitally.</p>
+  <p>The <strong>Red Hat Design System</strong> (RHDS) allows designers and developers across different teams to build branded experiences consistently. Based on the foundations of <a href="https://www.patternfly.org" target="_blank">PatternFly</a> and the <a href="https://www.redhat.com/en/about/brand/standards" target="_blank">Red Hat Brand Standards</a>, our design system reflects the Red&nbsp;Hat brand digitally.</p>
 
 {%- endcall %}
 
@@ -28,7 +28,7 @@ tags:
   <p><strong>PatternFly</strong> is the open source design system for Red Hat products, it is also the foundation for our components. We share design when possible by contributing ideas back to PatternFly to help grow its capabilities. When building a new component or updating an existing component, PatternFly is always our first source of inspiration.<br /><br />PatternFly can be used by designers and developers inside and outside of Red Hat. PatternFly is used to create React applications and provide HTML and CSS assets for other web projects. The Red Hat Design System is used to create Red Hat-branded websites or other digital properties. We collaborate with the <strong>Red Hat User Experience Design</strong> (UXD) team as they build user interface components for PatternFly.<br /><br />By sharing ideas between the PatternFly and RHDDS teams, we create a design language across all of Red Hat, for each stage of the customer lifecycle.</p>
 
   <rh-cta>
-    <a href="https://www.patternfly.org/v4/" target="_blank">Visit PatternFly</a>
+    <a href="https://www.patternfly.org" target="_blank">Visit PatternFly</a>
   </rh-cta>
 
   <div style="margin-top: 32px;">
@@ -74,7 +74,7 @@ tags:
         <tbody style="overflow:auto;">
           <tr>
             <td><strong>PatternFly</strong></td>
-            <td><a href="https://www.patternfly.org/v4/" target="_blank">PatternFly components</a></td>
+            <td><a href="https://www.patternfly.org" target="_blank">PatternFly components</a></td>
             <td><img src="{{ '/assets/about/how-we-build/table-patternfly.svg' | url }}" alt="Example PatternFly components" style="--example-img-max-width: 360px;"></td>
           </tr>
           <tr>

--- a/docs/design-code-status.njk
+++ b/docs/design-code-status.njk
@@ -147,7 +147,7 @@ title: Design/code status
             <td>Form</td>
             <td><span class="success">Complete</span></td>
             <td><div>WebRH</div></td>
-            <td><div><a href="../patterns/form">ux.redhat.com</a></div><div><a href="https://www.patternfly.org/v4/patterns/form" target="_blank">PatternFly</a></div></td>
+            <td><div><a href="../patterns/form">ux.redhat.com</a></div><div><a href="https://www.patternfly.org/components/forms/form">PatternFly</a></div></td>
           </tr>
           <tr>
             <td>Grid</td>

--- a/docs/design-code-status.njk
+++ b/docs/design-code-status.njk
@@ -32,7 +32,7 @@ title: Design/code status
             <td>Accordion</td>
             <td><span class="deemphasized">Refresh in progress</span></td>
             <td><div>PFE</div><div>Studio</div><div>WebRH</div></td>
-            <td><div><a href="../elements/accordion">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/accordion/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../elements/accordion">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/accordion/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Alert</td>
@@ -57,7 +57,7 @@ title: Design/code status
             <td>Avatar</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>Studio</div></td>
-            <td><div><a href="../elements/avatar">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/avatar/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../elements/avatar">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/avatar/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Blockquote</td>
@@ -75,25 +75,25 @@ title: Design/code status
             <td>Button</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>Custom</div></td>
-            <td><div><a href="../elements/button">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/button/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../elements/button">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/button/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Button (Stateful)</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div></td>
-            <td><div><span class="deemphasized">ux.redhat.com (backlog)</span></div><div><a href="https://patternflyelements.com/patterns/clipboard/" target="_blank">PFE</a></div></td>
+            <td><div><span class="deemphasized">ux.redhat.com (backlog)</span></div><div><a href="https://patternflyelements.com/components/clipboard-copy/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Call to action</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>RHDS</div><div>Custom</div></td>
-            <td><div><a href="../elements/call-to-action">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/call-to-action/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../elements/call-to-action">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/button/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Card</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>Custom</div></td>
-            <td><div><a href="../elements/card">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/card/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../elements/card">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/card/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Code block</td>
@@ -111,13 +111,13 @@ title: Design/code status
             <td>Disclosure</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>WebRH</div></td>
-            <td><div><a href="../patterns/disclosure">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/accordion/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../patterns/disclosure">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/accordion/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Dialog (content)</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>RHDS</div></td>
-            <td><div><a href="../elements/dialog">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/modal/" target="_blank">PFE</div></td>
+            <td><div><a href="../elements/dialog">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/modal/" target="_blank">PFE</div></td>
           </tr>
           <tr>
             <td>Dialog (video)</td>
@@ -129,7 +129,7 @@ title: Design/code status
             <td>Dropdown</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div></td>
-            <td><div><span class="deemphasized">ux.redhat.com (backlog)</span></div><div><a href="https://patternflyelements.com/patterns/dropdown/" target="_blank">PFE</a></div></td>
+            <td><div><span class="deemphasized">ux.redhat.com (backlog)</span></div><div><a href="https://patternflyelements.com/components/dropdown/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Filter</td>
@@ -165,13 +165,13 @@ title: Design/code status
             <td>Jump links</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>Custom</div></td>
-            <td><div><a href="../elements/jump-links">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/jump-links/" target="_blank">PFE</a></div></td>
+            <td><div><a href="../elements/jump-links">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/jump-links/" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Label</td>
             <td><span class="success">Complete</span></td>
             <td><span class="deemphasized">In progress</span></td>
-            <td><div><span class="deemphasized">ux.redhat.com (in progress)</span></div><div><a href="https://patternflyelements.org/patterns/label/demo/" target="_blank">PFE</a></div></td>
+            <td><div><span class="deemphasized">ux.redhat.com (in progress)</span></div><div><a href="https://patternflyelements.org/components/label" target="_blank">PFE</a></div></td>
           </tr>
           <tr>
             <td>Link</td>
@@ -219,7 +219,7 @@ title: Design/code status
             <td>Progress steps</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div></td>
-            <td><div><a href="../elements/progress-steps">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/progress-stepper/" target="_blank">PFE</div></td>
+            <td><div><a href="../elements/progress-steps">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/progress-stepper/" target="_blank">PFE</div></td>
           </tr>
           <tr>
             <td>Search bar</td>
@@ -273,7 +273,7 @@ title: Design/code status
             <td>Tabs</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>Studio</div><div>WebRH</div></td>
-            <td><div><a href="../elements/tabs">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/patterns/tabs/" target="_blank">PFE</div></td>
+            <td><div><a href="../elements/tabs">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/components/tabs/" target="_blank">PFE</div></td>
           </tr>
           <tr>
             <td>Tooltip</td>
@@ -285,7 +285,7 @@ title: Design/code status
             <td>Typography</td>
             <td><span class="success">Complete</span></td>
             <td><div>PFE</div><div>Studio</div><div>WebRH</div></td>
-            <td><div><a href="../foundations/typography">ux.redhat.com</a></div><div><a href="https://patternflyelements.com/theming/typography/" target="_blank">PFE</div></td>
+            <td><div><a href="../foundations/typography">ux.redhat.com</a></div></td>
           </tr>
           <tr>
             <td>Video thumbnail</td>

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -14,7 +14,7 @@ title: Home
 
 <div class="centered feature-box">
   <h2 class="feature-headline">Designing Red&nbsp;Hat digital experiences?</h2>
-  <p>You are at the right place. We rely on this design system to create consistent Red Hat® digital experiences. Using <a href="https://brand.redhat.com">Red&nbsp;Hat brand standards</a> and <a href="https://www.patternfly.org/v4/">PatternFly</a> as our foundational design language, we enable designers and developers to concurrently build branded experiences across <a href="https://www.redhat.com/">redhat.com</a>, <a href="https://access.redhat.com/">Red Hat Customer Portal</a>, and beyond.</p>
+  <p>You are at the right place. We rely on this design system to create consistent Red Hat® digital experiences. Using <a href="https://brand.redhat.com">Red&nbsp;Hat brand standards</a> and <a href="https://www.patternfly.org/">PatternFly</a> as our foundational design language, we enable designers and developers to concurrently build branded experiences across <a href="https://www.redhat.com/">redhat.com</a>, <a href="https://access.redhat.com/">Red Hat Customer Portal</a>, and beyond.</p>
   <rh-cta variant="secondary">
     <a href="/about">Learn more</a>
   </rh-cta>


### PR DESCRIPTION
## What I did

Fixed broken PatternFly and PFE links on UX dot.

## Testing Instructions

Check links in the DP's:
- [Homepage](https://deploy-preview-1478--red-hat-design-system.netlify.app/)
- [How we build page](https://deploy-preview-1478--red-hat-design-system.netlify.app/about/how-we-build/)
- [Design/code status page](https://deploy-preview-1478--red-hat-design-system.netlify.app/design-code-status/)

## Notes to Reviewers

Some of these links open in a new tab. I didn't fix that in this PR and can open a new issue instead.