### PR TITLE
docs: quick and dirty icon update for in progress elements

### DIFF
--- a/CONTRIBUTING_DESIGN.md
+++ b/CONTRIBUTING_DESIGN.md
@@ -10,7 +10,7 @@ contributing guide](./CONTRIBUTING_DEV.md#prerequisites)
 
 Once set up, run the 11ty development server with the following command:
 ```bash
-npm run watch:docs
+npm run serve
 ```
 
 This will start eleventy and a watch process that will reload the site if `*.njk`, `*.md`, `*.scss`,

--- a/docs/_data/repoStatus.yaml
+++ b/docs/_data/repoStatus.yaml
@@ -167,8 +167,7 @@
       status: N/A
     - name: Documentation
       status: Ready
-- tagName: rh-navigation
-  name: "Navigation Primary"
+- name: "Navigation (primary)"
   type: "Element"
   overallStatus: "Planned"
   libraries:
@@ -180,8 +179,7 @@
       status: Planned
     - name: Documentation
       status: Planned
-- tagName: rh-navigation-secondary
-  name: "Navigation Secondary"
+- name: "Navigation Secondary"
   type: "Element"
   overallStatus: "Available"
   libraries:
@@ -212,11 +210,23 @@
     - name: Figma library
       status: Ready
     - name: RH Elements
-      status: Ready
+      status: Planned
     - name: WebRH
       status: Ready
     - name: Documentation
       status: Ready
+- name: "Progress steps"
+  type: "Element"
+  overallStatus: "Available"
+  libraries:
+    - name: Figma library
+      status: Ready
+    - name: RH Elements
+      status: Planned
+    - name: WebRH
+      status: Ready
+    - name: Documentation
+      status: Ready      
 - name: "Skip Link"
   type: "Element"
   overallStatus: "New"

--- a/docs/_data/repoStatus.yaml
+++ b/docs/_data/repoStatus.yaml
@@ -167,7 +167,21 @@
       status: N/A
     - name: Documentation
       status: Ready
-- name: "Navigation Secondary"
+- tagName: rh-navigation
+  name: "Navigation Primary"
+  type: "Element"
+  overallStatus: "Planned"
+  libraries:
+    - name: Figma library
+      status: Planned
+    - name: RH Elements
+      status: Planned
+    - name: RH Shared Libs
+      status: Planned
+    - name: Documentation
+      status: Planned
+- tagName: rh-navigation-secondary
+  name: "Navigation Secondary"
   type: "Element"
   overallStatus: "Available"
   libraries:

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -1,12 +1,9 @@
 ---js
 {
-  isPlanned: function(repoStatus, tagName) {
-    const element = repoStatus.find(element => element.tagName === tagName);
+  isPlanned: function(repoStatus, name) {
+    const element = repoStatus.find(element => element.name === name);
     return element && element.libraries.find(library => library.name === 'RH Elements').status === "Planned";
   }
-  importElements: [
-    'rh-tag'
-  ]
 }
 ---
 

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -1,3 +1,15 @@
+---js
+{
+  isPlanned: function(repoStatus, tagName) {
+    const element = repoStatus.find(element => element.tagName === tagName);
+    return element && element.libraries.find(library => library.name === 'RH Elements').status === "Planned";
+  }
+  importElements: [
+    'rh-tag'
+  ]
+}
+---
+
 {%- set extraPageClasses = bodyClasses or "" -%}
 {%- if title -%}
   {% set extraPageClasses = extraPageClasses + ' page-' + title | slug -%}

--- a/docs/_includes/layouts/pages/basic.njk
+++ b/docs/_includes/layouts/pages/basic.njk
@@ -5,6 +5,7 @@ importElements:
   - rh-footer
   - rh-alert
   - rh-subnav
+  - rh-tag
 ---
 <link rel="stylesheet" href="/styles/pages/backpage.css">
 

--- a/docs/_includes/layouts/pages/elements.njk
+++ b/docs/_includes/layouts/pages/elements.njk
@@ -12,6 +12,7 @@ eleventyComputed:
     - rh-table
     - rh-accordion
     - rh-badge
+    - rh-tag
     - "{{ doc.tagName or element.tagName }}"
 ---
 {%- if hasToc %}
@@ -56,7 +57,9 @@ eleventyComputed:
   <article {% if hasToc and (content | toc).length > 0 %}class="has-toc"{% endif %}>
     <uxdot-header has-subnav>
       {%- set inProgress = doc.docsPage.manifest -%}
-      <h1 id="{{ slug }}" class="page-title">{{ doc.alias or (slug | deslugify) }}{{ ' ⚠️' if (slug === 'popover' or slug === 'navigation-primary' or slug === 'progress-steps') }}</h1>
+      {%- set name = (doc.alias) or (slug | deslugify) %}
+      {%- set planned = isPlanned(repoStatus, name) %}
+      <h1 id="{{ slug }}" class="page-title">{{ name }}{% if planned %} <rh-tag icon="bell" color="gray">Planned</rh-tag>{% endif %}</h1>
       {%- set manifest = doc.docsPage.manifest -%}
       {%- set demos = manifest and manifest.getDemos(doc.docsPage.tagName) -%}
       {%- set demosUrl -%}/elements/{{ slug }}/demos/{%- endset -%}

--- a/docs/_includes/layouts/pages/elements.njk
+++ b/docs/_includes/layouts/pages/elements.njk
@@ -5,7 +5,6 @@ eleventyComputed:
   title: "{{ doc.pageTitle }} | {{ slug | deslugify }}"
   importElements:
     - rh-alert
-    - rh-tag
     - rh-cta
     - rh-footer
     - rh-subnav

--- a/docs/_includes/layouts/pages/elements.njk
+++ b/docs/_includes/layouts/pages/elements.njk
@@ -56,7 +56,8 @@ eleventyComputed:
 <main id="main">
   <article {% if hasToc and (content | toc).length > 0 %}class="has-toc"{% endif %}>
     <uxdot-header has-subnav>
-      <h1 id="{{ slug }}" class="page-title">{{ doc.alias or (slug | deslugify) }}</h1>
+      {%- set inProgress = doc.docsPage.manifest -%}
+      <h1 id="{{ slug }}" class="page-title">{{ doc.alias or (slug | deslugify) }}{{ ' ⚠️' if (slug === 'popover' or slug === 'navigation-primary' or slug === 'progress-steps') }}</h1>
       {%- set manifest = doc.docsPage.manifest -%}
       {%- set demos = manifest and manifest.getDemos(doc.docsPage.tagName) -%}
       {%- set demosUrl -%}/elements/{{ slug }}/demos/{%- endset -%}

--- a/docs/_includes/layouts/pages/home.njk
+++ b/docs/_includes/layouts/pages/home.njk
@@ -3,6 +3,7 @@ layout: layouts/base.njk
 importElements:
   - rh-cta
   - rh-footer
+  - rh-tag
 ---
 
 {% include 'partials/component/masthead.njk' %}

--- a/docs/_includes/layouts/pages/tokens.njk
+++ b/docs/_includes/layouts/pages/tokens.njk
@@ -1,5 +1,7 @@
 ---
 layout: layouts/base.njk
+importElements:
+  - rh-tag
 ---
 
 <style>

--- a/docs/_includes/partials/component/sidenav.njk
+++ b/docs/_includes/partials/component/sidenav.njk
@@ -33,11 +33,12 @@
                     {%- set slug = fst.slug -%}
                     {%- set href = '/elements/' + slug + '/' -%}
                     {%- set active = href === page.url -%}
-                    {%- set planned = isPlanned(repoStatus, tagName) %}
+                    {%- set name = (fst.alias) or (slug | deslugify) %}
+                    {%- set planned = isPlanned(repoStatus, name) %}
                     {% if not (tagName in comingSoonItems) %}
                       <li>
                         <uxdot-sidenav-dropdown-menu-item {{ 'active' if active }}>
-                          <a href="{{ href }}">{{ (fst.alias) or (slug | deslugify) }}{% if planned %} <rh-tag icon="bell">Planned</rh-tag>{% endif %}</a>
+                          <a href="{{ href }}">{{ (fst.alias) or (slug | deslugify) }}{% if planned %} <rh-tag icon="bell" color="gray">Planned</rh-tag>{% endif %}</a>
                         </uxdot-sidenav-dropdown-menu-item>
                       </li>
                     {% endif %}

--- a/docs/_includes/partials/component/sidenav.njk
+++ b/docs/_includes/partials/component/sidenav.njk
@@ -36,7 +36,7 @@
                     {% if not (tagName in comingSoonItems) %}
                       <li>
                         <uxdot-sidenav-dropdown-menu-item {{ 'active' if active }}>
-                          <a href="{{ href }}">{{ (fst.alias) or (slug | deslugify) }}</a>
+                          <a href="{{ href }}">{{ (fst.alias) or (slug | deslugify) }}{{ ' ⚠️' if (slug === 'popover' or slug === 'navigation-primary' or slug === 'progress-steps') }}</a>
                         </uxdot-sidenav-dropdown-menu-item>
                       </li>
                     {% endif %}

--- a/docs/_includes/partials/component/sidenav.njk
+++ b/docs/_includes/partials/component/sidenav.njk
@@ -33,10 +33,11 @@
                     {%- set slug = fst.slug -%}
                     {%- set href = '/elements/' + slug + '/' -%}
                     {%- set active = href === page.url -%}
+                    {%- set planned = isPlanned(repoStatus, tagName) %}
                     {% if not (tagName in comingSoonItems) %}
                       <li>
                         <uxdot-sidenav-dropdown-menu-item {{ 'active' if active }}>
-                          <a href="{{ href }}">{{ (fst.alias) or (slug | deslugify) }}{{ ' ⚠️' if (slug === 'popover' or slug === 'navigation-primary' or slug === 'progress-steps') }}</a>
+                          <a href="{{ href }}">{{ (fst.alias) or (slug | deslugify) }}{% if planned %} <rh-tag icon="bell">Planned</rh-tag>{% endif %}</a>
                         </uxdot-sidenav-dropdown-menu-item>
                       </li>
                     {% endif %}


### PR DESCRIPTION
## What I did

Added a quick and dirty icon fix so that in-progress elements are more easily distinguished. 


## Testing Instructions

1. View the docs site, check to see if there is a caution icon next to the element navigation item AND next to the title within the element main page.

<img width="1970" alt="Screenshot 2024-08-01 at 2 23 43 PM" src="https://github.com/user-attachments/assets/c319b4e1-eef4-4f0d-96df-e4d3bd128af1">

## Notes to Reviewers

Full disclaimer, I realize that there's likely a much much much better way to do this 😅. However, seeing as it's a pretty sore pain point, this would band-aid the issue until a proper fix is in place.

Thanks for considering it!

Closes https://github.com/RedHat-UX/red-hat-design-system/issues/1733