### PR TITLE
docs(statuses): updating WebRH references to RH Shared Libs

### DIFF
--- a/docs/_data/repoStatus.yaml
+++ b/docs/_data/repoStatus.yaml
@@ -6,7 +6,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -18,7 +18,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -30,7 +30,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -42,7 +42,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -54,7 +54,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Planned
     - name: Documentation
       status: In Progress
@@ -66,7 +66,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -78,7 +78,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -90,7 +90,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -102,7 +102,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -114,7 +114,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -126,7 +126,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -138,7 +138,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -151,7 +151,7 @@
 
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -163,7 +163,7 @@
       status: N/A
     - name: RH Elements
       status: N/A
-    - name: WebRH
+    - name: RH Shared Libs
       status: N/A
     - name: Documentation
       status: Ready
@@ -175,7 +175,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -187,7 +187,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -199,7 +199,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -211,7 +211,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Planned
     - name: Documentation
       status: Ready
@@ -223,7 +223,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Planned
     - name: Documentation
       status: Ready
@@ -235,7 +235,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -247,7 +247,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -259,7 +259,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -271,7 +271,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -283,7 +283,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -295,7 +295,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -307,7 +307,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -319,7 +319,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -331,7 +331,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready
@@ -343,7 +343,7 @@
       status: Ready
     - name: RH Elements
       status: Ready
-    - name: WebRH
+    - name: RH Shared Libs
       status: Ready
     - name: Documentation
       status: Ready

--- a/docs/_plugins/shortcodes/repoStatus.cjs
+++ b/docs/_plugins/shortcodes/repoStatus.cjs
@@ -70,11 +70,11 @@ const STATUS_CHECKLIST = {
     'Deprecated': 'Component is no longer available in the RH Elements repo',
     'N/A': 'Not planned, not available, or does not apply',
   },
-  'WebRH': {
-    'Ready': 'Component is available in the WebRH repo',
-    'In progress': 'Component will be added to the WebRH repo when finished',
-    'Planned': 'Component should be added to the WebRH repo at a later date',
-    'Deprecated': 'Component is no longer available in the WebRH repo',
+  'RH Shared Libs': {
+    'Ready': 'Component is available in the RH Shared Libs repo',
+    'In progress': 'Component will be added to the RH Shared Libs repo when finished',
+    'Planned': 'Component should be added to the RH Shared Libs repo at a later date',
+    'Deprecated': 'Component is no longer available in the RH Shared Libs repo',
     'N/A': 'Not planned, not available, or does not apply',
   },
 };
@@ -157,7 +157,7 @@ function repoStatusTable() {
         <th scope="col" data-label="Name">Name</th>
         <th scope="col" data-label="Figma library">Figma library</th>
         <th scope="col" data-label="RH Elements">RH Elements</th>
-        <th scope="col" data-label="webRH">WebRH</th>
+        <th scope="col" data-label="RH Shared Libs">RH Shared Libs</th>
         <th scope="col" data-label="Documentation">Documentation</th>
       </tr>
     </thead>


### PR DESCRIPTION
## What I did

1. Changed references to `WebRH` in the repo status tables to `RH Shared Libs`


## Testing Instructions

1. Ensure everything looks good (code-wise) and is spelled correctly.


## Notes to Reviewers

#1734 reminded me that we needed to update these references, per @zhawkins 