### PR TITLE
docs(color): change minimum column width of color token swatches

### DIFF
--- a/docs/foundations/color/index.md
+++ b/docs/foundations/color/index.md
@@ -26,7 +26,7 @@ crayons:
 <style data-helmet>
 #crayons-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(358px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: var(--rh-space-2xl);
   & .crayons-list {
     margin: 0;
@@ -44,6 +44,18 @@ crayons:
     }
   }
 }
+@container (min-width: 576px) and (max-width: 746px) {
+  #crayons-grid {
+    grid-template-columns: repeat(auto-fill, minmax(245px, 1fr));
+  }
+}
+/*
+@container section (min-width:747px) {
+  #crayons-grid {
+    grid-template-columns: repeat(auto-fill, minmax(352px, 1fr));
+  }
+}
+*/
 </style>
 
 ## Introduction

--- a/docs/foundations/color/index.md
+++ b/docs/foundations/color/index.md
@@ -26,7 +26,7 @@ crayons:
 <style data-helmet>
 #crayons-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(358px, 1fr));
   gap: var(--rh-space-2xl);
   & .crayons-list {
     margin: 0;


### PR DESCRIPTION
## What I did

1. Changed the max number of columns for the color token swatches from 4 to 3.


## Testing Instructions

1. Check ["Color tokens" section](https://deploy-preview-1901--red-hat-design-system.netlify.app/foundations/color/#color-tokens) of the "Color" page in the DP.

## Notes to Reviewers
