### PR TITLE
docs(health-index): remove playground from overview

### DIFF
--- a/elements/rh-health-index/docs/00-overview.md
+++ b/elements/rh-health-index/docs/00-overview.md
@@ -14,15 +14,6 @@
 <rh-health-index grade="A">A</rh-health-index>
 
 
-## Demos
-
-View a live version of this component and see how it can be customized.
-
-{% playground tagName=tagName %}{% endplayground %}
-
-<rh-cta><a href="{{ './demo/' | url }}">Full screen demo</a></rh-cta>
-
-
 ## When to use
 
 - When you need to use severity to communicate the health of something

--- a/elements/rh-health-index/docs/00-overview.md
+++ b/elements/rh-health-index/docs/00-overview.md
@@ -21,5 +21,4 @@
 - When you need to measure how current or out of date something is
 
 
-
 {% repoStatusChecklist %}


### PR DESCRIPTION
## What I did

1. After a merge of main to staging/charmander, health-index which existed in staging/charmander needed to have the `{% playground %}` shortcode removed from docs, and missed it on the merge as it didn't represent a conflict.


## Testing Instructions

1.

## Notes to Reviewers
