### PR TITLE
docs: added alt text to kitten image on card pattern page

### DIFF
--- a/docs/patterns/card/index.md
+++ b/docs/patterns/card/index.md
@@ -71,10 +71,11 @@ importElements:
     --rh-color-text-primary-on-dark: #e8e4f5;
   }
 </style>
+
 ## Overview
 
-A card formats content in a small, contained space. It can be used to display a 
-preview of information or provide secondary content in relation to the content 
+A card formats content in a small, contained space. It can be used to display a
+preview of information or provide secondary content in relation to the content
 it's near. Several cards can be used together to group related information.
 
 ## Sample pattern
@@ -148,7 +149,7 @@ it's near. Several cards can be used together to group related information.
 ## Image title bar
 
 <rh-card class="bar full">
-  <img src="./kitten-900x300.jpeg" slot="header">
+  <img src="./kitten-900x300.jpeg" slot="header" alt="adorable kitten">
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit 
     libero, a pharetra augue. Nullam id dolor id nibh ultricies vehicula ut id 
     elit. Donec id elit non mi porta gravida at eget metus.</p>
@@ -187,7 +188,7 @@ A card can be used in light and dark themes.
 
 ### Custom Theming
 
-To customize a card the design tokens must be altered.  These design tokens are different depending on the context for the card (light or dark theme).
+To customize a card the design tokens must be altered. These design tokens are different depending on the context for the card (light or dark theme).
 
 Examples include:
 
@@ -196,7 +197,6 @@ Examples include:
 - [`--rh-color-text-primary-on-light`](https://ux.redhat.com/tokens/font/#rh-color-text-primary-on-light)
 
 For more information, please see the [card css custom properties](/elements/card/code/#css-custom-properties).
-
 
 #### Custom Light Theme
 
@@ -225,6 +225,7 @@ For more information, please see the [card css custom properties](/elements/card
 ## Usage
 
 ### Character count
+
 The recommended maximum character count for the elements of a card are listed below and include spaces.
 
 <rh-table>
@@ -255,6 +256,5 @@ The recommended maximum character count for the elements of a card are listed be
     </tbody>
   </table>
 </rh-table>
-
 
 {% include 'partials/component/feedback.html' %}


### PR DESCRIPTION
## What I did

1. Added an `alt` attribute to a picture of a cat.


## Testing Instructions

1. Go to the [DP card pattern page](https://deploy-preview-1699--red-hat-design-system.netlify.app/patterns/card/#image-title-bar)
2. Inspect the picture of the kitten 
3. Verify that it has a populated `alt` attribute.

![screencap of card with kitten pic](https://github.com/RedHat-UX/red-hat-design-system/assets/642695/bb27b520-611d-4091-9cec-f6befe0524cd)
