### PR TITLE
docs: fix getElementDescription filter

### DIFF
--- a/docs/_plugins/rhds.cjs
+++ b/docs/_plugins/rhds.cjs
@@ -227,7 +227,7 @@ module.exports = function(eleventyConfig, { tagsToAlphabetize }) {
      * but a DocsPage instance, 11ty assigns it to this.ctx._
      * @see https://github.com/11ty/eleventy/blob/bf7c0c0cce1b2cb01561f57fdd33db001df4cb7e/src/Plugins/RenderPlugin.js#L89-L93
      */
-    const docsPage = this.ctx.doc;
+    const { docsPage } = this.ctx.doc;
     return docsPage.description;
   });
 


### PR DESCRIPTION
## What I did

1. Fixes the element descriptions on overview pages.

Closes #1919 


## Testing Instructions

1. View Deploy preview, you should now see a description of the element below Overview for every element.

## Notes to Reviewers
