### PR TITLE
bug(docs): fix Side Nav overflow scroll

### DIFF
--- a/docs/assets/javascript/elements/uxdot-sidenav.js
+++ b/docs/assets/javascript/elements/uxdot-sidenav.js
@@ -78,7 +78,8 @@ class UxdotSideNav extends LitElement {
     ::slotted(ul) {
       padding-inline: 0;
       padding-block-start: var(--_padding-start);
-      padding-block-end: var(--_padding-end);
+      /* allow overflow to scroll with --_padding-end + section item height */
+      padding-block-end: calc(var(--_padding-end) + (var(--rh-font-size-body-text-lg, 1.125rem) * 1.5) + (var(--rh-space-lg, 16px) * 2));
       list-style: none;
       margin-block: 0 !important;
       height: var(--_max-height);


### PR DESCRIPTION
## What I did

1. Added padding to the `<ul>` in Side Nav to allow for overflow scroll to the last item


## Testing Instructions

1. Expand larger sections, like Tokens, and try to scroll down to "Get support"
2. Compare to live [ux.redhat.com](https://ux.redhat.com)


Closes #1660 
