### PR TITLE
docs: fix whitespace in repo status rh-tags

### DIFF
--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -167,9 +167,7 @@ function repoStatusTable() {
           <span>
             <a href="/elements/${listItem.name.toLowerCase().trim().split(' ').join('-')}">${listItem.name}</a>
             ${listItem.overallStatus !== 'Available' ?
-            `<rh-tag color="${STATUS_LEGEND[listItem.overallStatus].color}" variant="${STATUS_LEGEND[listItem.overallStatus].variant}">
-              ${listItem.overallStatus}${STATUS_LEGEND[listItem.overallStatus].icon}
-            </rh-tag>` : ''}
+            `<rh-tag color="${STATUS_LEGEND[listItem.overallStatus].color}" variant="${STATUS_LEGEND[listItem.overallStatus].variant}">${listItem.overallStatus}${STATUS_LEGEND[listItem.overallStatus].icon}</rh-tag>` : ''}
           </span>
         </td>${listItem.libraries.map(lib => html`
         <td data-label="${lib.name}">


### PR DESCRIPTION
## What I did

1. Fixed whitespace in repostatus that causes markdown to convert it to `<p>` tags when they shouldn't exist.


## Testing Instructions

1.

## Notes to Reviewers
