### PR TITLE
chore: correct eslint path to uxdot-elements.js in ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,7 @@ export default tseslint.config(
       'docs/core',
       'docs/components',
       'docs/assets/playgrounds',
-      'docs/assets/elements/javascript/**/*.js',
+      'docs/assets/javascript/elements/*.js',
       'node_modules',
 
       '!core/*/demo/*.js',


### PR DESCRIPTION
## What I did

1. Correct the path to the `uxdot-elements` in the eslint ignores.


## Testing Instructions

1.

## Notes to Reviewers
