### PR TITLE
docs: fix base "View Fullscreen" link URL on element Demos pages

### DIFF
--- a/docs/elements/demos.html
+++ b/docs/elements/demos.html
@@ -102,7 +102,7 @@ playground-project {
     {% set extension = filename.split('.').pop() %}
     {% set demoSlug  = filename.split('.').shift().replace('demo/', '').replaceAll('/', '-') %}
     {% set projectId       %}playground-{{ element.tagName }}-{{ demoSlug }}{% endset %}
-    {% set demoPageUrl     %}/elements/{{ slug }}/demo/{{ config.label | slugify }}/{% endset %}
+    {% set demoPageUrl     %}/elements/{{ slug }}/demo/{%- if demoSlug !== 'index' -%}{{ config.label | slugify }}/{%- endif -%}{% endset %}
     {% set githubSourcePrefix %}https://github.com/RedHat-UX/red-hat-design-system/tree/main/elements{% endset %}
     {% set githubSourceUrl %}{{ githubSourcePrefix }}/{{ element.tagName }}/demo/{{ filename
         | replace('demo/', '')


### PR DESCRIPTION
![CTA Demo screenshot](https://github.com/RedHat-UX/red-hat-design-system/assets/575865/b3a3f895-c70f-4b0c-a664-3515a45c2629)

## What I did

1. Fixed the URL for each "View Fullscreen" link on the Demos page for each RHDS element.

## Testing Instructions

1. [Visit the DP](https://deploy-preview-1688--red-hat-design-system.netlify.app/elements/card/demos/) and go to Elements > {{ Any Element }} > Demos. 
1. Scroll down and verify "View Fullscreen" works for each demo
    * Both the "base" element demo, color context, and any other variants.

## Notes to Reviewers

The URLs are broken for every "base" element on ux.redhat.com right now. 

For example, the URL for "View Fullscreen" for CTA's variants work; however, the "base" URL for "View Fullscreen" for CTA does not. This PR fixes that.