### PR TITLE
fix(button): center play icon in circle

### DIFF
--- a/.changeset/loud-spies-work.md
+++ b/.changeset/loud-spies-work.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-button variant="play">`: Play icon is now centered in the circle of the button.

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -470,7 +470,7 @@ button:hover {
   --_hover-color: var(--_play-color);
   --_hover-background-color: var(--_play-hover-background-color);
   --_hover-background-opacity: var(--_play-hover-background-opacity);
-  --_icon-size: var(--rh-size-icon-03, 32px);
+  --_icon-size: var(--rh-size-icon-02, 24px);
 }
 
 :host(:is([variant="play"])) [part="icon"] {

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -470,7 +470,12 @@ button:hover {
   --_hover-color: var(--_play-color);
   --_hover-background-color: var(--_play-hover-background-color);
   --_hover-background-opacity: var(--_play-hover-background-opacity);
-  --_icon-size: var(--rh-size-icon-04, 40px);
+  --_icon-size: var(--rh-size-icon-03, 32px);
+}
+
+:host(:is([variant="play"])) [part="icon"] {
+  position: relative;
+  inset-inline-start: 3px;
 }
 
 :host(:is([variant="play" i], [variant="close" i])) button {

--- a/elements/rh-button/rh-button.ts
+++ b/elements/rh-button/rh-button.ts
@@ -145,8 +145,8 @@ export class RhButton extends LitElement {
         `;
       case 'play':
         return html`
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-            <path d="m12.3 7.5-9-5c-.2-.1-.4-.1-.6 0-.2.1-.3.3-.3.5v10c0 .2.1.4.3.5.1.1.2.1.3.1.1 0 .2 0 .3-.1l9-5c.2-.1.3-.3.3-.5s-.1-.4-.3-.5z"/>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+            <path d="m30.37 15.339-28-15A.752.752 0 0 0 1.264 1v30a.752.752 0 0 0 1.104.661l28-15a.751.751 0 0 0 0-1.322Z"/>
           </svg>
         `;
       default:


### PR DESCRIPTION
## What I did

1. Centered the icon in the "play" variant of `<rh-button>`.


## Testing Instructions

1. First, view the "play" variant of `<rh-button>` in production [on uxdot](https://ux.redhat.com/elements/button/demo/variants/).
    * Note how it is not centered in the black circle
2. Now, go to the [variants demo](https://deploy-preview-1731--red-hat-design-system.netlify.app/elements/button/demo/variants/) in this DP.
3. Notice how the play icon is now centered in the circle.

## Notes to Reviewers (rounded corners or not?)

If you look at the `<rh-button>` [Figma](https://www.figma.com/design/j7Rjo2W6PLloxOSXQOpll0/Red-Hat-Design-System-library?m=auto&node-id=451-3138), you'll notice the play button does _not_ have rounded corners. [The docs](https://ux.redhat.com/elements/button/) for `<rh-button>` also reflect this.

If you look at the [current implementation](https://ux.redhat.com/elements/button/demo/variants/) of `<rh-button variant="play">` and the [Red Hat Icons Play SVGs](https://red-hat-icons.netlify.app/#ui), they _do_ have rounded corners. 

Should the corners be rounded?

## To Do's

- [x] Decide whether we should proceed with rounded corners or not for the play icon (Update 8/5/24: rounded!)
- [ ] Update docs accordingly (to be handled in a separate issue/PR)