### PR TITLE
docs: lightdomcss install shortcode

### DIFF
--- a/docs/_plugins/shortcodes.cjs
+++ b/docs/_plugins/shortcodes.cjs
@@ -4,6 +4,7 @@ const {
   RepoStatusTable,
 } = require('./shortcodes/repoStatus.cjs');
 const RenderInstallation = require('./shortcodes/renderInstallation.cjs');
+const RenderLightDom = require('./shortcodes/renderLightDom.cjs');
 const RenderCodeDocs = require('./shortcodes/renderCodeDocs.cjs');
 const SpacerTokensTable = require('./shortcodes/spacerTokensTable.cjs');
 const UxdotPattern = require('./shortcodes/uxdotPattern.cjs');
@@ -13,6 +14,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(RepoStatusChecklist);
   eleventyConfig.addPlugin(RepoStatusTable);
   eleventyConfig.addPlugin(RenderInstallation);
+  eleventyConfig.addPlugin(RenderLightDom);
   eleventyConfig.addPlugin(SpacerTokensTable);
   eleventyConfig.addPlugin(RenderCodeDocs);
   eleventyConfig.addPlugin(UxdotPattern);

--- a/docs/_plugins/shortcodes/renderLightDom.cjs
+++ b/docs/_plugins/shortcodes/renderLightDom.cjs
@@ -12,7 +12,6 @@ async function renderLightDom(content, {
 } = {}) {
   const docsPage = this.ctx.doc;
   let lightdomContent = '';
-  console.log(docsPage.tagName, shimcss);
 
   if (shimcss === true) {
     lightdomContent = markdown`
@@ -38,7 +37,7 @@ This element has an optional "Lightdom CSS" <em>shim</em> to help reduce <a href
 This element requires you to load "Lightdom CSS" stylesheets for styling deeply slotted elements.
 
 ~~~html
-<link rel="stylesheet" href="${docsPage.tagName}/${docsPage.tagName}-lightdom.css">
+<link rel="stylesheet" href="/path/to/${docsPage.tagName}/${docsPage.tagName}-lightdom.css">
 ~~~
 
 <rh-alert state="info">

--- a/docs/_plugins/shortcodes/renderLightDom.cjs
+++ b/docs/_plugins/shortcodes/renderLightDom.cjs
@@ -22,7 +22,7 @@ This element has an optional "Lightdom CSS" <em>shim</em> to help reduce <a href
 
 <rh-alert state="warning">
   <h4 slot="header">Warning</h4>
-  <p>Lightdom CSS shims are an optional, temporary solution for reducing CLS. Delcarative Shadow DOM is the better solution, and it is more widely available, Lightdom CSS shims will no longer be needed and we will deprecate them.</p>
+  <p>Lightdom CSS shims are an optional, temporary solution for reducing CLS. Delcarative Shadow DOM is the better solution, and once it is more widely available, Lightdom CSS shims will no longer be needed and will become deprecated.</p>
 </rh-alert>
 
 ~~~html

--- a/docs/_plugins/shortcodes/renderLightDom.cjs
+++ b/docs/_plugins/shortcodes/renderLightDom.cjs
@@ -1,0 +1,60 @@
+// for editor highlighting
+const html = String.raw;
+const markdown = String.raw;
+
+/**
+ * @param {string} content
+ * @param {object} [options]
+ * @param {boolean} [options.shimcss]
+ */
+async function renderLightDom(content, {
+  shimcss = false,
+} = {}) {
+  const docsPage = this.ctx.doc;
+  let lightdomContent = '';
+  console.log(docsPage.tagName, shimcss);
+
+  if (shimcss === true) {
+    lightdomContent = markdown`
+
+### Lightdom CSS shim
+
+This element has an optional "Lightdom CSS" <em>shim</em> to help reduce <a href="https://web.dev/cls/">Cumulative Layout Shift (CLS)</a> experience before the element has fully initialized.
+
+~~~html
+<link rel="stylesheet" href="/path/to/${docsPage.tagName}/${docsPage.tagName}-lightdom-shim.css">
+~~~
+
+<rh-alert state="info">
+  <h4 slot="header">Note</h4>
+  <p>Replace <code>/path/to/</code> with path to the CSS file, whether local or CDN.</p>
+</rh-alert>
+`;
+  } else {
+    lightdomContent = markdown`
+
+### Lightdom CSS
+
+This element requires you to load "Lightdom CSS" stylesheets for styling deeply slotted elements.
+
+~~~html
+<link rel="stylesheet" href="${docsPage.tagName}/${docsPage.tagName}-lightdom.css">
+~~~
+
+<rh-alert state="info">
+  <h4 slot="header">Note</h4>
+  <p>Replace <code>/path/to/</code> with path to the CSS file, whether local or CDN.</p>
+</rh-alert>
+`;
+  }
+
+  return lightdomContent.trim();
+}
+
+/**
+ * Renders Light DOM CSS installation info
+ * @param {import('@11ty/eleventy').UserConfig} eleventyConfig  computed config
+ */
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPairedShortcode('renderLightDom', renderLightDom);
+};

--- a/docs/_plugins/shortcodes/renderLightDom.cjs
+++ b/docs/_plugins/shortcodes/renderLightDom.cjs
@@ -20,6 +20,11 @@ async function renderLightDom(content, {
 
 This element has an optional "Lightdom CSS" <em>shim</em> to help reduce <a href="https://web.dev/cls/">Cumulative Layout Shift (CLS)</a> experience before the element has fully initialized.
 
+<rh-alert state="warning">
+  <h4 slot="header">Warning</h4>
+  <p>Lightdom CSS shims are an optional, temporary solution for reducing CLS. Delcarative Shadow DOM is the better solution, and it is more widely available, Lightdom CSS shims will no longer be needed and we will deprecate them.</p>
+</rh-alert>
+
 ~~~html
 <link rel="stylesheet" href="/path/to/${docsPage.tagName}/${docsPage.tagName}-lightdom-shim.css">
 ~~~

--- a/docs/_plugins/shortcodes/renderLightDom.cjs
+++ b/docs/_plugins/shortcodes/renderLightDom.cjs
@@ -20,11 +20,6 @@ async function renderLightDom(content, {
 
 This element has an optional "Lightdom CSS" <em>shim</em> to help reduce <a href="https://web.dev/cls/">Cumulative Layout Shift (CLS)</a> experience before the element has fully initialized.
 
-<rh-alert state="warning">
-  <h4 slot="header">Warning</h4>
-  <p>Lightdom CSS shims are an optional, temporary solution for reducing CLS. Delcarative Shadow DOM is the better solution, and once it is more widely available, Lightdom CSS shims will no longer be needed and will become deprecated.</p>
-</rh-alert>
-
 ~~~html
 <link rel="stylesheet" href="/path/to/${docsPage.tagName}/${docsPage.tagName}-lightdom-shim.css">
 ~~~
@@ -32,6 +27,11 @@ This element has an optional "Lightdom CSS" <em>shim</em> to help reduce <a href
 <rh-alert state="info">
   <h4 slot="header">Note</h4>
   <p>Replace <code>/path/to/</code> with path to the CSS file, whether local or CDN.</p>
+</rh-alert>
+
+<rh-alert state="warning">
+  <h4 slot="header">Warning</h4>
+  <p>Lightdom CSS shims are an optional, temporary solution for reducing CLS. Delcarative Shadow DOM is the better solution, and once it is more widely available, Lightdom CSS shims will no longer be needed and will become deprecated.</p>
 </rh-alert>
 `;
   } else {

--- a/elements/rh-audio-player/docs/40-code.md
+++ b/elements/rh-audio-player/docs/40-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ## Usage
 
 {% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-breadcrumb/docs/30-code.md
+++ b/elements/rh-breadcrumb/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ## Usage
 
 ```html

--- a/elements/rh-code-block/docs/40-code.md
+++ b/elements/rh-code-block/docs/40-code.md
@@ -1,5 +1,7 @@
 {% renderInstall %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ## Usage
 
 The content of code-block snippets must be contained within a non-executable 

--- a/elements/rh-cta/docs/30-code.md
+++ b/elements/rh-cta/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom shimcss=true %}{% endrenderLightDom %}
+
 ## Usage
 
 ```html

--- a/elements/rh-footer/docs/30-code.md
+++ b/elements/rh-footer/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 {% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}
 
 {% renderCodeDocs for='rh-footer-universal' %}{% endrenderCodeDocs %}

--- a/elements/rh-navigation-secondary/docs/30-code.md
+++ b/elements/rh-navigation-secondary/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true%}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ### System Integration
 
 #### Current page indicator

--- a/elements/rh-pagination/docs/30-code.md
+++ b/elements/rh-pagination/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ## Usage
 
 ```html

--- a/elements/rh-skip-link/docs/30-code.md
+++ b/elements/rh-skip-link/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall %}{% endrenderInstall %}
 
+{% renderLightDom shimcss=true %}{% endrenderLightDom %}
+
 ## Usage
 ```html
 <rh-skip-link>

--- a/elements/rh-subnav/docs/30-code.md
+++ b/elements/rh-subnav/docs/30-code.md
@@ -1,3 +1,5 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 {% renderCodeDocs hideDescription=true %}{% endrenderCodeDocs %}

--- a/elements/rh-table/docs/30-code.md
+++ b/elements/rh-table/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ## Usage
 
 <rh-alert state="warning">

--- a/elements/rh-tile/docs/30-code.md
+++ b/elements/rh-tile/docs/30-code.md
@@ -1,5 +1,7 @@
 {% renderInstall lightdomcss=true %}{% endrenderInstall %}
 
+{% renderLightDom %}{% endrenderLightDom %}
+
 ## Usage
 
 <rh-alert state="warning">


### PR DESCRIPTION
## What I did

1. Added a `renderLightDom` shortcode for rendering installation instructions for `Lightdom CSS` 


## Testing Instructions

1. Check the section shows up where necessary, like `skip-link` and `rh-cta` have a lightdom shim, while `footer`, `tile`, and `audio-player` have the proper light dom CSS.
