### PR TITLE
feat(tile): add border-block-start custom props

### DIFF
--- a/elements/rh-tile/demo/custom-props.html
+++ b/elements/rh-tile/demo/custom-props.html
@@ -42,10 +42,18 @@
   }
 
   rh-tile {
+    width: 320px;
+  }
+
+  rh-tile:nth-child(2) {
     --rh-tile-border-color: red;
     --rh-tile-link-color: green;
     --rh-tile-interactive-color: rebeccapurple;
     --rh-tile-background-color: #f2f2f2;
-    width: 320px;
+  }
+
+  rh-tile:nth-child(3) {
+    --rh-tile-border-block-start-width: var(--rh-border-width-lg, 3px);
+    --rh-tile-border-block-start-color: var(--rh-color-accent-brand-on-light, #ee0000);
   }
 </style>

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -37,7 +37,11 @@
   padding: var(--_padding);
   font-weight: var(--rh-font-weight-heading-medium, 500);
   border-radius: var(--rh-border-radius-default, 3px);
-  border: var(--rh-border-width-sm, 1px) solid var(--_border-color);
+  border-style: solid;
+  border-width: var(--_border-width);
+  border-color: var(--_border-color);
+  border-block-start-width: var(--rh-tile-border-block-start-width, var(--_border-width));
+  border-block-start-color: var(--rh-tile-border-block-start-color, var(--_border-color));
   background-color: var(--_background-color);
   color: var(--_text-color);
 
@@ -70,6 +74,7 @@
         --rh-tile-disabled-background-color,
         var(--rh-color-surface-light, #e0e0e0)
       );
+  --_border-width: var(--rh-border-width-sm, 1px);
   --_border-color: var(--rh-tile-border-color, var(--rh-color-border-subtle-on-light, #c7c7c7));
   --_link-color: var(--rh-tile-link-color, var(--_interactive-color));
 }

--- a/elements/rh-tile/rh-tile.ts
+++ b/elements/rh-tile/rh-tile.ts
@@ -46,6 +46,8 @@ export class TileSelectEvent extends Event {
  * @cssprop --rh-tile-focus-background-color - Color tile surface on focus/hover.<br>Could cause accessibility issues; prefer to use `--rh-color-surface-lighter` and `--rh-color-surface-darker` for theming. {@default var(--rh-color-surface-lighter, #f2f2f2)}
  * @cssprop --rh-tile-disabled-background-color - Color tile surface when disabled.<br>Could cause accessibility issues; prefer to use `--rh-color-surface-light` and `--rh-color-surface-dark` for theming. {@default var(--rh-color-surface-light, #e0e0e0)}
  * @cssprop --rh-tile-border-color - Color of tile border.<br>Could cause accessibility issues; prefer to use `--rh-color-border-subtle-on-light` and `--rh-color-border-subtle-on-dark` for theming. {@default var(--rh-color-border-subtle-on-light, #c7c7c7)}
+ * @cssprop --rh-tile-border-block-start-color - Color of tile border "block start" (often "top").<br>Could cause accessibility issues; prefer to use `--rh-color-border-subtle-on-light` and `--rh-color-border-subtle-on-dark` for theming. {@default var(--rh-color-border-subtle-on-light, #c7c7c7)}
+ * @cssprop --rh-tile-border-block-start-width - Width of tile border "block start" (often "top"). {@default var(--rh-border-width-sm, 1px)}
  */
 @customElement('rh-tile')
 export class RhTile extends LitElement {


### PR DESCRIPTION
## What I did

1. Added `--rh-tile-border-block-start-width` and `--rh-tile-border-block-start-color` CSS custom props
2. Updated the Custom Props demo to illustrate the use


## Testing Instructions

1. Check out [Custom Props demo locally](http://localhost:8000/elements/tile/demo/custom-props/) to verify the new custom props work
2. Check my CSS skills
3. Proofread the [Custom Props info in the docs](https://deploy-preview-1720--red-hat-design-system.netlify.app/elements/tile/code/#rh-tile)
