### PR TITLE
fix(tile): tile headline size

### DIFF
--- a/.changeset/tiny-melons-help.md
+++ b/.changeset/tiny-melons-help.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Fixed the headline, title, body text, and footer font-sizes to match the Tile specs for both the default and compact variants

--- a/elements/rh-tile/demo/color-context.html
+++ b/elements/rh-tile/demo/color-context.html
@@ -36,7 +36,7 @@
   <h2>Desaturated heading</h2>
 
   <rh-tile desaturated>
-    <img slot ="icon" src="logo-red-hat.svg" alt="Red Hat">
+    <img slot="icon" src="logo-red-hat.svg" alt="Red Hat">
     <div slot="title">Title</div>
     <h2 slot="headline"><a href="#top">Link</a></h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -61,14 +61,14 @@
   </rh-tile>
 
   <rh-tile compact>
-    <img slot ="icon" src="logo-red-hat.svg" alt="Red Hat">
+    <img slot="icon" src="logo-red-hat.svg" alt="Red Hat">
     <h2 slot="headline"><a href="#top">Link</a></h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     <div slot="footer">Suspendisse eu turpis elementum</div>
   </rh-tile>
 
   <rh-tile compact>
-    <img slot ="icon" src="logo-red-hat.svg" alt="Red Hat">
+    <img slot="icon" src="logo-red-hat.svg" alt="Red Hat">
     <h2 slot="headline"><a href="#top">Link</a></h2>
   </rh-tile>
 

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -243,7 +243,7 @@ svg {
 
 ::slotted([slot="headline"]) {
   margin-block-end: var(--_margin) !important;
-  font-size: var(--rh-font-size-body-text-xl, 1.25rem) !important;
+  font-size: var(--rh-font-size-heading-xs, 1.25rem) !important;
 }
 
 #outer:is(.compact, .checkable) ::slotted([slot="icon"]) {

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -201,6 +201,7 @@ svg {
 
 #body {
   margin: 0 0 var(--_margin);
+  font-size: var(--rh-font-size-body-text-md, 1rem);
 }
 
 ::slotted(*) {
@@ -237,6 +238,12 @@ svg {
 
 ::slotted([slot="title"]) {
   text-transform: uppercase;
+  font-size: var(--rh-font-size-body-text-md, 1rem) !important;
+}
+
+::slotted([slot="headline"]) {
+  margin-block-end: var(--_margin) !important;
+  font-size: var(--rh-font-size-body-text-xl, 1.25rem) !important;
 }
 
 #outer:is(.compact, .checkable) ::slotted([slot="icon"]) {
@@ -245,18 +252,17 @@ svg {
   max-height: var(--rh-size-icon-03, 32px);
 }
 
-#outer:is(.compact, .checkable) ::slotted([slot="headline"]),
-#body {
-  font-size: var(--rh-font-size-body-text-lg, 1.125rem);
+#outer:is(.compact, .checkable) ::slotted([slot="headline"]) {
+  font-size: var(--rh-font-size-body-text-lg, 1.125rem) !important;
 }
 
 #outer:is(.compact, .checkable) #body,
 ::slotted([slot="footer"]) {
-  font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+  font-size: var(--rh-font-size-body-text-sm, 0.875rem) !important;
 }
 
 #outer:is(.compact, .checkable) ::slotted([slot="footer"]) {
-  font-size: var(--rh-font-size-body-text-xs, 0.75rem);
+  font-size: var(--rh-font-size-body-text-xs, 0.75rem) !important;
 }
 
 *:is(#image, #tile, #headline, #body, #footer) {

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -244,6 +244,7 @@ svg {
 ::slotted([slot="headline"]) {
   margin-block-end: var(--_margin) !important;
   font-size: var(--rh-font-size-heading-xs, 1.25rem) !important;
+  font-weight: var(--rh-font-weight-body-text-medium, 500) !important;
 }
 
 #outer:is(.compact, .checkable) ::slotted([slot="icon"]) {


### PR DESCRIPTION
## What I did

1. Fixed the headline, title, body text, and footer font-sizes to match the [Tile specs](https://www.figma.com/design/8cZsqpCsq3KyiHf5VyBuRO/Element---Tile?node-id=507-2284&m=dev) for both the default and compact variants.


## Testing Instructions

1. Inspect the font-sizes of the headlines, title, body, and footer in the demos and ensure they match both variants in the spec.
2. Dev: check that my CSS looks good too, and that there should be no repercussions (e.g., with my `!important` flags).


Closes: #1591 
