### PR TITLE
chore(tabs): add a nested demo

### DIFF
--- a/elements/rh-tabs/demo/nested.html
+++ b/elements/rh-tabs/demo/nested.html
@@ -1,0 +1,35 @@
+<rh-tabs>
+  <rh-tab id="users" slot="tab">Users</rh-tab>
+  <rh-tab-panel>Users</rh-tab-panel>
+  <rh-tab slot="tab">Containers</rh-tab>
+  <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+  <rh-tab slot="tab">Database</rh-tab>
+  <rh-tab-panel>Database</rh-tab-panel>
+  <rh-tab slot="tab">Servers</rh-tab>
+  <rh-tab-panel>Servers</rh-tab-panel>
+  <rh-tab slot="tab">Nested</rh-tab>
+  <rh-tab-panel>
+    <rh-tabs>
+      <rh-tab slot="tab">Nested Users</rh-tab>
+      <rh-tab-panel>Users</rh-tab-panel>
+      <rh-tab slot="tab">Nested Containers</rh-tab>
+      <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+      <rh-tab slot="tab">Nested Database</rh-tab>
+      <rh-tab-panel>Database</rh-tab-panel>
+      <rh-tab slot="tab">Nested Servers</rh-tab>
+      <rh-tab-panel>Servers</rh-tab-panel>
+      <rh-tab slot="tab">Nested Cloud</rh-tab>
+      <rh-tab-panel>Cloud</rh-tab-panel>
+    </rh-tabs>
+  </rh-tab-panel>
+</rh-tabs>
+
+<style>
+  rh-tab-panel {
+    padding: 0;
+  }
+</style>
+
+<script type="module">
+  import '@rhds/elements/rh-tabs/rh-tabs.js';
+</script>


### PR DESCRIPTION
## What I did

1. Add a nested demo

Closes #1481 

## Testing Instructions

1.  View [nested demo](https://deploy-preview-1573--red-hat-design-system.netlify.app/elements/tabs/demo/nested/)

## Notes to Reviewers

@eyevana here is a demo showing nested tabs working.  The bug outlined in #1481 was fixed by our implementation changes from a tabs-controller to aria-tabs-controller upstream in pfe.  https://github.com/patternfly/patternfly-elements/pull/2699

Thanks for filling the issue!
