### PR TITLE
fix(navigation-secondary): correct line height logo text

### DIFF
--- a/.changeset/wild-foxes-smoke.md
+++ b/.changeset/wild-foxes-smoke.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-secondary>`: corrected logo slot text line-height

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -99,7 +99,7 @@ rh-navigation-secondary > [slot="nav"] {
 
 rh-navigation-secondary > [slot="logo"],
 rh-navigation-secondary > [slot="nav"] {
-  line-height: var(--rh-line-height-body-text, 1.5);
+  line-height: var(--rh-line-height-heading, 1.3);
 }
 
 rh-navigation-secondary > [slot="cta"] {


### PR DESCRIPTION
## What I did

1. Corrects logo-height for logo text to use the 130% value aka `var(--rh-line-height-heading, 1.3)`

Closes #1746 

## Testing Instructions

1.

## Notes to Reviewers
