### PR TITLE
fix(navigation secondary):dark variant block-end border visibility

### DIFF
--- a/.changeset/happy-eels-fail.md
+++ b/.changeset/happy-eels-fail.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-navigation-secondary>`: corrected visibility of the block-end border on dark variant'
+`<rh-navigation-secondary>`: corrected visibility of the borders when using the dark color palette

--- a/.changeset/happy-eels-fail.md
+++ b/.changeset/happy-eels-fail.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-secondary>`: corrected visibility of the block-end border on dark variant'

--- a/elements/rh-navigation-secondary/rh-navigation-secondary.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary.css
@@ -16,12 +16,14 @@
   --_nav-max-height: var(--_max-height, max-content);
   --_nav-min-height: var(--_min-height, 80px);
   --_current-active-child-border-color: var(--rh-color-brand-red-on-light, #ee0000);
+  --_border-color: transparent;
 
   z-index: var(--rh-navigation-secondary-z-index, 102);
 }
 
 :host([color-palette="dark"]) {
   --_current-active-child-border-color: var(--rh-color-brand-red-on-dark, #ee0000);
+  --_border-color: var(--rh-color-border-subtle-on-dark, #707070);
 }
 
 nav {
@@ -53,9 +55,10 @@ nav.rtl {
     "logo menu"
     "main main";
   height: fit-content;
-  min-height: var(--_min-height);
+  min-height: 100%;
   max-height: 100vh;
   overflow-y: auto;
+  border-block-end: var(--rh-border-width-sm, 1px) solid var(--_border-color);
 }
 
 rh-surface {


### PR DESCRIPTION
## What I did

1. Corrected block-end border visibility on dark variant

Closes #1831 

## Testing Instructions

1. [View Deploy Preview](https://deploy-preview-1833--red-hat-design-system.netlify.app/elements/navigation-secondary/demo/dark-variant/)

## Notes to Reviewers
