### PR TITLE
docs: updated usage demos url on element code tags

### DIFF
--- a/elements/rh-audio-player/docs/40-code.md
+++ b/elements/rh-audio-player/docs/40-code.md
@@ -2,7 +2,7 @@
 
 ## Usage
 {% playground tagName=tagName %}{% endplayground %}
-{% cta href="./demo/", target="_blank" %}
+{% cta href="../demo/", target="_blank" %}
 View the demo in a new tab
 {% endcta %}
 

--- a/elements/rh-button/docs/30-code.md
+++ b/elements/rh-button/docs/30-code.md
@@ -2,7 +2,7 @@
 
 ## Usage
   {% playground tagName=button %}{% endplayground %}
-  {% cta href="./demo/", target="_blank" %}
+  {% cta href="../demo/", target="_blank" %}
 View the demo in a new tab
   {% endcta %}
 

--- a/elements/rh-tile/docs/30-code.md
+++ b/elements/rh-tile/docs/30-code.md
@@ -5,7 +5,7 @@
     Tiles require light DOM CSS to be included on the page in order to style links properly.
   {% endalert %}
   {% playground tagName=tile %}{% endplayground %}
-  {% cta href="./demo/", target="_blank" %}
+  {% cta href="../demo/", target="_blank" %}
 View the demo in a new tab
   {% endcta %}
 {% endband %}

--- a/elements/rh-tooltip/docs/30-code.md
+++ b/elements/rh-tooltip/docs/30-code.md
@@ -2,7 +2,7 @@
 
 ## Usage
   {% playground tagName=button %}{% endplayground %}
-  {% cta href="./demo/", target="_blank" %}
+  {% cta href="../demo/", target="_blank" %}
 View the demo in a new tab
   {% endcta %}
 


### PR DESCRIPTION
## What I did

For the docs **Code** page of each of the following elements, I fixed the link to the **View the demo in a new tab** link:

- `rh-audio-player`
- `rh-button`
- `rh-tile`
- `rh-tooltip`


## Testing Instructions

In the DP, go to each of the following pages, and make sure the **View the demo in a new tab** link is correct:

- [Audio player](https://deploy-preview-1493--red-hat-design-system.netlify.app/elements/audio-player/code/#usage)
- [Button](https://deploy-preview-1493--red-hat-design-system.netlify.app/elements/button/code/#usage)
- [Tile](https://deploy-preview-1493--red-hat-design-system.netlify.app/elements/tile/code/#usage)
- [Tooltip](https://deploy-preview-1493--red-hat-design-system.netlify.app/elements/tooltip/code/#usage)

## Notes to Reviewers
