### PR TITLE
docs(get started): add links to accessibility docs

### DIFF
--- a/docs/get-started/designers.md
+++ b/docs/get-started/designers.md
@@ -40,6 +40,10 @@ Our design system libraries and the documentation website offer assets and guida
         <h3>Elements and patterns</h3>
         <p>Our libraries include <a href="/elements">elements</a> and <a href="/patterns">patterns</a> you can use to create digital experiences.</p>
     </div>
+    <div>
+        <h3>Accessibility</h3>
+        <p><a href="/accessibility/design/">Designer-specific guidelines</a> equip you with the information to create inclusive digital experiences.</p>
+    </div>
 </div>
 
 ## Access Figma

--- a/docs/get-started/developers/index.md
+++ b/docs/get-started/developers/index.md
@@ -32,7 +32,7 @@ Our design system libraries and the documentation website offer assets and guida
     </div>
     <div>
         <h3>Documentation</h3>
-        <p>This website offers guidance about how to use our <a href="elements">elements</a> and <a href="patterns">patterns</a> correctly.</p>
+        <p>This website offers guidance about how to use our <a href="elements">elements</a> and <a href="patterns">patterns</a>. Learn how to apply them accessibily with <a href="/accessibility/development/">developer-specific guidelines</a>.</p>
     </div>
     <div>
         <h3>GitHub repositories</h3>


### PR DESCRIPTION
## What I did

1. Add link to designer accessibility docs to "Get started: Designers"
2. Add link to developer accessibility docs to "Get started: Developers"


## Testing Instructions

- Check links in DP: ["Get started: Designers"](https://deploy-preview-1553--red-hat-design-system.netlify.app/get-started/designers/#learn-about-our-design-system) (under "Accessibility") and ["Get started: Developers" ](https://deploy-preview-1553--red-hat-design-system.netlify.app/get-started/developers/#learn-about-our-design-system) (under "Documentation")

## Notes to Reviewers
