### PR TITLE
docs: hide demos tab when there are none

### DIFF
--- a/docs/_includes/layouts/pages/elements.njk
+++ b/docs/_includes/layouts/pages/elements.njk
@@ -54,9 +54,10 @@ eleventyComputed:
   <article {% if hasToc and (content | toc).length > 0 %}class="has-toc"{% endif %}>
     <uxdot-header has-subnav>
       <h1 id="{{ slug }}" class="page-title">{{ doc.alias or (slug | deslugify) }}</h1>
-      {%- set demos = element.manifest and element.manifest.getDemos(element.tagName) -%}
-      <rh-subnav slot="subnav">{% for tab in doc.tabs %}{% if loop.last and demos.length > 1 %}
-        {%- set demosUrl = ("/elements/" + slug + "/demos/") -%}
+      {%- set manifest = doc.docsPage.manifest -%}
+      {%- set demos = manifest and manifest.getDemos(doc.docsPage.tagName) -%}
+      {%- set demosUrl -%}/elements/{{ slug }}/demos/{%- endset -%}
+      <rh-subnav slot="subnav">{% for tab in doc.tabs %}{% if loop.last and demos.length %}
         <a {{ 'active' if page.url === demosUrl }} href="{{ demosUrl }}">Demos</a>{% endif %}
         <a {{ 'active' if tab.href == page.url }} href="{{ tab.href }}">
           {{- tab.pageTitle | capitalize -}}

--- a/docs/_includes/layouts/pages/elements.njk
+++ b/docs/_includes/layouts/pages/elements.njk
@@ -54,7 +54,8 @@ eleventyComputed:
   <article {% if hasToc and (content | toc).length > 0 %}class="has-toc"{% endif %}>
     <uxdot-header has-subnav>
       <h1 id="{{ slug }}" class="page-title">{{ doc.alias or (slug | deslugify) }}</h1>
-      <rh-subnav slot="subnav">{% for tab in doc.tabs %}{% if loop.last %}
+      {%- set demos = element.manifest and element.manifest.getDemos(element.tagName) -%}
+      <rh-subnav slot="subnav">{% for tab in doc.tabs %}{% if loop.last and demos.length > 1 %}
         {%- set demosUrl = ("/elements/" + slug + "/demos/") -%}
         <a {{ 'active' if page.url === demosUrl }} href="{{ demosUrl }}">Demos</a>{% endif %}
         <a {{ 'active' if tab.href == page.url }} href="{{ tab.href }}">


### PR DESCRIPTION
## What I did

1. hide the demos tab when the list is empty


## Testing Instructions

1. check that demos tab exists for e.g. alert
2. ensure that it does not for e.g. popover