### PR TITLE
docs(support-page): updating issue links

### DIFF
--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -34,11 +34,11 @@ The best way to get help or feedback is through GitHub. This allows us to pull y
 
 <div id="rhds-help-grid" class="grid sm-three-columns">
   <rh-tile>
-    <h4 slot="headline"><a href="https://github.com/RedHat-UX/red-hat-design-system/issues/new?labels=bug&template=3-bug-report.yml&title=%5Bbug%5D+%3Ctitle%3E">File a bug report</a></h4>
+    <h4 slot="headline"><a href="https://github.com/RedHat-UX/red-hat-design-system/issues/new?assignees=&labels=bug&projects=&template=1-bug-report.yml&title=%5Bbug%5D+%60%3Crh-component-name%3E%60+...">File a bug report</a></h4>
     If something is broken in an existing web component, submit a bug report and describe the error as thoroughly as possible.
   </rh-tile>
   <rh-tile>
-    <h4 slot="headline"><a href="https://github.com/RedHat-UX/red-hat-design-system/issues/new?assignees=&labels=feature,needs%20discovery&projects=&template=4-feature-request.yml&title=%5Bfeat%5D+%3Ctitle%3E">Request a feature or component</a></h4>
+    <h4 slot="headline"><a href="https://github.com/RedHat-UX/red-hat-design-system/issues/new?assignees=&labels=feature%2Cdiscovery+needed&projects=&template=3-feature-request.yml&title=%5Bfeat%5D+%60%3Crh-component-name%3E%60+...">Request a feature or component</a></h4>
     Help shape the design system’s roadmap by requesting new features or components.
   </rh-tile>
   <rh-tile>
@@ -52,7 +52,7 @@ The best way to get help or feedback is through GitHub. This allows us to pull y
 
 <div id="docs-help-grid" class="grid sm-three-columns">
   <rh-tile>
-    <h4 slot="headline"><a href="https://github.com/RedHat-UX/red-hat-design-system/issues/new?assignees=&labels=bug,docs&projects=&template=3-bug-report.yml&title=%5Bbug%5D+%3Ctitle%3E">Report a bug on ux.redhat.com</a></h4>
+    <h4 slot="headline"><a href="https://github.com/RedHat-UX/red-hat-design-system/issues/new?assignees=&labels=docs%2Cbug&projects=&template=5-docs-problem.yml&title=%5Bdocs%5D%5Bbug%5D+...">Report a bug on ux.redhat.com</a></h4>
     Submit an issue to fix bugs, like 404s, on ux.redhat.com.
   </rh-tile>
   <rh-tile>


### PR DESCRIPTION
## What I did

1. Updated `File a bug report`, `Request a feature or component`, and `Report a bug on ux.redhat.com` links to new issue templates


## Testing Instructions

1. Go to [Support page](https://ux.redhat.com/support/)
2. Double check those 3 tile links work ok?

