### PR TITLE
docs: fix Udacity course URL

### DIFF
--- a/docs/accessibility/resources.md
+++ b/docs/accessibility/resources.md
@@ -45,7 +45,7 @@ order: 60
 
 ## Training
 
-- [Free Web Accessibility course on Udacity](https://classroom.udacity.com/courses/ud891)
+- [Free Web Accessibility course on Udacity](https://www.udacity.com/course/web-accessibility--ud891)
 - [Deque University ](https://dequeuniversity.com/)
 - [EdX Accessibility Courses](https://www.edx.org/learn/accessibility)
 - [WebAIM Training](https://webaim.org/services/training/)


### PR DESCRIPTION
## What I did

1. Fixed Udacity course URL on accessibility resources


## Testing Instructions

1. Double check the link works

