### PR TITLE
docs: add assistive tech page and new resources

### DIFF
--- a/docs/accessibility/assistive-tech.md
+++ b/docs/accessibility/assistive-tech.md
@@ -1,0 +1,61 @@
+---
+title: Assistive technologies
+tags:
+  - accessibility
+order: 55
+---
+
+## What are assistive technologies?
+
+Assistive technologies are devices and software that enable or enhance participation in physical or digital environments that may not otherwise match a person’s abilities.
+
+In the physical world, technologies like wheelchairs improve mobility, glasses and hearing aids increase sensory acuity, and respirator masks allow the immunocompromised to access spaces where they may be at risk.
+
+## Digital assistive technologies
+
+Assistive technologies also allow people to better engage with digital environments. These technologies may be physical equipment, software, or a combination of both.
+
+### Assistive equipment
+
+Physical devices used to interact with digital experiences include the following:
+
+- Braille displays: desktop devices using raised-and-lowered braille pins to communicate on-screen information.
+- Mouth sticks and head pointers: lightweight tools allowing people to type, gesture, and perform other tasks hands-free.
+- Eye trackers: camera-based devices that follow users’ eye movements to access computer functions.
+- Adaptive switches: a category including buttons, joysticks, and breath controllers that can be used to interact with digital devices.
+
+Some devices we may not typically think of as assistive technologies, like computer keyboards, operate as such when used in certain ways or when built with certain features. Keyboard-only users often need to perform the same tasks as mouse or touchscreen users, but do so via keypresses and shortcuts. Some keyboards also include braille dots or large print symbols.
+
+### Assistive software
+
+Software-based assistive technologies available for computers and mobile devices include the following:
+
+- Screen readers
+- Screen magnifiers
+- Speech input software
+
+#### Screen readers
+
+Screen readers provide audio and/or braille descriptions of on-screen elements and events—including those appearing and occurring in web browsers. Desktop screen reader users typically navigate and interact with experiences via keyboard, while mobile devices are typically gesture-operated.
+
+Screen readers are often packaged with operating systems: macOS and iOS devices include VoiceOver, Windows includes Narrator, and Android includes TalkBack. Unix-like systems using GNOME come packaged with the Orca screen reader. Windows users can also install popular third-party screen readers, like JAWS and NVDA.
+
+Visit our [Accessibility QA and testing page](https://ux.redhat.com/accessibility/qa-testing/#screen-readers) for information on web browser and screen reader combinations.
+
+#### Screen magnifiers
+
+Screen magnifiers zoom in on parts of a screen to enhance its contents for low-vision users. Some magnifiers may bundle other features, too, like options to combine magnification with screen reading.
+
+As with screen readers, operating systems may include on-screen magnification, like macOS’s zoom feature or Windows’s Magnifier. iOS and Android devices include zoom/magnification options in their accessibility settings. And Orca (the screen reader for GNOME) also includes magnification features. Third-party options also exist, like Freedom Scientific’s ZoomText (which can be packaged with their JAWS screen reader).
+
+#### Speech input software
+
+Speech input software enables hands-free control of computers and mobile devices via dictation.
+
+Most modern operating systems include speech input features, like macOS’s Voice Control and Windows’ voice access (as of Windows 11, version 22H2) and Speech Recognition (for earlier versions of Windows). Popular third-party speech input software includes Nuance Dragon (formerly Dragon NaturallySpeaking).
+
+#### Other software solutions
+
+Some software can emulate physical assistive technology devices. An example of this is iOS’s Switch Control mode, which acts similarly to an adaptive switch. iOS also includes Magnifier, which uses a device’s camera and screen not only to zoom in on objects, but also to detect them, identify them, and enhance their on-screen representations (e.g., by changing contrast).
+
+Assistive technologies may also be baked into software, like how online and offline video players typically include options to display captions. Creators will still need to supply these assistive technologies with source files or content: captions, transcripts, audio descriptions, etc.

--- a/docs/accessibility/q-a-testing.md
+++ b/docs/accessibility/q-a-testing.md
@@ -82,14 +82,52 @@ If you do nothing else to test your projects, try navigating the entire experien
 
 If you’re feeling ambitious and want to combine testing tasks, perform your keyboard testing with a screen reader turned on. The screen reader you use for testing depends on the operating system and browser you wish to test.
 
-| Operating system | Browser | Screen reader                                                                                                                                            |
-| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MacOS            | Safari  | [VoiceOver for Mac](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) (included with MacOS)                                 |
-| Windows          | Firefox | [NVDA](https://www.nvaccess.org/download/) (free download)                                                                                               |
-| Windows          | Chrome  | [JAWS](https://www.freedomscientific.com/products/software/jaws/) (paid)                                                                                 |
-| Linux            | Firefox | [Orca](https://help.gnome.org/users/orca/stable/index.html.en) (included with GNOME desktop environment)                                                 |
-| Android          | Chrome  | [Talkback](https://support.google.com/accessibility/android/answer/6283677?hl=en&ref_topic=10601571&sjid=4695144848639410734-NC) (included with Android) |
-| iOS              | Safari  | [VoiceOver for iOS](https://support.apple.com/en-sa/guide/iphone/iph3e2e415f/ios) (included with iOS)                                                    |
+<rh-table>
+  <table>
+    <caption>
+      Browser and screen reader pairings
+    </caption>
+    <thead>
+      <tr>
+        <th scope="col" data-label="OS">Operating system</th>
+        <th scope="col" data-label="Browser">Browser</th>
+        <th scope="col" data-label="Reader">Screen reader</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-label="OS">MacOS</td>
+        <td data-label="Browser">Safari</td>
+        <td data-label="Reader"><a href="https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac">VoiceOver for Mac</a> (included with MacOS)</td>
+      </tr>
+      <tr>
+        <td data-label="OS">Windows</td>
+        <td data-label="Browser">Firefox</td>
+        <td><a href="https://www.nvaccess.org/download/">NVDA</a> (free download)</td>
+      </tr>
+      <tr>
+        <td data-label="OS">Windows</td>
+        <td data-label="Browser">Chrome</td>
+        <td data-label="Reader"><a href="https://www.freedomscientific.com/products/software/jaws/">JAWS</a> (paid)</td>
+      </tr>
+      <tr>
+        <td data-label="OS">Linux</td>
+        <td data-label="Browser">Firefox</td>
+        <td data-label="Reader"><a href="https://help.gnome.org/users/orca/stable/index.html.en">Orca</a> (included with GNOME desktop environment)</td>
+      </tr>
+      <tr>
+        <td data-label="OS">Android</td>
+        <td data-label="Browser">Chrome</td>
+        <td data-label="Reader"><a href="https://support.google.com/accessibility/android/answer/6283677?hl=en&amp;ref_topic=10601571&amp;sjid=4695144848639410734-NC">Talkback</a> (included with Android)</td>
+      </tr>
+      <tr>
+        <td data-label="OS">iOS</td>
+        <td data-label="Browser">Safari</td>
+        <td data-label="Reader"><a href="https://support.apple.com/en-sa/guide/iphone/iph3e2e415f/ios">VoiceOver for iOS</a> (included with iOS)</td>
+      </tr>
+    </tbody>
+  </table>
+</rh-table>
 
 Deque offers a collection of [screen reader shortcuts](https://dequeuniversity.com/screenreaders/) for all of the above listed technologies.
 

--- a/docs/accessibility/q-a-testing.md
+++ b/docs/accessibility/q-a-testing.md
@@ -2,9 +2,9 @@
 title: QA and Testing
 sidenavTitle: QA and Testing
 permalink: /accessibility/qa-testing/index.html
-tags: 
- - accessibility
-order: 10
+tags:
+  - accessibility
+order: 50
 importElements:
   - rh-blockquote
 ---
@@ -21,14 +21,12 @@ importElements:
 
 Automated tools can help you quickly identify many potential high-impact accessibility issues. Among such tools are free browser extensions like WebAIM’s WAVE, Deque’s axe DevTools, and IBM's Equal Access Checker.
 
-
 ### WebAIM WAVE
 
 WAVE is an accessibility checker that’s particularly useful for visual users who prefer to see issues and alerts in context: kind of an augmented reality for the browser window. It may return some false positive results on color contrast, but such issues should always be manually confirmed, anyway. (And sometimes, what looks to be a false positive is a legitimate error, once you start digging into the CSS!)
 
 Getting started with WAVE is simple. Just go to a page, click the extension button, and it annotates your screen with icons, based on topic (e.g., headings, color contrast issues, etc.). But it’s more than just a visual tool. Clicking on annotations often gives you the option to view relevant in-page code and WCAG criteria.
 The [WAVE browser extension](https://wave.webaim.org/) is available for Chrome, Firefox, and Edge.
-
 
 ### Deque axe DevTools
 
@@ -37,7 +35,6 @@ Tucked away in your browser’s DevTools panel after installation, Deque’s axe
 Different WCAG versions (2.0 through 2.2) and conformance levels (A through AAA) can be specified in the extension’s settings. (At Red Hat, we target WCAG 2.1 AA.) And you can toggle best practices results on and off, depending on whether you’re interested solely in strict WCAG conformance. You can read the full list of rules being tested at the [axe-core GitHub repository](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md).
 
 The [axe DevTools extension](https://www.deque.com/axe/devtools/) is available for Chrome, Firefox, and Edge. The free version allows you to test entire pages. The paid Pro version adds the capability to specify page sections for testing, provides additional export options, and also includes some guided walkthroughs for further testing.
-
 
 ### IBM Equal Access Checker
 
@@ -48,7 +45,6 @@ Running Equal Access Checker in conjunction with a tool like axe DevTools can be
 In addition to WCAG versions 2.0, 2.1, and 2.2, Equal Access Checker can run scans based on IBM’s internal accessibility target. Currently, this target includes all of WCAG 2.1 AA, plus some additional U.S. (Section 508) and European (EN 301 549) standards not covered by WCAG. IBM has posted the [Equal Access testing ruleset](https://www.ibm.com/able/requirements/checker-rule-sets) at their accessibility site.
 
 [Equal Access Checker](https://www.ibm.com/able/toolkit/tools/#develop) can be installed as a browser extension in Chrome, Firefox, and Edge. It’s also available as CI/CD Node packages.
-
 
 ## Testing
 
@@ -65,39 +61,37 @@ Designers can evaluate their designs for things like color contrast, honest affo
 
 Keep in mind that testing isn’t easy. With many accessibility checks being judgment calls (what constitutes good alt text or clear form instructions?), even [experts disagree on accessibility](https://www.w3.org/TR/accessibility-conformance-challenges/#themes-from-research). Seek perfection, but accept progress along the way. Fix obvious errors, and use your best judgment with other potential issues—asking other subject matter experts as you go, if you have access to them.
 
-
 ### Testing technologies
 
 When manually testing web pages for accessibility, the following four tools are invaluable:
+
 - Your keyboard
 - A screen reader
 - A color contrast checker
 - The browser inspector
 
-
 #### Keyboard testing
 
 If you do nothing else to test your projects, try navigating the entire experience with your keyboard, via the following keys:
-- *<kbd>Tab</kbd> and <kbd>shift+tab</kbd>* to move forward and backward between focusable items (e.g., links, form controls, and scrollable windows).
-- *Arrow keys (<kbd>↑ → ↓ ←</kbd>)* to scroll windows, to operate form controls and tab interfaces, and to navigate through groups of focusable items (like sections of an accordion or options in a menu).
-- *<kbd>Enter</kbd> and/or <kbd>Space</kbd>* to follow links, activate buttons, select list items, and trigger other interactive items, as appropriate.
 
+- _<kbd>Tab</kbd> and <kbd>shift+tab</kbd>_ to move forward and backward between focusable items (e.g., links, form controls, and scrollable windows).
+- _Arrow keys (<kbd>↑ → ↓ ←</kbd>)_ to scroll windows, to operate form controls and tab interfaces, and to navigate through groups of focusable items (like sections of an accordion or options in a menu).
+- _<kbd>Enter</kbd> and/or <kbd>Space</kbd>_ to follow links, activate buttons, select list items, and trigger other interactive items, as appropriate.
 
 #### Screen readers
 
-If you’re feeling ambitious and want to combine testing tasks, perform your keyboard testing with a screen reader turned on.  The screen reader you use for testing depends on the operating system and browser you wish to test. 
+If you’re feeling ambitious and want to combine testing tasks, perform your keyboard testing with a screen reader turned on. The screen reader you use for testing depends on the operating system and browser you wish to test.
 
-| Operating system | Browser | Screen reader                                                                                                                    |
-| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| MacOS            | Safari  | [VoiceOver for Mac](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) (included with MacOS)         |
-| Windows          | Firefox | [NVDA](https://www.nvaccess.org/download/) (free download)                                                                       |
-| Windows          | Chrome  | [JAWS](https://www.freedomscientific.com/products/software/jaws/) (paid)                                                         |
-| Linux            | Firefox | [Orca](https://help.gnome.org/users/orca/stable/index.html.en)  (included with GNOME desktop environment)                        |
-| Android          | Chrome  | [Talkback](https://support.google.com/accessibility/android/answer/6283677?hl=en&ref_topic=10601571&sjid=4695144848639410734-NC) (included with Android)|
-| iOS              | Safari  | [VoiceOver for iOS](https://support.apple.com/en-sa/guide/iphone/iph3e2e415f/ios) (included with iOS) |
+| Operating system | Browser | Screen reader                                                                                                                                            |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MacOS            | Safari  | [VoiceOver for Mac](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) (included with MacOS)                                 |
+| Windows          | Firefox | [NVDA](https://www.nvaccess.org/download/) (free download)                                                                                               |
+| Windows          | Chrome  | [JAWS](https://www.freedomscientific.com/products/software/jaws/) (paid)                                                                                 |
+| Linux            | Firefox | [Orca](https://help.gnome.org/users/orca/stable/index.html.en) (included with GNOME desktop environment)                                                 |
+| Android          | Chrome  | [Talkback](https://support.google.com/accessibility/android/answer/6283677?hl=en&ref_topic=10601571&sjid=4695144848639410734-NC) (included with Android) |
+| iOS              | Safari  | [VoiceOver for iOS](https://support.apple.com/en-sa/guide/iphone/iph3e2e415f/ios) (included with iOS)                                                    |
 
 Deque offers a collection of [screen reader shortcuts](https://dequeuniversity.com/screenreaders/) for all of the above listed technologies.
-
 
 #### Color contrast checkers
 
@@ -106,7 +100,6 @@ A [plurality of web accessibility issues](https://webaim.org/projects/million/#c
 TPGi’s [Colour Contrast Analyzer](https://www.tpgi.com/color-contrast-checker/) is a free Mac and Windows application that helps you measure contrast between colors via an eyedropper tool (which lets you test the color of any pixel on your screen) or by typing in color values.
 
 If you’re either not on a device where you can install TPGi’s tool or just want a quick gut check, WebAIM has an [online contrast checker](https://webaim.org/resources/contrastchecker/) that allows you to type in foreground and background color values.
-
 
 #### Browser inspector
 

--- a/docs/accessibility/q-a-testing.md
+++ b/docs/accessibility/q-a-testing.md
@@ -7,14 +7,22 @@ tags:
 order: 50
 importElements:
   - rh-blockquote
+  - rh-table
 ---
 
+<link rel="stylesheet" href="{{ '/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css' | url }}">
+<link rel="stylesheet" href="{{ '/styles/samp.css' | url }}">
+
 <style>
-    rh-blockquote {
-        display: block;
-        margin-block: 2em !important;
-        max-width: 36em;
-    }
+  .page-spacing .container rh-table {
+    margin-block-end: var(--rh-space-3xl, 48px);
+  }
+
+  rh-blockquote {
+    display: block;
+    margin-block: 2em !important;
+    max-width: 36em;
+  }
 </style>
 
 ## Accessibility tools

--- a/docs/accessibility/resources.md
+++ b/docs/accessibility/resources.md
@@ -24,6 +24,7 @@ order: 60
 - [Web Accessibility Evaluation Tool (WAVE)](https://wave.webaim.org/extension/): browser extension for accessibility evaluation
 - [axe DevTools](https://www.deque.com/axe/devtools/): browser extension for accessibility testing
 - [IBM’s Equal Access Checker](https://www.ibm.com/able/toolkit/tools/#develop): browser extensions and CI/CD node packages for accessibility testing
+- [TetraLogical A11y Quick Tests](https://www.youtube.com/playlist?list=PLTqm2yVMMUKWTr9XWdW5hJ9tk512Ow0SE): series of very short videos on accessibility testing methods
 
 ### Color accessibility checkers
 
@@ -51,3 +52,6 @@ order: 60
 - [How A Screen Reader User Accesses The Web: A Smashing Video (with Léonie Watson)](https://www.smashingmagazine.com/2019/02/accessibility-webinar/) — Highly recommended!
 - [Google Chrome Developers #A11ycast on YouTube](https://www.youtube.com/user/ChromeDevelopers/search?query=%23a11ycast)
 - [Google Developers: Progressive Web Apps Training](https://developers.google.com/web/ilt/pwa/)
+- [Google A11ycasts](https://www.youtube.com/watch?v=HtTyRajRuyY&index=1)
+- [Web Accessibility Perspective Videos](https://www.w3.org/WAI/perspective-videos/)
+- [US Department of Education OCR Video Series](https://adata.org/ocr-videos)

--- a/docs/accessibility/resources.md
+++ b/docs/accessibility/resources.md
@@ -1,5 +1,8 @@
 ---
 title: Resources
+tags:
+  - accessibility
+order: 60
 ---
 
 ## Fundamentals
@@ -25,7 +28,7 @@ title: Resources
 ### Color accessibility checkers
 
 - [Let’s get color blind](https://chromewebstore.google.com/detail/lets-get-color-blind/bkdgdianpkfahpkmphgehigalpighjck): browser extension that adds color blindness filters to web sites
-- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/):  website for checking color contrast
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/): website for checking color contrast
 - [Colour Contrast Checker](https://colourcontrast.cc/): website for checking color contrast
 - [Sim Daltonism app](https://apps.apple.com/us/app/sim-daltonism/id693112260?mt=12): macOS application “window” for viewing color blindness
 


### PR DESCRIPTION
## What I did

1. Added a new page for assistive technologies
2. Added a few new resources to the a11y resources page.

## Testing Instructions

1. View the preview [assistive tech page](https://deploy-preview-1638--red-hat-design-system.netlify.app/accessibility/assistive-tech/). (Entire page is new)
2. View the preview [resources page](https://deploy-preview-1638--red-hat-design-system.netlify.app/accessibility/resources/). (Added TetraLogical A11y Quick Tests to the general a11y testing section. Added Google A11ycasts, Web Accessibility Perspective Videos, and the US Dept of Ed OCR Video Series to the training section.)
3. Ensure the links to these pages appear in the Accessibility section of the site nav.