### PR TITLE
fix(menu): improve keyboard accessibility on firefox

### DIFF
--- a/.changeset/large-kings-drop.md
+++ b/.changeset/large-kings-drop.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-menu>`: improved focus accessibility for keyboard navigation users on firefox
+`<rh-button>`: improved focus accessibility for keyboard navigation users on firefox

--- a/.changeset/large-kings-drop.md
+++ b/.changeset/large-kings-drop.md
@@ -3,4 +3,4 @@
 ---
 
 `<rh-menu>`: improved focus accessibility for keyboard navigation users on firefox
-`<rh-button>`: improved focus accessibility for keyboard navigation users on firefox
+`<rh-button>`: improved focus accessibility on firefox

--- a/elements/rh-button/rh-button.ts
+++ b/elements/rh-button/rh-button.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
+import { query } from 'lit/decorators/query.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
@@ -47,6 +48,8 @@ export class RhButton extends LitElement {
 
   /** Shorthand for the `icon` slot, the value is icon name */
   @property() icon?: string;
+
+  @query('button') private _button!: HTMLButtonElement;
 
   /**
    * Changes the style of the button.
@@ -149,6 +152,10 @@ export class RhButton extends LitElement {
       default:
         return '';
     }
+  }
+
+  focus() {
+    this._button?.focus();
   }
 }
 

--- a/elements/rh-menu/demo/color-context.html
+++ b/elements/rh-menu/demo/color-context.html
@@ -1,6 +1,5 @@
 <rh-context-demo>
   <rh-menu>
-    <rh-button>Toggle Links</rh-button>
     <a href="#">Link1</a>
     <a href="#">Link2</a>
     <a href="#">Link3</a>

--- a/elements/rh-menu/demo/color-context.html
+++ b/elements/rh-menu/demo/color-context.html
@@ -13,4 +13,3 @@
   import '@rhds/elements/rh-button/rh-button.js';
   import '@rhds/elements/lib/elements/rh-context-demo/rh-context-demo.js';
 </script>
-

--- a/elements/rh-menu/demo/position-left.html
+++ b/elements/rh-menu/demo/position-left.html
@@ -1,5 +1,4 @@
 <rh-menu position="left" persistent>
-  <rh-button slot="button">Toggle Settings</rh-button>
   <rh-button variant="link">Menuitem1</rh-button>
   <rh-button variant="link">Menuitem2</rh-button>
   <rh-button variant="link">Menuitem3</rh-button>

--- a/elements/rh-menu/demo/position-right.html
+++ b/elements/rh-menu/demo/position-right.html
@@ -1,5 +1,4 @@
 <rh-menu position="right">
-  <rh-button slot="button">Toggle Links</rh-button>
   <a href="#">Link1</a>
   <a href="#">Link2</a>
   <a href="#">Link3</a>

--- a/elements/rh-menu/demo/position-top.html
+++ b/elements/rh-menu/demo/position-top.html
@@ -1,5 +1,4 @@
 <rh-menu position="top">
-  <rh-button slot="button">Toggle Menu</rh-button>
   <rh-button variant="link">Menuitem1</rh-button>
   <rh-button variant="link">Menuitem2</rh-button>
   <rh-button variant="link">Menuitem3</rh-button>

--- a/elements/rh-menu/demo/rh-menu.html
+++ b/elements/rh-menu/demo/rh-menu.html
@@ -1,5 +1,4 @@
 <rh-menu id="rh-buttons">
-  <rh-button slot="button">Toggle Menu</rh-button>
   <rh-button data-item="1" variant="link">Menuitem1</rh-button>
   <rh-button data-item="2" variant="link">Menuitem2</rh-button>
   <rh-button data-item="3" variant="link">Menuitem3</rh-button>

--- a/elements/rh-menu/rh-menu.css
+++ b/elements/rh-menu/rh-menu.css
@@ -9,9 +9,12 @@ slot {
   width: max-content;
 }
 
+::slotted(a) {
+  padding: 5px !important; /* WARNING: not a token value */
+}
+
 .dark::slotted(a) {
   color: var(--rh-color-interactive-blue-lightest, #b9dafc) !important;
-  padding: 5px !important; /* WARNING: not a token value */
 }
 
 .dark::slotted(a:hover) {

--- a/elements/rh-menu/rh-menu.ts
+++ b/elements/rh-menu/rh-menu.ts
@@ -27,6 +27,8 @@ export class MenuToggleEvent extends Event {
 export class RhMenu extends LitElement {
   static readonly styles = [styles];
 
+  static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
   @queryAssignedElements() private _menuItems!: HTMLElement[];
 
   @colorContextConsumer() private on?: ColorTheme;
@@ -63,6 +65,10 @@ export class RhMenu extends LitElement {
 
   activateItem(item: HTMLElement) {
     this.#tabindex.setActiveItem(item);
+  }
+
+  focus() {
+    this.#tabindex.activeItem?.focus();
   }
 }
 


### PR DESCRIPTION
## What I did

1.  `<rh-menu>`: 
    - Added  `delegatesFocus:true` and `focus()` to improve the keyboard navigation accessibility on firefox
    - Improved demos by removing uneeded trigger button `slot="button` elements.
    - Fixed CSS bug where padding was only applied to dark slotted a tags
2. `<rh-button>`: Added  `focus()` to ensure the shadow button receives focus from firefox.


## Testing Instructions

1.  View  Menu [Deploy preview demo](https://deploy-preview-1529--red-hat-design-system.netlify.app/elements/menu/demo/)
2. View Audio Player integration [Deploy preview demo](https://deploy-preview-1529--red-hat-design-system.netlify.app/elements/audio-player/demo/)

## Notes to Reviewers

Please review Audio player's implementation as well.