### PR TITLE
fix(site-status): use rh-icon

### DIFF
--- a/.changeset/sour-cloths-poke.md
+++ b/.changeset/sour-cloths-poke.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-site-status>`: use `<rh-icon>` for status indicators

--- a/elements/rh-site-status/rh-site-status.css
+++ b/elements/rh-site-status/rh-site-status.css
@@ -20,12 +20,8 @@ a {
   text-decoration: none;
   align-items: center;
   gap: var(--rh-space-md, 8px);
-  color: var(--rh-color-text-primary-on-light, #151515);
+  color: var(--rh-color-text-primary);
   text-transform: lowercase;
-}
-
-.dark a {
-  color: var(--rh-color-text-primary-on-dark, #ffffff);
 }
 
 span:first-letter {
@@ -33,10 +29,7 @@ span:first-letter {
 }
 
 a:focus {
-  outline:
-    var(--rh-border-width-md, 2px)
-    solid
-    var(--rh-color-border-interactive-on-light, #0066cc);
+  outline: var(--rh-border-width-md, 2px) solid var(--rh-color-border-interactive);
   border-radius: var(--rh-border-radius-default, 3px);
 }
 
@@ -44,6 +37,16 @@ a:is(:hover,:focus) {
   text-decoration: underline;
 }
 
-.dark a:focus {
-  outline-color: var(--rh-color-border-interactive-on-dark, #92c5f9);
+#icon {
+  position: relative;
+  width: var(--rh-size-icon-01, 16px);
+  height: var(--rh-size-icon-01, 16px);
+  color: var(--rh-color-white, #ffffff);
+
+  & rh-icon {
+    position: absolute;
+    &.success { color: var(--rh-color-status-success); }
+    &.warning { color: var(--rh-color-status-warning); }
+    &.danger { color: var(--rh-color-status-danger); }
+  }
 }

--- a/elements/rh-site-status/rh-site-status.ts
+++ b/elements/rh-site-status/rh-site-status.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, svg } from 'lit';
+import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -6,13 +6,21 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
 
-import '../rh-spinner/rh-spinner.js';
+import '@rhds/elements/rh-icon/rh-icon.js';
+import '@rhds/elements/rh-spinner/rh-spinner.js';
+
+// eagerly load these to avoid icon FOUC
+import '@rhds/icons/ui/check-circle.js';
+import '@rhds/icons/ui/check-circle-fill.js';
+import '@rhds/icons/ui/warning-fill.js';
+import '@rhds/icons/ui/warning.js';
+import '@rhds/icons/ui/error.js';
+import '@rhds/icons/ui/error-fill.js';
 
 import styles from './rh-site-status.css';
 
 type Impact = 'none' | 'minor' | 'major' | 'critical';
 type StatusKey = 'operational' | 'degraded_performance' | 'partial_outage' | 'major_outage';
-type Indicator = Impact | StatusKey;
 
 interface Page {
   id?: string;
@@ -68,38 +76,11 @@ export interface SummaryResponse {
   incidents: Incident[];
 }
 
-const STATUS_ICONS = Object.freeze({
-  'ok': svg`
-    <path d="M8 16.5C12.4183 16.5 16 12.9183 16 8.5C16 4.08172 12.4183 0.5 8 0.5C3.58172 0.5 0 4.08172 0 8.5C0 12.9183 3.58172 16.5 8 16.5Z" fill="#63993D"/>
-    <path d="M6.89999 12.1C6.69999 12.1 6.49999 12 6.39999 11.9L3.49999 9.00001C3.19999 8.70001 3.19999 8.30001 3.49999 8.00001C3.79999 7.70001 4.19999 7.70001 4.49999 8.00001L6.89999 10.4L11.5 5.80001C11.8 5.50001 12.2 5.50001 12.5 5.80001C12.8 6.10001 12.8 6.50001 12.5 6.80001L7.39999 11.9C7.19999 12 6.99999 12.1 6.89999 12.1Z" fill="white"/>
-  `,
-  'warn': svg`
-    <path d="M0 14.6H16L8 0.400024L0 14.6Z" fill="#F5921B"/>
-    <path d="M8.00005 9.80007C7.60005 9.80007 7.30005 9.50007 7.30005 9.10007V5.90007C7.30005 5.50007 7.60005 5.20007 8.00005 5.20007C8.40005 5.20007 8.70005 5.50007 8.70005 5.90007V9.20007C8.70005 9.50007 8.40005 9.80007 8.00005 9.80007ZM8.20005 12.7001C8.30005 12.7001 8.30005 12.7001 8.40005 12.7001C8.40005 12.7001 8.50005 12.7001 8.50005 12.6001L8.60005 12.5001C8.80005 12.3001 8.80005 12.1001 8.80005 11.9001C8.80005 11.7001 8.70005 11.5001 8.60005 11.3001L8.50005 11.2001L8.40005 11.1001C8.30005 11.1001 8.30005 11.1001 8.20005 11.1001C7.90005 11.0001 7.70005 11.1001 7.50005 11.3001C7.30005 11.5001 7.30005 11.7001 7.30005 11.9001C7.30005 12.1001 7.40005 12.3001 7.50005 12.5001C7.70005 12.7001 7.90005 12.7001 8.10005 12.7001C8.10005 12.7001 8.10005 12.7001 8.20005 12.7001Z" fill="white"/>
-  `,
-  'danger': svg`
-    <path d="M8 16.5C12.4183 16.5 16 12.9183 16 8.5C16 4.08172 12.4183 0.5 8 0.5C3.58172 0.5 0 4.08172 0 8.5C0 12.9183 3.58172 16.5 8 16.5Z" fill="#F4784A"/>
-    <path d="M8.0001 9.80005C7.6001 9.80005 7.3001 9.50005 7.3001 9.10005V4.50005C7.3001 4.10005 7.6001 3.80005 8.0001 3.80005C8.4001 3.80005 8.7001 4.10005 8.7001 4.50005V9.10005C8.7001 9.50005 8.4001 9.80005 8.0001 9.80005ZM8.2001 12.8C8.3001 12.8 8.3001 12.8 8.4001 12.7C8.5001 12.7 8.5001 12.7 8.5001 12.6C8.6001 12.6 8.6001 12.5 8.6001 12.5C8.8001 12.3 8.9001 12.1 8.9001 11.9C8.9001 11.7 8.8001 11.5 8.6001 11.3L8.5001 11.2L8.4001 11.1C8.3001 11.1 8.3001 11.1 8.2001 11.1C7.9001 11 7.6001 11.1 7.4001 11.3L7.3001 11.4L7.2001 11.5C7.2001 11.6 7.2001 11.6 7.1001 11.7C7.1001 11.8 7.1001 11.8 7.1001 11.9C7.1001 12.1 7.2001 12.3 7.4001 12.5C7.6001 12.7 7.8001 12.8 8.0001 12.8C8.1001 12.8 8.1001 12.8 8.2001 12.8Z" fill="white"/>
-  `,
-} as const);
-
 // map statuspage.io's text to our text; at least one of their status
 // strings is too long for the space we have
 const TEXT_MAP = Object.freeze({
   'Partially Degraded Service': 'Partial service',
 });
-
-// map statuspage.io's statuses to icon map keys
-const STATUS_MAP = Object.freeze({
-  'none': 'ok',
-  'operational': 'ok',
-  'degraded_performance': 'warn',
-  'partial_outage': 'warn',
-  'major_outage': 'warn',
-  'major': 'warn',
-  'minor': 'warn',
-  'critical': 'danger',
-} satisfies Record<Indicator, keyof typeof STATUS_ICONS>);
 
 const getSummaryOrThrow = async (response: Response) => {
   if (!response.ok) {
@@ -174,10 +155,18 @@ export class RhSiteStatus extends LitElement {
 
   get #icon() {
     const status = this.#component?.status ?? this.#status?.indicator;
-    if (status) {
-      return STATUS_ICONS[STATUS_MAP[status]];
-    } else {
-      return STATUS_ICONS.danger;
+    switch (status) {
+      case 'none':
+      case 'operational':
+        return { icon: 'check-circle-fill', status: 'success' };
+      case 'degraded_performance':
+      case 'partial_outage':
+      case 'major_outage':
+      case 'major':
+      case 'minor':
+        return { icon: 'warning-fill', status: 'warning' };
+      default:
+        return { icon: 'error-fill', status: 'danger' };
     }
   }
 
@@ -199,18 +188,19 @@ export class RhSiteStatus extends LitElement {
 
   protected override render() {
     const { on = 'light' } = this;
+    const loading = this.#loading;
+    const { icon, status } = this.#icon;
     return html`
-      <div id="container" class="${classMap({ on: true, [on]: true })}">
+      <div id="container" class="${classMap({ on: true, [on]: true, loading })}">
         <a href="https://status.redhat.com/"
            aria-busy="${String(this.#loading) as 'true' | 'false'}"
            aria-live="polite">${this.#loading ? html`
           <rh-spinner size="sm"></rh-spinner>
           <span><slot name="loading-text">Loading</slot></span>` : html`
-          <svg xmlns="http://www.w3.org/2000/svg"
-               width="16"
-               height="17"
-               viewbox="0 0 16 17"
-               fill="none">${this.#icon}</svg>
+          <div id="icon">
+            <rh-icon loading="eager" set="ui" icon="${icon.replace(`-fill`, '')}"></rh-icon>
+            <rh-icon loading="eager" set="ui" icon="${icon}" class="${status}"></rh-icon>
+          </div>
           <span>${this.#text}</span>`}
         </a>
       </div>


### PR DESCRIPTION
Closes #1615

## What I did

1. replace svg with rh-icon in site-status
2. use new status color tokens
3. bodge up a solution to two-tone icons by superimposing the filled icons on the non-filled