### PR TITLE
docs: remove `role` attributes from `<uxdot-sidenav>`

### DIFF
--- a/docs/assets/javascript/elements/uxdot-sidenav.ts
+++ b/docs/assets/javascript/elements/uxdot-sidenav.ts
@@ -153,8 +153,6 @@ export class UxdotSideNavItem extends LitElement {
 
   @property() href?: string;
 
-  @property({ reflect: true }) role = 'menuitem';
-
   render() {
     const { active } = this;
     return html`
@@ -168,8 +166,6 @@ export class UxdotSideNavDropdown extends LitElement {
   static styles = [dropdownStyles];
 
   @property({ type: Boolean, reflect: true }) expanded = false;
-
-  @property({ reflect: true }) role = 'menu';
 
   connectedCallback() {
     super.connectedCallback();
@@ -205,8 +201,6 @@ export class UxdotSideNavDropdown extends LitElement {
 @customElement('uxdot-sidenav-dropdown-menu')
 export class UxdotSideNavDropdownMenu extends LitElement {
   static styles = [dropdownMenuStyles];
-
-  @property({ reflect: true }) role = 'menu';
 
   render() {
     return html`


### PR DESCRIPTION
## What I did

1. Removed the `role="menu"` and `role="menuitem"` attributes from the `<uxdot-sidenav>` elements.

### Why?

1. Generally, these roles are not meant for site navigations. See the APG Guidelines for [Menu and Menubar](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) and MDN docs on the [menu role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role). 
1. aXe DevTools throws an error saying `menu`/`menuitem` have improper nesting

## Testing Instructions

1. Open the [docs DP](https://deploy-preview-1939--red-hat-design-system.netlify.app/), run aXe DevTools, make sure there are no `menu`/`menuitem` errors.
2. Verify `<uxdot-sidenav>` and its child components don't have these roles in the DOM.