### PR TITLE
fix: fix <rh-alert> body copy and button color

### DIFF
--- a/elements/rh-alert/rh-alert.css
+++ b/elements/rh-alert/rh-alert.css
@@ -93,6 +93,7 @@ header ::slotted(:is(h1,h2,h3,h4,h5,h6)) {
 
 #description {
   font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+  color: var(--rh-color-text-primary-on-light, #151515);
 }
 
 #description > ::slotted(*) {


### PR DESCRIPTION
## What I did

Ensure that the copy in `<rh-alert>` doesn't change in different color contexts. All alert variants should look the same in light and dark theme.


## Testing Instructions

1.

## Notes to Reviewers
