### PR TITLE
docs: fix repo-status tag padding in mobile

### DIFF
--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -251,9 +251,12 @@ function repoStatusTable() {
 <tr>
 <td data-label="Name">
   <a href="/elements/${listItem.name}">${listItem.name}</a>
-  ${listItem.overallStatus !== 'Available' ? `<rh-tag color="${STATUS_LEGEND[listItem.overallStatus].color}" variant="${STATUS_LEGEND[listItem.overallStatus].variant}">
-    ${listItem.overallStatus}${STATUS_LEGEND[listItem.overallStatus].icon}
-  </rh-tag>` : ''}
+  ${listItem.overallStatus !== 'Available' ? `
+  <span>
+    <rh-tag color="${STATUS_LEGEND[listItem.overallStatus].color}" variant="${STATUS_LEGEND[listItem.overallStatus].variant}">
+      ${listItem.overallStatus}${STATUS_LEGEND[listItem.overallStatus].icon}
+    </rh-tag>
+  </span>` : ''}
 </td>
 ${listItem.libraries.map(lib => {
     return /* html */`

--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -250,13 +250,13 @@ function repoStatusTable() {
     return /* html */`
 <tr>
 <td data-label="Name">
-  <a href="/elements/${listItem.name}">${listItem.name}</a>
-  ${listItem.overallStatus !== 'Available' ? `
   <span>
-    <rh-tag color="${STATUS_LEGEND[listItem.overallStatus].color}" variant="${STATUS_LEGEND[listItem.overallStatus].variant}">
-      ${listItem.overallStatus}${STATUS_LEGEND[listItem.overallStatus].icon}
-    </rh-tag>
-  </span>` : ''}
+    <a href="/elements/${listItem.name}">${listItem.name}</a>
+    ${listItem.overallStatus !== 'Available' ?
+      `<rh-tag color="${STATUS_LEGEND[listItem.overallStatus].color}" variant="${STATUS_LEGEND[listItem.overallStatus].variant}">
+        ${listItem.overallStatus}${STATUS_LEGEND[listItem.overallStatus].icon}
+      </rh-tag>` : ''}
+  </span>
 </td>
 ${listItem.libraries.map(lib => {
     return /* html */`


### PR DESCRIPTION
## What I did

1. This MR fixes https://github.com/RedHat-UX/red-hat-design-system/issues/1550
2. Added a span around rh-tag (overall status) in the Repo Status table to fix the extra padding issue in mobile view


## Testing Instructions

1. Go to https://ux.redhat.com/design-code-status/
3. Check the mobile view for the repo status table
4. the overall status i.e New, Experimental, Beta should not have extra padding in mobile view

## Notes to Reviewers
