### PR TITLE
chore: improve test run speed by removing full build deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,10 +116,17 @@
         "docs"
       ]
     },
+    "build:test": {
+      "dependencies": [
+        "patch",
+        "analyze",
+        "compile"
+      ]
+    },
     "test": {
       "command": "wtr --group default",
       "dependencies": [
-        "build"
+        "build:test"
       ]
     },
     "compile": {


### PR DESCRIPTION
## What I did

1. Improved running speed of `npm run test` I believe we don't need the full build stack as a dependency for tests such as the docs and artifact builds.
2. Created `build:test` which reduces deps needed for test runs.


## Testing Instructions

1.

## Notes to Reviewers
