### PR TITLE
fix(accordion): remove deprecated icon property from header

### DIFF
--- a/.changeset/silly-turtles-hang.md
+++ b/.changeset/silly-turtles-hang.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-accordion-header>`: removed deprecated icon property

--- a/.changeset/silly-turtles-hang.md
+++ b/.changeset/silly-turtles-hang.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-accordion-header>`: removed deprecated icon property
+`<rh-accordion-header>`: removed deprecated and unused `icon` property

--- a/elements/rh-accordion/rh-accordion-header.ts
+++ b/elements/rh-accordion/rh-accordion-header.ts
@@ -67,9 +67,6 @@ export class RhAccordionHeader extends LitElement {
 
   @property({ reflect: true, attribute: 'heading-tag' }) headingTag?: string;
 
-  /** @deprecated */
-  @property({ reflect: true }) icon = 'angle-down';
-
   @colorContextConsumer() private on?: ColorTheme;
 
   @consume({ context, subscribe: true })


### PR DESCRIPTION
## What I did

1. Removed deprecated icon property from header

Closees #1748 

## Testing Instructions

1.

## Notes to Reviewers

Unless I'm missing it, the icon property didn't appear to be used or its functionality had already been removed.  Please check me here.