### PR TITLE
docs: fix layout of release notes table on mobile

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -25,12 +25,22 @@ importElements:
     --rh-icon-size: var(--rh-size-icon-03, 32px);
   }
 
-  [data-label="Change"] {
-    width: 30%;
-  }
+  @media (min-width: 768px) {
+    [data-label="Change"] {
+      width: 30%;
+    }
 
-  [data-label="Type"] {
-    width: 10%;
+    [data-label="Type"] {
+      width: 10%;
+    }
+  }
+  @media (max-width: 768px) {
+    rh-table thead ~ tbody tr :is(th, td) {
+      display: block;
+    }
+    rh-table thead ~ tbody tr :is(td,th):before {
+      margin-inline-end: var(--rh-length-2xs, 3px);
+    }
   }
 </style>
 


### PR DESCRIPTION
## What I did

Relase Notes page on mobile before the changes:

![UX Dot release notes page screenshot on mobile](https://github.com/user-attachments/assets/05cada23-b4e2-40c6-a321-9e4057633b12)

After these changes:

![UX Dot release notes page screenshot on mobile after this pr's changes, shows readable mobile view](https://github.com/user-attachments/assets/7840c657-f104-4998-9ff5-34e667f4cea2)

## Testing Instructions

1. Visit the [Release Notes page in the DP](http://localhost:8080/release-notes/)
2. Shrink your browser down to mobile viewports
3. Make sure it's readable