### PR TITLE
chore: lit css nesting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@rhds/elements",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/elements",
-      "version": "2.0.0",
-      "hasInstallScript": true,
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.2",
@@ -70,6 +69,7 @@
         "ts-patch": "^3.2.1",
         "tsx": "^4.17.0",
         "typescript": "^5.5.4",
+        "typescript-transform-lit-css": "^2.0.0",
         "wireit": "^0.14.7"
       },
       "optionalDependencies": {
@@ -1955,6 +1955,29 @@
         "@csstools/css-tokenizer": "^3.0.1"
       }
     },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
+      "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
     "node_modules/@csstools/selector-specificity": {
       "version": "4.0.0",
       "funding": [
@@ -2074,7 +2097,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -2092,7 +2114,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2110,7 +2131,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2128,7 +2148,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2145,7 +2164,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2162,7 +2180,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2180,7 +2197,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -2198,7 +2214,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -2216,7 +2231,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2234,7 +2248,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2252,7 +2265,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2270,7 +2282,6 @@
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2288,7 +2299,6 @@
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2306,7 +2316,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2324,7 +2333,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2342,7 +2350,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2374,7 +2381,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -2392,7 +2398,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -2409,7 +2414,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -2427,7 +2431,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -2445,7 +2448,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2463,7 +2465,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2481,7 +2482,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4393,7 +4393,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cssnano": "^6.1.2"
       }
@@ -4402,7 +4401,6 @@
       "version": "6.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^6.1.2",
         "lilconfig": "^3.1.1"
@@ -4422,7 +4420,6 @@
       "version": "6.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "css-declaration-sorter": "^7.2.0",
@@ -4466,7 +4463,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -4478,7 +4474,6 @@
       "version": "9.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0"
@@ -4494,7 +4489,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0",
@@ -4512,7 +4506,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "postcss-value-parser": "^4.2.0"
@@ -4528,7 +4521,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -4540,7 +4532,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -4552,7 +4543,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -4564,7 +4554,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -4576,7 +4565,6 @@
       "version": "6.0.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
         "stylehacks": "^6.1.1"
@@ -4592,7 +4580,6 @@
       "version": "6.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0",
@@ -4610,7 +4597,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4625,7 +4611,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "colord": "^2.9.3",
         "cssnano-utils": "^4.0.2",
@@ -4642,7 +4627,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "cssnano-utils": "^4.0.2",
@@ -4659,7 +4643,6 @@
       "version": "6.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.16"
       },
@@ -4674,7 +4657,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
       },
@@ -4686,7 +4668,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4701,7 +4682,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4716,7 +4696,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4731,7 +4710,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4746,7 +4724,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4761,7 +4738,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "postcss-value-parser": "^4.2.0"
@@ -4777,7 +4753,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4792,7 +4767,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4807,7 +4781,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssnano-utils": "^4.0.2",
         "postcss-value-parser": "^4.2.0"
@@ -4823,7 +4796,6 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0"
@@ -4839,7 +4811,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -4854,7 +4825,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
         "svgo": "^3.2.0"
@@ -4870,7 +4840,6 @@
       "version": "6.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.16"
       },
@@ -4885,7 +4854,6 @@
       "version": "6.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.0",
         "postcss-selector-parser": "^6.0.16"
@@ -5032,7 +5000,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -5047,7 +5014,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -5062,7 +5028,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -5076,7 +5041,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -5090,7 +5054,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5105,7 +5068,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5120,7 +5082,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5135,7 +5096,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5150,7 +5110,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5165,7 +5124,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5180,7 +5138,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5221,7 +5178,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -5236,7 +5192,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -5251,7 +5206,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -6461,7 +6415,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -6479,7 +6432,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -6497,7 +6449,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -6515,7 +6466,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -6533,7 +6483,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -6551,7 +6500,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -6569,7 +6517,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -6587,7 +6534,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -6605,7 +6551,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6623,7 +6568,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6641,7 +6585,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6659,7 +6602,6 @@
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6677,7 +6619,6 @@
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6695,7 +6636,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6713,7 +6653,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6731,7 +6670,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -6765,7 +6703,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -6783,7 +6720,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -6801,7 +6737,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -6819,7 +6754,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -6837,7 +6771,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -6855,7 +6788,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -7931,7 +7863,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -8258,7 +8189,6 @@
       "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -12378,7 +12308,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -13596,7 +13525,6 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true,
-      "license": "MIT",
       "optional": true
     },
     "node_modules/filelist": {
@@ -14173,7 +14101,6 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -18541,7 +18468,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
       "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
       "dev": true,
-      "license": "MIT",
       "optional": true
     },
     "node_modules/nanocolors": {
@@ -20081,7 +20007,6 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -20396,6 +20321,57 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-nesting": {
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.5.tgz",
+      "integrity": "sha512-N1NgI1PDCiAGWPTYrwqm8wpjv0bgDmkYHH72pNsqTCv9CObxjxftdYu6AKtGN+pnJa7FQjMm3v4sp8QJbFsYdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@csstools/selector-resolve-nested": "^1.1.0",
+        "@csstools/selector-specificity": "^3.1.1",
+        "postcss-selector-parser": "^6.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-nesting/node_modules/@csstools/selector-specificity": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
+      "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -20927,8 +20903,6 @@
     },
     "node_modules/prism-esm": {
       "version": "1.29.0-fix.4",
-      "resolved": "https://registry.npmjs.org/prism-esm/-/prism-esm-1.29.0-fix.4.tgz",
-      "integrity": "sha512-7/xHdroa6z9BhaGIpHA8SWIpefUz5l2eg2KT8pczFatyBiuni89q0jnKrScJbtFt1QkLwCRw36J1x8zUEGc5HA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22145,7 +22119,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -24703,7 +24676,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -24720,7 +24692,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -24737,7 +24708,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -24754,7 +24724,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -24771,7 +24740,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -24788,7 +24756,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -24805,7 +24772,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -24822,7 +24788,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -24839,7 +24804,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24856,7 +24820,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24873,7 +24836,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24890,7 +24852,6 @@
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24907,7 +24868,6 @@
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24924,7 +24884,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24941,7 +24900,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24958,7 +24916,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -24975,7 +24932,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -24992,7 +24948,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -25009,7 +24964,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -25026,7 +24980,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -25043,7 +24996,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -25060,7 +25012,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -25200,6 +25151,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typescript-transform-lit-css": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-transform-lit-css/-/typescript-transform-lit-css-2.0.0.tgz",
+      "integrity": "sha512-gfiW2suwc9Y4H5G0CDP/23Ry5ktWb7oBqmfD9ErG0m0yx+FU+/MmRlGHQM2tqm5v3tKP+IK6KPybnwdsT+lm6Q==",
+      "dev": true,
+      "dependencies": {
+        "@pwrs/lit-css": "^3.0.0"
+      },
+      "peerDependencies": {
+        "clean-css": "^5",
+        "lit": "^2.7.2 || ^3.0.0",
+        "postcss": "^8",
+        "postcss-nesting": "^12",
+        "ts-patch": "^3.0",
+        "typescript": "^5"
       }
     },
     "node_modules/typical": {

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
     "ts-patch": "^3.2.1",
     "tsx": "^4.17.0",
     "typescript": "^5.5.4",
+    "typescript-transform-lit-css": "^2.0.0",
     "wireit": "^0.14.7"
   },
   "optionalDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,9 +44,9 @@
     ],
     "plugins": [
       {
-        "transform": "@patternfly/pfe-tools/typescript/transformers/css-imports.cjs",
+        "transform": "typescript-transform-lit-css",
         "inline": true,
-        "minify": true
+        "cssnano": true
       },
       {
         "name": "typescript-lit-html-plugin"


### PR DESCRIPTION
## What I did

1. remove `@patternfly/pfe-tools/typescript/transformers/css-imports.cjs`
2. add `typescript-transform-lit-css`


## Testing Instructions

1. make some nested css in a shadow style
2. build clean
3. ensure that *all* the file css is legit in the output
