### PR TITLE
docs: remove sidenav links underlines

### DIFF
--- a/docs/assets/javascript/elements/uxdot-sidenav-lightdom.css
+++ b/docs/assets/javascript/elements/uxdot-sidenav-lightdom.css
@@ -52,8 +52,3 @@ uxdot-sidenav-dropdown > details > summary:after {
 uxdot-sidenav-dropdown > details[open] > summary:after {
   transform: rotate(135deg);
 }
-
-uxdot-sidenav-item > a {
-  text-decoration: none;
-  color: var(--rh-color-text-primary-on-light, #151515) !important;
-}

--- a/docs/assets/javascript/elements/uxdot-sidenav-lightdom.css
+++ b/docs/assets/javascript/elements/uxdot-sidenav-lightdom.css
@@ -52,3 +52,8 @@ uxdot-sidenav-dropdown > details > summary:after {
 uxdot-sidenav-dropdown > details[open] > summary:after {
   transform: rotate(135deg);
 }
+
+uxdot-sidenav-item > a {
+  text-decoration: none;
+  color: var(--rh-color-text-primary-on-light, #151515) !important;
+}

--- a/docs/assets/javascript/elements/uxdot-sidenav.js
+++ b/docs/assets/javascript/elements/uxdot-sidenav.js
@@ -309,10 +309,14 @@ class UxdotSideNavItem extends SSRRoleElement {
 
     a {
       display: block;
-      text-decoration: none;
-      color: var(--rh-color-text-primary-on-light, #151515) !important;
       font-size: var(--rh-font-size-body-text-lg, 1.125rem);
       padding: var(--rh-space-lg, 16px) var(--rh-space-2xl, 32px);
+    }
+
+    a,
+    ::slotted(a) {
+      text-decoration: none !important;
+      color: var(--rh-color-text-primary-on-light, #151515) !important;
     }
 
     a:hover {


### PR DESCRIPTION
## What I did

1. Removed the inherited underline from links in the sidenav


## Testing Instructions

1. Check it looks right on the deploy preview
2. Check the code in the lightdom CSS is the right way to go

