### PR TITLE
fix: remove rti from navigations

### DIFF
--- a/.changeset/giant-planets-argue.md
+++ b/.changeset/giant-planets-argue.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-accordion>`: removed Roving Tabindex keyboard navigation in favor of tab based navigation.
+`<rh-accordion>`: removed arrow-key keyboard navigation in favor of tab navigation.

--- a/.changeset/giant-planets-argue.md
+++ b/.changeset/giant-planets-argue.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-accordion>`: removed Roving Tabindex keyboard navigation in favor of tab based navigation.

--- a/.changeset/gorgeous-impalas-knock.md
+++ b/.changeset/gorgeous-impalas-knock.md
@@ -3,7 +3,7 @@
 ---
 
 `<rh-subnav>`:
- - removed Roving Tabindex keyboard navigation in favor of tab based navigation.
+ - removed arrow-key keyboard navigation in favor of tab navigation.
  - add `accessible-label` attribute to explicitly label landmark.
  - corrects overflow icons
 

--- a/.changeset/gorgeous-impalas-knock.md
+++ b/.changeset/gorgeous-impalas-knock.md
@@ -1,0 +1,15 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-subnav>`:
+ - removed Roving Tabindex keyboard navigation in favor of tab based navigation.
+ - add `accessible-label` attribute to explicitly label landmark.
+
+ ```
+ <rh-subnav accessible-label="Customer service">
+  <a href="#" active>Help</a>
+  <a href="#">Contact Us</a>
+  <a href="#">FAQ</a>
+ </rh-subnav>
+ ```

--- a/.changeset/gorgeous-impalas-knock.md
+++ b/.changeset/gorgeous-impalas-knock.md
@@ -5,6 +5,7 @@
 `<rh-subnav>`:
  - removed Roving Tabindex keyboard navigation in favor of tab based navigation.
  - add `accessible-label` attribute to explicitly label landmark.
+ - corrects overflow icons
 
  ```
  <rh-subnav accessible-label="Customer service">

--- a/.changeset/swift-nails-notice.md
+++ b/.changeset/swift-nails-notice.md
@@ -2,7 +2,7 @@
 "@rhds/elements": minor
 ---
 
-`<rh-navigation-secondary>`
+`<rh-navigation-secondary>`:
  - removed Roving Tabindex keyboard navigation in favor of tab based navigation.
  - add `accessible-label` attribute to explicitly label landmark.
 

--- a/.changeset/swift-nails-notice.md
+++ b/.changeset/swift-nails-notice.md
@@ -1,0 +1,13 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-navigation-secondary>`
+ - removed Roving Tabindex keyboard navigation in favor of tab based navigation.
+ - add `accessible-label` attribute to explicitly label landmark.
+
+ ```
+ <rh-navigation-secondary accessible-label="Main">
+  ...
+ </rh-navigation-secondary>
+ ```

--- a/.changeset/swift-nails-notice.md
+++ b/.changeset/swift-nails-notice.md
@@ -3,7 +3,7 @@
 ---
 
 `<rh-navigation-secondary>`:
- - removed Roving Tabindex keyboard navigation in favor of tab based navigation.
+ - removed arrow-key keyboard navigation in favor of tab navigation.
  - add `accessible-label` attribute to explicitly label landmark.
 
  ```

--- a/docs/_includes/partials/component/header.njk
+++ b/docs/_includes/partials/component/header.njk
@@ -11,7 +11,7 @@
   {% endif %}
 
   {% if subnav.collection %}
-    <rh-subnav slot="subnav">{% for tab in collections[subnav.collection] | sort(attribute="data.subnav.order") %}
+    <rh-subnav slot="subnav" accessible-label="{{heading}}">{% for tab in collections[subnav.collection] | sort(attribute="data.subnav.order") %}
       <a {{ 'active' if tab.url == page.url }} href="{{ tab.url }}">
         {{ tab.data.title }}
       </a>{% endfor %}

--- a/docs/assets/javascript/elements/uxdot-sidenav.ts
+++ b/docs/assets/javascript/elements/uxdot-sidenav.ts
@@ -4,8 +4,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
-import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
-
 import '@rhds/elements/rh-icon/rh-icon.js';
 
 import styles from './uxdot-sidenav.css';
@@ -28,15 +26,6 @@ export class UxdotSideNav extends LitElement {
 
   #closeButton: HTMLElement | null = null;
 
-  #tabindex = RovingTabindexController.of(this, {
-    getItems: () => isServer ? [] : this.shadowRoot?.querySelector('slot')
-        ?.assignedElements({ flatten: true })
-        ?.flatMap(slotted => Array.from(slotted.querySelectorAll<UxdotSideNavItem>([
-          'uxdot-sidenav-dropdown > details > summary',
-          'uxdot-sidenav-item',
-          'details[open] uxdot-sidenav-dropdown-menu-item',
-        ].join()))) ?? [],
-  });
 
   async connectedCallback() {
     super.connectedCallback();
@@ -48,7 +37,6 @@ export class UxdotSideNav extends LitElement {
     if (!isServer) {
       this.#triggerElement?.addEventListener('click', this.#onTriggerClick.bind(this));
       this.addEventListener('click', this.#onClick.bind(this));
-      this.addEventListener('expand', this.#onExpandRequest);
       this.addEventListener('keydown', this.#onKeydown.bind(this));
       window.addEventListener('keyup', this.#onKeyup.bind(this));
     }
@@ -106,13 +94,6 @@ export class UxdotSideNav extends LitElement {
     const path = event.composedPath();
     if (!path.includes(this)) {
       this.toggle();
-    }
-  }
-
-  async #onExpandRequest(event: Event) {
-    if (event.target instanceof UxdotSideNavDropdown) {
-      this.#tabindex.atFocusedItemIndex =
-        this.#tabindex.items.indexOf(event.target.querySelector('summary') as UxdotSideNavItem);
     }
   }
 

--- a/docs/assets/javascript/elements/uxdot-sidenav.ts
+++ b/docs/assets/javascript/elements/uxdot-sidenav.ts
@@ -4,6 +4,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
+import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
+
 import '@rhds/elements/rh-icon/rh-icon.js';
 
 import styles from './uxdot-sidenav.css';
@@ -26,6 +28,15 @@ export class UxdotSideNav extends LitElement {
 
   #closeButton: HTMLElement | null = null;
 
+  #tabindex = RovingTabindexController.of(this, {
+    getItems: () => isServer ? [] : this.shadowRoot?.querySelector('slot')
+        ?.assignedElements({ flatten: true })
+        ?.flatMap(slotted => Array.from(slotted.querySelectorAll<UxdotSideNavItem>([
+          'uxdot-sidenav-dropdown > details > summary',
+          'uxdot-sidenav-item',
+          'details[open] uxdot-sidenav-dropdown-menu-item',
+        ].join()))) ?? [],
+  });
 
   async connectedCallback() {
     super.connectedCallback();
@@ -37,6 +48,7 @@ export class UxdotSideNav extends LitElement {
     if (!isServer) {
       this.#triggerElement?.addEventListener('click', this.#onTriggerClick.bind(this));
       this.addEventListener('click', this.#onClick.bind(this));
+      this.addEventListener('expand', this.#onExpandRequest);
       this.addEventListener('keydown', this.#onKeydown.bind(this));
       window.addEventListener('keyup', this.#onKeyup.bind(this));
     }
@@ -94,6 +106,13 @@ export class UxdotSideNav extends LitElement {
     const path = event.composedPath();
     if (!path.includes(this)) {
       this.toggle();
+    }
+  }
+
+  async #onExpandRequest(event: Event) {
+    if (event.target instanceof UxdotSideNavDropdown) {
+      this.#tabindex.atFocusedItemIndex =
+        this.#tabindex.items.indexOf(event.target.querySelector('summary') as UxdotSideNavItem);
     }
   }
 
@@ -219,4 +238,3 @@ export class UxdotSideNavDropdownMenu extends LitElement {
 export class UxdotSideNavDropdownMenuItem extends UxdotSideNavItem {
   static styles = [itemStyles, dropdownMenuItemStyles];
 }
-

--- a/elements/rh-accordion/rh-accordion.ts
+++ b/elements/rh-accordion/rh-accordion.ts
@@ -6,8 +6,6 @@ import { property } from 'lit/decorators/property.js';
 import { observes } from '@patternfly/pfe-core/decorators/observes.js';
 import { provide } from '@lit/context';
 
-import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
-
 import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
 import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
 
@@ -116,13 +114,6 @@ export class RhAccordion extends LitElement {
   protected expandedSets = new Set<number>();
 
   #expandedIndex: number[] = [];
-
-  // side effects are used
-  // eslint-disable-next-line no-unused-private-class-members
-  #tabindex: RovingTabindexController<HTMLButtonElement> = RovingTabindexController.of(this, {
-    getItems: () => this.headers.flatMap(x =>
-      x.hasUpdated ? [x.shadowRoot!.querySelector('button')!] : []),
-  });
 
   #logger = new Logger(this);
 

--- a/elements/rh-navigation-secondary/demo/analytics.html
+++ b/elements/rh-navigation-secondary/demo/analytics.html
@@ -1,6 +1,7 @@
 <rh-navigation-secondary id="navigation-secondary-analytics"
                          role="navigation"
-                         data-analytics-region="secondary-navigation-Ansible">
+                         data-analytics-region="secondary-navigation-Ansible"
+                         accessible-label="ansible">
   <a href="#" slot="logo" id="logo-id" aria-current="page">
     Red Hat Ansible Automation Platform
   </a>

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -317,7 +317,6 @@ export class RhNavigationSecondary extends LitElement {
       if (!lastFocusable) {
         return;
       }
-      event.preventDefault();
       this.close();
       if (!this.mobileMenuExpanded) {
         this.overlayOpen = false;

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -6,7 +6,6 @@ import { state } from 'lit/decorators/state.js';
 import { queryAssignedElements } from 'lit/decorators/query-assigned-elements.js';
 
 import { ComposedEvent } from '@patternfly/pfe-core';
-import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
 import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
@@ -100,10 +99,6 @@ export class RhNavigationSecondary extends LitElement {
                                                               [slot="nav"] > li > a`))) ?? [];
   }
 
-  #tabindex = RovingTabindexController.of(this, {
-    getItems: () => this.#items,
-  });
-
   #internals = InternalsController.of(this, { role: 'navigation' });
 
   /**
@@ -114,6 +109,7 @@ export class RhNavigationSecondary extends LitElement {
 
   @queryAssignedElements({ slot: 'nav' }) private _nav?: HTMLElement[];
 
+  @property({ attribute: 'accessible-label' }) accessibleLabel = 'secondary';
 
   /**
    * `mobileMenuExpanded` property is toggled when the mobile menu button is clicked,
@@ -178,7 +174,7 @@ export class RhNavigationSecondary extends LitElement {
                   aria-expanded="${String(expanded) as 'true' | 'false'}"
                   @click="${this.#toggleMobileMenu}"><slot name="mobile-menu">Menu</slot></button>
           <rh-surface color-palette="${dropdownPalette}">
-            <slot name="nav" @slotchange="${() => this.#tabindex.items = this.#items}"></slot>
+            <slot name="nav"></slot>
             <div id="cta" part="cta">
               <slot name="cta"></slot>
             </div>
@@ -260,8 +256,6 @@ export class RhNavigationSecondary extends LitElement {
         if (!this.#screenSize.matches.has('md')) {
           this.mobileMenuExpanded = false;
           this.shadowRoot?.querySelector('button')?.focus?.();
-        } else {
-          this.#tabindex.items[this.#tabindex.atFocusedItemIndex]?.focus();
         }
         this.close();
         this.overlayOpen = false;
@@ -330,7 +324,6 @@ export class RhNavigationSecondary extends LitElement {
       if (!this.mobileMenuExpanded) {
         this.overlayOpen = false;
       }
-      this.#tabindex.atFocusedItemIndex++;
     }
   }
 
@@ -371,10 +364,6 @@ export class RhNavigationSecondary extends LitElement {
     }
     const dropdown = this.#dropdownByIndex(index);
     if (dropdown && RhNavigationSecondary.isDropdown(dropdown)) {
-      const link = dropdown.querySelector('a');
-      if (link) {
-        this.#tabindex.atFocusedItemIndex = this.#items.indexOf(link);
-      }
       this.#openDropdown(dropdown);
     }
   }
@@ -430,8 +419,7 @@ export class RhNavigationSecondary extends LitElement {
     this.removeAttribute('role');
     // remove aria-labelledby from slotted `<ul>` on upgrade
     this.querySelector(':is([slot="nav"]):is(ul)')?.removeAttribute('aria-labelledby');
-    // if the accessibleLabel attr is undefined, check aria-label if undefined use default
-    this.#internals.ariaLabel = 'secondary';
+    this.#internals.ariaLabel = this.accessibleLabel;
   }
 
   /**

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -103,6 +103,10 @@ export class RhNavigationSecondary extends LitElement {
 
   @queryAssignedElements({ slot: 'nav' }) private _nav?: HTMLElement[];
 
+  /**
+   * Customize the default `aria-label` on the `<nav>` container.
+   * Defaults to "secondary" if no attribute/property is set.
+   */
   @property({ attribute: 'accessible-label' }) accessibleLabel = 'secondary';
 
   /**

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.ts
@@ -93,12 +93,6 @@ export class RhNavigationSecondary extends LitElement {
   /** Compact mode  */
   #compact = false;
 
-  get #items() {
-    return this._nav?.flatMap(slotted =>
-      Array.from(slotted.querySelectorAll<HTMLAnchorElement>(`rh-navigation-secondary-dropdown > a,
-                                                              [slot="nav"] > li > a`))) ?? [];
-  }
-
   #internals = InternalsController.of(this, { role: 'navigation' });
 
   /**

--- a/elements/rh-subnav/demo/dynamic.html
+++ b/elements/rh-subnav/demo/dynamic.html
@@ -1,4 +1,4 @@
-<rh-subnav id="demo">
+<rh-subnav id="demo" accessible-label="dynamic">
   <a href="#">Users</a>
   <a href="#">Containers</a>
   <a href="#">Databases</a>

--- a/elements/rh-subnav/rh-subnav.ts
+++ b/elements/rh-subnav/rh-subnav.ts
@@ -1,6 +1,5 @@
 import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { query } from 'lit/decorators/query.js';
 import { queryAssignedElements } from 'lit/decorators/query-assigned-elements.js';

--- a/elements/rh-subnav/rh-subnav.ts
+++ b/elements/rh-subnav/rh-subnav.ts
@@ -64,6 +64,10 @@ export class RhSubnav extends LitElement {
   @colorContextProvider()
   @property({ reflect: true, attribute: 'color-palette' }) colorPalette?: ColorPalette;
 
+  /**
+   * Customize the default `aria-label` on the `<nav>` container.
+   * Defaults to "subnavigation" if no attribute/property is set.
+   */
   @property({ attribute: 'accessible-label' }) accessibleLabel = 'subnavigation';
 
   @queryAssignedElements() private links!: HTMLAnchorElement[];


### PR DESCRIPTION
## What I did

1. removed RTI from `rh-subnav`,`rh-navigation-secondary`, `uxdot-sidenav` as previously discussed with @hellogreg and @adamjohnson 
2. Corrects `rh-subnav` icons.
3. added `accessible-label` to `rh-subnav` and `rh-navigation-secondary`.  



## Testing Instructions

1.

## Notes to Reviewers
