### PR TITLE
docs: fix hidden overflow on release notes table

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -17,24 +17,11 @@ hasToc: true
     max-width: 320px;
   }
 
-  rh-tile [slot="headline"] {
-    font-weight: var(--rh-font-weight-heading-bold, 700);
-  }
-
   rh-tile [icon="github"] {
     --rh-icon-size: var(--rh-size-icon-03, 32px);
   }
 
-  @media (min-width: 768px) {
-    [data-label="Change"] {
-      width: 30%;
-    }
-
-    [data-label="Type"] {
-      width: 10%;
-    }
-  }
-  @media (max-width: 768px) {
+  @container host (max-width: 768px) {
     rh-table thead ~ tbody tr :is(th, td) {
       display: block;
     }


### PR DESCRIPTION
## What I did

1. Fixed `<rh-table>`'s on the Release Notes page so that the text inside each `<th>`/`<td>` is visible.
1. Changed some page styles targeting `<rh-table>` to use `@container` queries.
1. Removed `font-weight: 700;` from tile since it's being overridden from component styles.


## Testing Instructions

1. Open up the [Release Notes page](https://ux.redhat.com/release-notes/#changelog) on uxdot in production.
2. Resize window to 770-800px (ish).
3. Observe clipped / hidden text in `<rh-tag>`.
4. Raise one eyebrow.
5. Open up the [Release Notes page](https://deploy-preview-1952--red-hat-design-system.netlify.app/release-notes/#changelog) in this PR's DP.
6. Verify no text is clipped at ~770-800px and everything looks as it should.
7. Lower aforementioned eyebrow.

## Notes to Reviewers

Closes #1951.