### PR TITLE
fix(card): adding important to margin unset for headings

### DIFF
--- a/.changeset/breezy-bears-judge.md
+++ b/.changeset/breezy-bears-judge.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-Unsetting margins on slotted headings
+`<rh-card>`:  Corrected slotted header margin

--- a/.changeset/breezy-bears-judge.md
+++ b/.changeset/breezy-bears-judge.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Unsetting margins on slotted headings

--- a/elements/rh-card/rh-card.css
+++ b/elements/rh-card/rh-card.css
@@ -89,7 +89,7 @@ article {
 
 #header ::slotted(:is(h1, h2, h3, h4, h5, h6)) {
   font-size: inherit !important;
-  margin: unset;
+  margin: unset !important;
 }
 
 #body ::slotted(:is(h1, h2, h3, h4, h5, h6)) {


### PR DESCRIPTION
## What I did

1. Added an `!important` to the `margin: unset` on headings slotted into `header` to prevent inheriting margins, like in the [card patterns](https://github.com/RedHat-UX/red-hat-design-system/pull/1188#issuecomment-2256012174) per @zeroedin's [proposed solution](https://github.com/RedHat-UX/red-hat-design-system/pull/1188#issuecomment-2256237360)

## Testing Instructions

1. Check this fixes the [Title Card pattern](https://deploy-preview-1188--red-hat-design-system.netlify.app/patterns/card/examples/#title-bar-card)
2. Double check there are no unintended consequences across the demos

