### PR TITLE
docs: redirect from /components/get-started

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run docs"
 
 [[redirects]]
+  from = '/components/get-started/*'
+  to = '/get-started/'
+[[redirects]]
   from = '/components/accordion/*'
   to = '/elements/accordion/:splat'
 [[redirects]]


### PR DESCRIPTION
## What I did

1. redirect `/components/get-started/` to `/get-started/`

see https://github.com/orgs/RedHat-UX/discussions/1704#discussioncomment-10011187