### PR TITLE
docs: remove fullscreen demo styles

### DIFF
--- a/docs/_includes/layouts/demo.njk
+++ b/docs/_includes/layouts/demo.njk
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/assets/logo-red-hat.svg">
     <title>{{ demo.title or demo.tagName }} | Red Hat Design System</title>
-    
+
     <link rel="preconnect" href="https://ga.jspm.io">
 
     <link rel="stylesheet" href="{{ '/styles/dev-server/styles.css' | url }}" media="all">
@@ -15,11 +15,6 @@
     <script type="module">
       import 'element-internals-polyfill';
     </script>
-    <style>
-      html, body, main, [data-demo] { height: 100%; }
-      [data-demo] { grid-row: -1/1; }
-      main { display: grid; }
-    </style>
   </head>
   <body unresolved>{% if demo.filePath %}
     <main>


### PR DESCRIPTION
## What I did

Removed some styles affecting the layout of certain elements in full screen demos.

## Testing Instructions

Visit any of the elements named below in [this PR's DP](https://deploy-preview-1774--red-hat-design-system.netlify.app/) and compare the demos to [the DP for `staging/charmander`](https://deploy-preview-1567--red-hat-design-system.netlify.app/).

For example, compare the rh-button full screen demo in the [staging/charmander DP](https://deploy-preview-1567--red-hat-design-system.netlify.app/elements/button/demo/) versus [this PR's DP](https://deploy-preview-1774--red-hat-design-system.netlify.app/elements/button/demo/).

Of note: while this PR doesn't depend on `staging/charmander`, it does pre-emptively fix an issue introduced there. 

## Notes to Reviewers

Here's a list of elements where these styles messed with each element's full screen demo:

  * Badge
  * Button
  * CTA (ish)
  * Card
  * Dialog
  * Skip link (ish)
  * Statistic
  * Switch (ish)
  * Tag
  * Tooltip (uxdot styles "break" demo)