### PR TITLE
fix(card): computed context

### DIFF
--- a/elements/rh-card/rh-card.ts
+++ b/elements/rh-card/rh-card.ts
@@ -101,10 +101,14 @@ export class RhCard extends LitElement {
   }
 
   override render() {
-    const { on = 'light', variant = '' } = this;
     const promo = this.variant === 'promo';
     const standard = this.#isStandardPromo;
     const computedPalette = this.#computedPalette;
+    const computedContext = this.colorPalette ?
+      this.colorPalette?.includes('light') ? 'light' : 'dark'
+      : undefined;
+    const on = computedContext ?? this.on ?? 'light';
+    const { variant = '' } = this;
     const hasHeader = this.#slots.hasSlotted('header');
     const hasFooter = this.#slots.hasSlotted('footer');
     const hasImage = this.#slots.hasSlotted('image');

--- a/elements/rh-card/rh-card.ts
+++ b/elements/rh-card/rh-card.ts
@@ -100,13 +100,17 @@ export class RhCard extends LitElement {
     }
   }
 
+  get #computedContext() {
+    return this.colorPalette ?
+      this.colorPalette?.includes('light') ? 'light' : 'dark'
+      : undefined;
+  }
+
   override render() {
     const promo = this.variant === 'promo';
     const standard = this.#isStandardPromo;
     const computedPalette = this.#computedPalette;
-    const computedContext = this.colorPalette ?
-      this.colorPalette?.includes('light') ? 'light' : 'dark'
-      : undefined;
+    const computedContext = this.#computedContext;
     const on = computedContext ?? this.on ?? 'light';
     const { variant = '' } = this;
     const hasHeader = this.#slots.hasSlotted('header');


### PR DESCRIPTION
## What I did

1. Compute context.  First check if `this.colorPalette` is set, if so use that as basis for `light|dark` if undefined check to see if `this.on` is set, if so use that as basis, if not default to light.


## Testing Instructions

1. [View Deploy preview](https://deploy-preview-1943--red-hat-design-system.netlify.app)

## Notes to Reviewers

Ensure color-context and card patterns function as expected.
