### PR TITLE
docs(dev-getstarted): fixing broken links

### DIFF
--- a/docs/get-started/developers/index.md
+++ b/docs/get-started/developers/index.md
@@ -28,7 +28,7 @@ Our design system libraries and the documentation website offer assets and guida
 <div class="grid sm-two-columns">
   <div>
     <h3>Foundations</h3>
-    <p><a href="foundations">Foundations</a> are how we express our brand through color, space, typography, etc.</p>
+    <p><a href="/foundations">Foundations</a> are how we express our brand through color, space, typography, etc.</p>
   </div>
   <div>
     <h3>Design tokens</h3>
@@ -36,7 +36,7 @@ Our design system libraries and the documentation website offer assets and guida
   </div>
   <div>
     <h3>Documentation</h3>
-    <p>This website offers guidance about how to use our <a href="elements">elements</a> and <a href="patterns">patterns</a>. Learn how to apply them accessibily with <a href="/accessibility/development/">developer-specific guidelines</a>.</p>
+    <p>This website offers guidance about how to use our <a href="/elements">elements</a> and <a href="/patterns">patterns</a>. Learn how to apply them accessibily with <a href="/accessibility/development/">developer-specific guidelines</a>.</p>
   </div>
   <div>
     <h3>GitHub repositories</h3>


### PR DESCRIPTION
## What I did

1. Fixed broken links


## Testing Instructions

1. Go to [Developers' Get Start page](https://ux.redhat.com/get-started/developers/)
2. Check the `foundations`, `elements`, and `patterns` links work (see image below)

<img width="598" alt="Screenshot of Developers Get Started page with arrows pointing to broken links" src="https://github.com/RedHat-UX/red-hat-design-system/assets/1890950/b7487222-ad3f-4078-aaa5-15d4e6439b28">

Closes: #1672 
