### PR TITLE
docs: `uxdot-repo-status-list` missing border

### DIFF
--- a/docs/assets/javascript/elements/uxdot-repo-status-list.css
+++ b/docs/assets/javascript/elements/uxdot-repo-status-list.css
@@ -5,7 +5,7 @@
 }
 
 #inner-container {
-  border: var(--rh-border-width-sm);
+  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
   border-radius: var(--rh-border-radius-default);
   margin-block-start: var(--rh-space-lg);
 }


### PR DESCRIPTION
## What I did

1. Corrected border style for `uxdot-repo-status-list` 


## Testing Instructions

1. View deploy preview `uxdot-repo-status-list`  should have a subtle border on inner container.

## Notes to Reviewers
