### PR TITLE
docs: adjust changesets to align language around container query support

### DIFF
--- a/.changeset/gentle-rings-scream.md
+++ b/.changeset/gentle-rings-scream.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-table>`: adds container query support
+`<rh-table>`: tables now adjust to the size of their containing element, not to the size of the viewport.

--- a/.changeset/large-geese-suffer.md
+++ b/.changeset/large-geese-suffer.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-tabs>`: tabs now adjust to the size of their containing element, not just to the size of the viewport.
+`<rh-tabs>`: tabs now adjust to the size of their containing element, not to the size of the viewport.


### PR DESCRIPTION
## What I did

1. Adjusted language in changesets around tabs and table `@container` support


## Testing Instructions

1.

## Notes to Reviewers
