### PR TITLE
fix(tabs): add display contents to panel container

### DIFF
--- a/.changeset/six-toys-learn.md
+++ b/.changeset/six-toys-learn.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tabs>`: allow tabs to participate in advanced layouts

--- a/elements/rh-tabs/rh-tab-panel.css
+++ b/elements/rh-tabs/rh-tab-panel.css
@@ -6,3 +6,7 @@
 :host([hidden]) {
   display: none !important;
 }
+
+#container {
+  display: contents;
+}

--- a/elements/rh-tabs/rh-tab-panel.ts
+++ b/elements/rh-tabs/rh-tab-panel.ts
@@ -1,16 +1,9 @@
-import type { RhTabsContext } from './context.js';
-
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
-import { property } from 'lit/decorators/property.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { consume } from '@lit/context';
-
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 
 import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
-
-import { context } from './context.js';
 
 import styles from './rh-tab-panel.css';
 
@@ -28,10 +21,6 @@ export class RhTabPanel extends LitElement {
    * Sets color theme based on parent context
    */
   @colorContextConsumer() private on?: ColorTheme;
-
-  @consume({ context, subscribe: true })
-  @property({ attribute: false })
-  private ctx?: RhTabsContext;
 
   #internals = this.attachInternals();
 
@@ -55,10 +44,8 @@ export class RhTabPanel extends LitElement {
 
   render() {
     const { on = 'light' } = this;
-    const { vertical = false, box = false } = this.ctx ?? {};
-    const inset = this.ctx?.box === 'inset' ? 'inset' : '';
     return html`
-      <div id="container" class="${classMap({ on: true, [on]: true, box, inset, vertical })}">
+      <div id="container" class="${classMap({ on: true, [on]: true })}">
         <slot></slot>
       </div>
     `;


### PR DESCRIPTION
## What I did

1. Added display contents to panel container (Enables @eyevana's noted issue of subgrid participation)
2. Removed unnecessary lit/context given shift to set panel padding via css var in `rh-tabs.css`


## Testing Instructions

1. [View Deploy preview](https://deploy-preview-1918--red-hat-design-system.netlify.app/elements/tabs/demo/color-context/)

## Notes to Reviewers

~~@bennypowers don't believe this change needs a changeset as it doesn't change anything for the end user.  Thoughts?~~
