### PR TITLE
fix(button): host display contents

### DIFF
--- a/.changeset/selfish-spies-fry.md
+++ b/.changeset/selfish-spies-fry.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-button>`: corrected style issue which caused layout side effects

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -281,7 +281,6 @@ button > span {
   --_play-hover-background-color: rgb(var(--_white-rgb) / var(--rh-opacity-80, 80%));
 }
 
-:host,
 #rhds-container {
   display: contents;
 }

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -281,10 +281,6 @@ button > span {
   --_play-hover-background-color: rgb(var(--_white-rgb) / var(--rh-opacity-80, 80%));
 }
 
-#rhds-container {
-  display: contents;
-}
-
 :host([hidden]),
 [hidden] {
   display: none !important;


### PR DESCRIPTION
## What I did

1.  Removed errant `:host { display: contents}`
2. Removed orphaned `#rhds_container` style.

Closes #1829 


## Testing Instructions

1. View deploy preview.  Note also view Alert's usage of `rh-button` there should be a margin now between the buttons

## Notes to Reviewers
