### PR TITLE
chore: correcting pfe to devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@rhds/elements",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.1",
+        "@patternfly/elements": "^3.0.1",
         "@patternfly/icons": "^1.0.2",
         "@patternfly/pfe-core": "^3.0.0",
         "@rhds/tokens": "^2.0.1",
@@ -26,7 +27,6 @@
         "@lit/reactive-element": "^2.0.4",
         "@parse5/tools": "^0.3.0",
         "@patternfly/create-element": "^1.0.2",
-        "@patternfly/elements": "^3.0.0",
         "@patternfly/eslint-config-elements": "^3.0.0",
         "@patternfly/eslint-plugin-elements": "^2.0.0",
         "@patternfly/pfe-tools": "^2.0.1",
@@ -4092,9 +4092,9 @@
       }
     },
     "node_modules/@patternfly/elements": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/elements/-/elements-3.0.1.tgz",
+      "integrity": "sha512-vrnpPF1LSuuCRMDsHU6ZUIrAworWPiY+ZtCQ+jv0HQw63ET1X81lmBDCt3o5wKhwswAW08ke6sIDLsZiF2vKJw==",
       "dependencies": {
         "@lit/context": "^1.1.0",
         "@patternfly/icons": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
   },
   "dependencies": {
     "@lit/context": "^1.1.1",
+    "@patternfly/elements": "^3.0.1",
     "@patternfly/icons": "^1.0.2",
     "@patternfly/pfe-core": "^3.0.0",
     "@rhds/tokens": "^2.0.1",
@@ -253,7 +254,6 @@
     "@lit/reactive-element": "^2.0.4",
     "@parse5/tools": "^0.3.0",
     "@patternfly/create-element": "^1.0.2",
-    "@patternfly/elements": "^3.0.0",
     "@patternfly/eslint-config-elements": "^3.0.0",
     "@patternfly/eslint-plugin-elements": "^2.0.0",
     "@patternfly/pfe-tools": "^2.0.1",


### PR DESCRIPTION
## What I did

1.  Moved `@patternfly/elements` to a dependency of the project so a user downloading the project will have access to `pf-icon` which RHDS still depends on.


## Testing Instructions

1.

## Notes to Reviewers
