### PR TITLE
fix: add analyze to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "start": "wireit",
     "dev": "wireit",
     "serve": "wireit",
+    "analyze": "wireit",
     "new": "npm init @patternfly/element",
     "🚧-BUILD": "❓ Make packages and artifacts",
     "build": "wireit",


### PR DESCRIPTION
## What I did

1. Add `analyze` command to npm scripts, caused `npm run new` to fail.  See #1482 


## Testing Instructions

1.  Create a new component with `npm run new`

## Notes to Reviewers
