### PR TITLE
fix(tile): remove `display: block` on image slot

### DIFF
--- a/.changeset/shaggy-foxes-smoke.md
+++ b/.changeset/shaggy-foxes-smoke.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tile>`: corrected layout when rendering some image slotted elements

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -85,7 +85,6 @@
   }
 
   & ::slotted([slot='image']) {
-    display: block;
     max-width: 100%;
     margin-top: 0;
     margin-bottom: var(--_padding);


### PR DESCRIPTION
## What I did

1. Removed `display: block` on image slot

Closes #1927 

## Testing Instructions

1.  [View Deploy Preview](https://deploy-preview-1928--red-hat-design-system.netlify.app/about/roadmap/) Roadmap tile
2. [View Deploy Preview](https://deploy-preview-1928--red-hat-design-system.netlify.app/elements/tile/demos/) tile demos
3. Look at other implementations of `<rh-tile>`

## Notes to Reviewers

I'm thinking this change is ok, unsure if it will have negative effects on current usage.  If anything we are correcting an bug but could have layout changing properties if someone had previously tried to slot a non block element into the `image` slot.
