### PR TITLE
fix(accordion): bold accordion headers

### DIFF
--- a/.changeset/forty-toes-exercise.md
+++ b/.changeset/forty-toes-exercise.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-accordion>`: Make `<rh-accordion-header>`'s bold.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 package-lock.json binary
 yarn.lock binary
-

--- a/elements/rh-accordion/rh-accordion-header.css
+++ b/elements/rh-accordion/rh-accordion-header.css
@@ -13,15 +13,6 @@
   --_isRTL: -1;
 }
 
-#heading {
-  font-size: 100%;
-  padding: 0;
-  margin: 0;
-  color: var(--rh-color-text-primary-on-light, #151515);
-  background-color: var(--_rhds-background-color, var(--rh-color-surface-lightest, #ffffff));
-  font-weight: var(--rh-font-weight-heading-medium, 500);
-}
-
 button,
 a {
   cursor: pointer;
@@ -81,7 +72,6 @@ a {
     var(--_padding-inline-start);
   font-family: var(--rh-font-family-body-text, RedHatText, "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif);
   font-size: var(--_font-size);
-  font-weight: var(--rh-font-weight-body-text-medium, 500);
   color: var(--_text-color);
 }
 
@@ -113,6 +103,10 @@ span {
   &.bottom {
     flex-direction: column;
   }
+}
+
+#header-text {
+  font-weight: var(--rh-font-weight-heading-bold, 700);
 }
 
 [part="accents"] {

--- a/elements/rh-accordion/rh-accordion-header.ts
+++ b/elements/rh-accordion/rh-accordion-header.ts
@@ -92,7 +92,7 @@ export class RhAccordionHeader extends LitElement {
                 class="toggle"
                 @click="${this.#onClick}">
           <span id="header-container" class="${classMap({ [accents ?? '']: !!accents })}">
-            <span part="text"><slot></slot></span>
+            <span id="header-text" part="text"><slot></slot></span>
             <span part="accents"><slot name="accents"></slot></span>
           </span>
           <svg id="icon"


### PR DESCRIPTION
## What I did

1. Made `<rh-accordion-header>`'s bold.


## Testing Instructions

1. See [the DP](https://deploy-preview-1805--red-hat-design-system.netlify.app/elements/accordion/) for #1805 and you'll notice accordion headers are not bolded.
2. View Elements > Accordion and associated demos in this PR's DP.
3. Verify that `<rh-accordion-header>`'s are bolded. 

## Notes to Reviewers

Related to #1715.