### PR TITLE
docs(nav): fixing broken link on Nav element Overview

### DIFF
--- a/elements/rh-navigation/docs/00-overview.md
+++ b/elements/rh-navigation/docs/00-overview.md
@@ -13,4 +13,4 @@ every page to ensure a consistent user experience across websites.
 ## Demos
 View a live version of this component to see how it can be customized.
 
-<rh-cta><a href="https://codepen.io/heyMP/pen/gOoYXov">View this component in action</rh-cta>
+<rh-cta><a href="https://codepen.io/heyMP/pen/gOoYXov">View this component in action</a></rh-cta>


### PR DESCRIPTION
## What I did

1. Fixed the broken link at the bottom of the Nav element Overview page


## Testing Instructions

1. Checkout out the Nav element Overview page in the deploy preview
2. Compare with the [broken live version](https://ux.redhat.com/elements/navigation-primary/)
