### PR TITLE
docs: fixing rh-table lightdom CSS link/href path

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,7 +9,7 @@ importElements:
 ---
 
 <link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-lightdom.css">
-<link rel="stylesheet" href=" /assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">
+<link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">
 
 <style>
   rh-tile {


### PR DESCRIPTION
## What I did

1. Fixed the link/href for `rh-table` lightdom CSS (there was a space messing up the path, causing it to 404)


## Testing Instructions

1. Double check everything looks ok on the [Release Notes page](https://deploy-preview-1795--red-hat-design-system.netlify.app/release-notes/)

