### PR TITLE
fix: adds accents slot to rh-accordion-header

### DIFF
--- a/elements/rh-accordion/demo/accents.html
+++ b/elements/rh-accordion/demo/accents.html
@@ -1,0 +1,31 @@
+<rh-accordion>
+    <rh-accordion-header>
+      <h4>Item One</h4>
+      <rh-tag slot="accents" color="green" variant="outline" icon="circle-check">Green</rh-tag>
+      <rh-tag slot="accents" color="red" variant="filled" icon="info">Red</rh-tag>
+      <rh-tag slot="accents" color="orange" variant="outline" icon="bell">Orange</rh-tag>
+      <rh-tag slot="accents" color="purple" variant="filled" icon="ban">Purple</rh-tag>
+    </rh-accordion-header>
+    <rh-accordion-panel>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </rh-accordion-panel>
+    <rh-accordion-header>
+      <h4>Item Two</h4>
+      <rh-tag slot="accents" color="green" variant="outline" icon="circle-check">Green</rh-tag>
+    </rh-accordion-header>
+    <rh-accordion-panel>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </rh-accordion-panel>
+    <rh-accordion-header>
+      <h4>Item Three</h4>
+      <rh-tag slot="accents" color="red" variant="filled" icon="info">Red</rh-tag>
+    </rh-accordion-header>
+    <rh-accordion-panel>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </rh-accordion-panel>
+</rh-accordion>
+
+<script type="module">
+    import '@rhds/elements/rh-accordion/rh-accordion.js';
+    import '@rhds/elements/rh-tag/rh-tag.js'
+</script>

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -107,6 +107,12 @@ span {
   text-align: start;
 }
 
+[part="container"] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rh-space-xs, 4px);
+}
+
 #button[aria-expanded="true"] #icon {
   rotate: calc(var(--_isRTL, -1) * 180deg);
 }
@@ -144,4 +150,10 @@ span {
   position: absolute;
   inset-block: 0;
   inset-inline-start: 0;
+}
+
+@media screen and (min-width: 576px) {
+  [part="container"] {
+    flex-direction: row;
+  }
 }

--- a/elements/rh-accordion/rh-accordion-header.ts
+++ b/elements/rh-accordion/rh-accordion-header.ts
@@ -123,8 +123,13 @@ export class RhAccordionHeader extends LitElement {
       <button id="button"
               class="toggle"
               aria-expanded="${String(!!this.expanded) as 'true' | 'false'}">
-        <span part="text">${headingText ?? html`
+        <span part="container">
+          <span part="text">${headingText ?? html`
           <slot></slot>`}
+          </span>
+          <span part="accents">
+            <slot name="accents"></slot>
+          </span>
         </span>
         <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
           <path d="M201.4 374.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 306.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"/>


### PR DESCRIPTION
## What I did

1. Added an accents slot to rh-accordion-header which was missing from the code
2. Wrapped text and accents slot into a container span
3. Created a accents.html file with rh-tags in accemts slot
4. Added styles for mobile


## Testing Instructions

1.

## Notes to Reviewers

1. We still need to revisit the styles and mappings for the accents as we didn't find any in the figma
