### PR TITLE
fix(navigation-secondary): improved accessibility customization

### DIFF
--- a/.changeset/strong-snails-reflect.md
+++ b/.changeset/strong-snails-reflect.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-secondary>`: improved accessibility'

--- a/.changeset/strong-snails-reflect.md
+++ b/.changeset/strong-snails-reflect.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-navigation-secondary>`: improved accessibility'
+`<rh-navigation-secondary>`: improved accessibility

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -387,7 +387,7 @@ export class RhNavigationSecondary extends LitElement {
     // remove aria-labelledby from slotted `<ul>` on upgrade
     this.querySelector(':is([slot="nav"]):is(ul)')?.removeAttribute('aria-labelledby');
     // if the accessibleLabel attr is undefined, check aria-label if undefined use default
-    this.#internals.ariaLabel = this.getAttribute('aria-label') ?? 'secondary';
+    this.#internals.ariaLabel = 'secondary';
   }
 
   /**

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -7,6 +7,7 @@ import { queryAssignedElements } from 'lit/decorators/query-assigned-elements.js
 
 import { ComposedEvent } from '@patternfly/pfe-core';
 import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
+import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import '@rhds/elements/rh-surface/rh-surface.js';
@@ -53,7 +54,6 @@ function focusableChildElements(parent: HTMLElement): NodeListOf<HTMLElement> {
 
 /**
  * The Secondary navigation is used to connect a series of pages together. It displays wayfinding content and links relevant to the page it is placed on. It should be used in conjunction with the [primary navigation](../navigation-primary).
- *
  * @summary Propagates related content across a series of pages
  * @slot logo           - Logo added to the main nav bar, expects `<a>Text</a> | <a><svg/></a> | <a><img/></a>` element
  * @slot nav            - Navigation list added to the main nav bar, expects `<ul>` element
@@ -73,22 +73,9 @@ function focusableChildElements(parent: HTMLElement): NodeListOf<HTMLElement> {
 export class RhNavigationSecondary extends LitElement {
   static readonly styles = [styles];
 
-  /**
-   * Color palette darker | lighter (default: lighter)
-   */
-  @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
-
-  @queryAssignedElements({ slot: 'nav' }) private _nav?: HTMLElement[];
-
   #logger = new Logger(this);
 
   #logoCopy: HTMLElement | null = null;
-
-  /**
-   * The accessible label for the <nav> element
-   */
-  #label = 'secondary';
 
   /** Is the element in an RTL context? */
   #dir = new DirController(this);
@@ -102,6 +89,17 @@ export class RhNavigationSecondary extends LitElement {
                                                                   rh-secondary-nav-dropdown) > a,
                                                               [slot="nav"] > li > a`))) ?? [],
   });
+
+  #internals = InternalsController.of(this, { role: 'navigation' });
+
+  /**
+   * Color palette darker | lighter (default: lighter)
+   */
+  @colorContextProvider()
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
+
+  @queryAssignedElements({ slot: 'nav' }) private _nav?: HTMLElement[];
+
 
   /**
    * `mobileMenuExpanded` property is toggled when the mobile menu button is clicked,
@@ -151,9 +149,8 @@ export class RhNavigationSecondary extends LitElement {
     // CTA must always be 'lightest' on mobile screens
     const dropdownPalette = this.#compact ? 'lightest' : this.colorPalette;
     return html`
-      <nav part="nav"
-           class="${classMap({ compact: this.#compact, rtl })}"
-           aria-label="${this.#label}">
+      <div part="nav"
+           class="${classMap({ compact: this.#compact, rtl })}">
         ${this.#logoCopy}
         <div id="container" part="container" class="${classMap({ expanded })}">
           <slot name="logo" id="logo"></slot>
@@ -167,7 +164,7 @@ export class RhNavigationSecondary extends LitElement {
             </div>
           </rh-surface>
         </div>
-      </nav>
+      </div>
       <rh-navigation-secondary-overlay
           .open="${this.overlayOpen}"
           @click="${this.#onOverlayClick}"
@@ -389,11 +386,8 @@ export class RhNavigationSecondary extends LitElement {
     this.removeAttribute('role');
     // remove aria-labelledby from slotted `<ul>` on upgrade
     this.querySelector(':is([slot="nav"]):is(ul)')?.removeAttribute('aria-labelledby');
-    // transfer the aria-label to the shadow <nav>
-    if (this.hasAttribute('aria-label')) {
-      this.#label = this.getAttribute('aria-label') ?? 'secondary';
-      this.removeAttribute('aria-label');
-    }
+    // if the accessibleLabel attr is undefined, check aria-label if undefined use default
+    this.#internals.ariaLabel = this.getAttribute('aria-label') ?? 'secondary';
   }
 
   /**

--- a/elements/rh-navigation-secondary/test/rh-navigation-secondary.spec.ts
+++ b/elements/rh-navigation-secondary/test/rh-navigation-secondary.spec.ts
@@ -88,7 +88,7 @@ describe('<rh-navigation-secondary>', async function() {
       });
 
       it('should not have class compact on shadow root nav', async function() {
-        await expect(element.shadowRoot?.querySelector('nav')?.classList.contains('compact')).to.be.false;
+        await expect(element.shadowRoot?.querySelector('[part="nav"]')?.classList.contains('compact')).to.be.false;
       });
 
       it('lightdom passes the a11y audit', async function() {
@@ -138,7 +138,7 @@ describe('<rh-navigation-secondary>', async function() {
       });
 
       it('should have class compact on shadow root nav', function() {
-        expect(element.shadowRoot?.querySelector('nav')?.classList.contains('compact')).to.be.true;
+        expect(element.shadowRoot?.querySelector('[part="nav"]')?.classList.contains('compact')).to.be.true;
       });
 
       it('lightdom passes the a11y audit', async function() {


### PR DESCRIPTION
## What I did

1. applied navigation role to host using internals
2. removed shadow nav element

Closes #1655

## Testing Instructions

1. View deploy preview, change `aria-label` on host to a different value, that value should update in accessibility tree, and removing it will change it back to "secondary"

## Notes to Reviewers
