### PR TITLE
docs: accessibility IA and content cleanup

### DIFF
--- a/docs/accessibility/accessibility-tools.md
+++ b/docs/accessibility/accessibility-tools.md
@@ -4,7 +4,7 @@ sidenavTitle: Accessibility tools
 permalink: /accessibility/accessibility-tools/index.html
 tags:
   - accessibility
-order: 50
+order: 10
 importElements:
   - rh-blockquote
 ---
@@ -13,9 +13,9 @@ importElements:
 
 Automated tools can help you quickly identify many potential high-impact accessibility issues. Among such tools are free browser extensions like:
 
-  * Deque’s aXe DevTools
-  * WebAIM’s WAVE
-  * IBM's Equal Access Checker
+- Deque’s aXe DevTools
+- WebAIM’s WAVE
+- IBM's Equal Access Checker
 
 ### Deque aXe DevTools
 
@@ -66,11 +66,11 @@ Running an accessibility audit in Lighthouse is recommended to catch errors dete
 
 Chrome and Edge also have an "Accessibility Pane" that lets users see information about the currently selected DOM node. This includes properties like:
 
-   * An element's role
-   * If an element is focusable
-   * If the element contains any `aria` attributes and their values
-   * An element's title
-   * ...and many other accessibility-related properties
+- An element's role
+- If an element is focusable
+- If the element contains any `aria` attributes and their values
+- An element's title
+- ...and many other accessibility-related properties
 
 <figure>
   <uxdot-example width-adjustment="893px">

--- a/docs/accessibility/assistive-tech.md
+++ b/docs/accessibility/assistive-tech.md
@@ -2,7 +2,7 @@
 title: Assistive technologies
 tags:
   - accessibility
-order: 40
+order: 20
 ---
 
 ## What are assistive technologies?

--- a/docs/accessibility/ci-cd.md
+++ b/docs/accessibility/ci-cd.md
@@ -5,7 +5,7 @@ permalink: /accessibility/ci-cd/index.html
 hasToc: false
 tags:
   - accessibility
-order: 80
+order: 30
 ---
 
 <script data-helmet type="module">
@@ -14,11 +14,11 @@ order: 80
 
 ## Accessibility tools for CI/CD pipelines
 
-Many Red Hat projects use continuous integration and continuous delivery pipelines to help deliver robust digital products to our users. There are several accessibility tools for CI/CD. The Red Hat Design System uses the [Chai A11y aXe][chaia11yaxe] module and [PatternFly Elements Tools][pfe-tools]'s  a11ySnapshot feature, based on [Web Test Runner][a11ysnapshot], for unit tests.
+Many Red Hat projects use continuous integration and continuous delivery pipelines to help deliver robust digital products to our users. There are several accessibility tools for CI/CD. The Red Hat Design System uses the [Chai A11y aXe][chaia11yaxe] module and [PatternFly Elements Tools][pfe-tools]'s a11ySnapshot feature, based on [Web Test Runner][a11ysnapshot], for unit tests.
 
 ### Chai A11y aXe
 
-Chai A11y Axe is a plugin to perform automated accessibility tests via [aXe](https://www.deque.com/axe/) for the [Chai Assertion Library](https://www.chaijs.com/). Here's how to test and see if a web component in the Red Hat Design System passes aXe accessibility tests. In this example, we're going to use Chai A11y aXe with `<rh-tag>`:
+Chai A11y aXe is a plugin to perform automated accessibility tests via [aXe](https://www.deque.com/axe/) for the [Chai Assertion Library](https://www.chaijs.com/). Here's how to test and see if a web component in the Red Hat Design System passes aXe accessibility tests. In this example, we're going to use Chai A11y aXe with `<rh-tag>`:
 
 1. Follow the instructions to [Install the project](https://ux.redhat.com/get-started/developers/contributing/).
 1. Open `elements/rh-tag/test/rh-tag.spec.ts`.
@@ -29,13 +29,11 @@ Chai A11y Axe is a plugin to perform automated accessibility tests via [aXe](htt
 
 The aXe assertion from step 3 looks like this, add it anywhere inside the first `describe('<rh-tag>')` block:
 
-
 <rh-code-block highlighting="prerendered">
 
 ```ts
-it('should be accessible', async function() {
-  await expect(element)
-      .to.be.accessible();
+it("should be accessible", async function () {
+  await expect(element).to.be.accessible();
 });
 ```
 
@@ -63,22 +61,20 @@ These ax-tree assertions can go inside the top-level `describe('rh-skip-link')` 
 <rh-code-block highlighting="prerendered">
 
 ```ts
-describe('when the element loads', function() {
+describe("when the element loads", function () {
   let element: RhSkipLink;
-  beforeEach(async function() {
+  beforeEach(async function () {
     element = await createFixture<RhSkipLink>(html`
       <rh-skip-link>
-        <a href="#main-content">
-          Skip to main content
-        </a>
+        <a href="#main-content"> Skip to main content </a>
       </rh-skip-link>
     `);
   });
 
-  it('should have a link with the name, "Skip to main content"', async function() {
+  it('should have a link with the name, "Skip to main content"', async function () {
     const snapshot = await a11ySnapshot();
-    expect(snapshot).to.axContainRole('link');
-    expect(snapshot).to.axContainName('Skip to main content');
+    expect(snapshot).to.axContainRole("link");
+    expect(snapshot).to.axContainName("Skip to main content");
   });
 });
 ```

--- a/docs/accessibility/content.md
+++ b/docs/accessibility/content.md
@@ -1,8 +1,8 @@
 ---
 title: Content
 tags:
- - accessibility
-order: 10
+  - accessibility
+order: 40
 importElements:
   - rh-code-block
   - rh-blockquote
@@ -117,7 +117,7 @@ If the above image supplements the text of an article about Red Hat or our produ
 
 ```html rhcodeblock
 <a href="https://www.redhat.com/">
-  <img src="logo-redhat.png" alt="Red Hat homepage">
+  <img src="logo-redhat.png" alt="Red Hat homepage" />
 </a>
 ```
 
@@ -127,18 +127,18 @@ Grouped images that convey a single meaning (e.g., movie rating stars), can be g
 
 ```html rhcodeblock
 <div aria-label="2 of 3 attempts left">
-  <img src="pending.jpg" alt>
-  <img src="pending.jpg" alt>
-  <img src="failed.jpg" alt>
+  <img src="pending.jpg" alt />
+  <img src="pending.jpg" alt />
+  <img src="failed.jpg" alt />
 </div>
 ```
 
 Or the first element of the group can have alt text, while the others are hidden:
 
 ```html rhcodeblock
-<img src="pending.jpg" alt="2 of 3 attempts left">
-<img src="pending.jpg" alt>
-<img src="failed.jpg" alt>
+<img src="pending.jpg" alt="2 of 3 attempts left" />
+<img src="pending.jpg" alt />
+<img src="failed.jpg" alt />
 ```
 
 ### Embedded media (and other non-text) titles
@@ -146,9 +146,8 @@ Or the first element of the group can have alt text, while the others are hidden
 Though the techniques may vary, meaningful embedded media objects require text alternatives—just like images do. This applies to `<video>`. `<audio>`, and `<canvas>` elements; objects; applets; ASCII art; and (if you still use them) multimedia embeds like Flash and Silverlight.
 A common technique is labeling objects with ARIA attributes:
 
-
 ```html rhcodeblock
-<video src="video.mp4" aria-label="Deploying applications with OpenShift">
+<video src="video.mp4" aria-label="Deploying applications with OpenShift"></video>
 ```
 
 ## Writing microcopy
@@ -187,7 +186,6 @@ In addition to the best practices for all microcopy, adhere to the following bes
 
 In addition to the best practices for all microcopy, adhere to the following best practices for buttons, when possible.
 
-
 ```html rhcodeblock
 <button>Save draft</button>
 ```
@@ -219,13 +217,11 @@ In addition to the best practices for all microcopy, adhere to the following bes
 
 Use clear language in headings to describe the content that follows them:
 
-
 ```html rhcodeblock
 <h1>Red Hat Enterprise Linux</h1>
 ```
 
 At Red Hat, we use sentence case for our headings:
-
 
 ```html rhcodeblock
 <h2>How companies are using RHEL</h2>
@@ -255,21 +251,20 @@ And here’s how that outline would be reflected in a page’s heading structure
 
 ```html rhcodeblock
 <h1>Midwestern Recipes</h1>
-  <h2>Sides</h2>
-    <h3>Cheese</h3>
-      <h4>Fried cheese curds</h4>
-      <h4>Beer cheese dip</h4>
-  <h2>Desserts</h2>
-    <h3>Bars</h3>
-      <h4>Scotch-a-roos</h4>
-      <h4>Dream bars</h4>
-    <h3>Pastries</h3>
-      <h4>Kringle</h4>
-      <h4>Dutch letters</h4>
+<h2>Sides</h2>
+<h3>Cheese</h3>
+<h4>Fried cheese curds</h4>
+<h4>Beer cheese dip</h4>
+<h2>Desserts</h2>
+<h3>Bars</h3>
+<h4>Scotch-a-roos</h4>
+<h4>Dream bars</h4>
+<h3>Pastries</h3>
+<h4>Kringle</h4>
+<h4>Dutch letters</h4>
 ```
 
 Note that an `<h1>` is often the first heading on a page:
-
 
 ```html rhcodeblock
 <h1>Midwestern Recipes</h1>
@@ -277,7 +272,6 @@ Note that an `<h1>` is often the first heading on a page:
 ```
 
 But it doesn’t have to be the first heading on a page. This is also acceptable:
-
 
 ```html rhcodeblock
 <h2>Navigation</h2>
@@ -294,7 +288,9 @@ Each web page is required to have a page `<title>` element within its `<head>` t
   <head>
     <title>Red Hat Ansible Automation Platform</title>
   </head>
-  <body>...</body>
+  <body>
+    ...
+  </body>
 </html>
 ```
 
@@ -307,7 +303,6 @@ As mentioned in the Headings section, page titles and `<h1>` elements often rela
 ### iframe titles
 
 Non-hidden, non-empty `<iframe>` elements are required to have titles describing their meaning or purpose, similar to alternative text for images.
-
 
 ```html rhcodeblock
 <iframe src="video.html" title="Video: Network automation with Ansible"></iframe>
@@ -339,7 +334,9 @@ For example, the following doesn’t need to be a table:
 
 ```html rhcodeblock
 <table>
-  <caption>Groceries</caption>
+  <caption>
+    Groceries
+  </caption>
   <tbody>
     <tr>
       <th scope="row">Apples</th>
@@ -538,13 +535,17 @@ For pages with multilingual content, each element containing a different languag
 ```html rhcodeblock
 <!DOCTYPE html>
 <html lang="en">
-  <head>...</head>
+  <head>
+    ...
+  </head>
   <body>
-      <p>Colombian author Gabriel García Márquez wrote that
-      we each live three lives: one public, one private, and
-      one secret. (Full original quote: <span lang="es">“Todos
-      los seres humanos tenemos tres vidas: pública, privada y
-      secreta.”</span>)</p>
+    <p>
+      Colombian author Gabriel García Márquez wrote that we each live three lives: one public, one
+      private, and one secret. (Full original quote:
+      <span lang="es"
+        >“Todos los seres humanos tenemos tres vidas: pública, privada y secreta.”</span
+      >)
+    </p>
   </body>
 </html>
 ```

--- a/docs/accessibility/contributors.md
+++ b/docs/accessibility/contributors.md
@@ -1,8 +1,8 @@
 ---
 title: Contributors
-tags: 
- - accessibility
-order: 90
+tags:
+  - accessibility
+order: 50
 ---
 
 ## Overview
@@ -12,29 +12,29 @@ order: 90
   <p>This section covers accessibility for design system contributors. Contributors should also be familiar with accessibility <a href="../">fundamentals</a>, <a href="../content">content</a>, <a href="../design">design</a>, and <a href="../development">development</a>.</p>
 </rh-alert>
 
-
 ## ARIA issues with shadowDOM
 
 Currently, there is no way to associate ARIA attributes with elements in different DOM trees. So an element in light DOM can't use the ID reference of an element in shadowDOM to associate elements with one another, and vice versa (e.g., via aria-labelledby, aria-describedby, etc.).
 
 The following resources explain the problem in more detail and provide some workarounds, examples, and future proposals:
+
 - Alice Boxhall's [How Shadow DOM and accessibility are in conflict](https://alice.pages.igalia.com/blog/how-shadow-dom-and-accessibility-are-in-conflict/)
 - Nolan Lawson's [Shadow DOM and accessibility: the trouble with ARIA](https://nolanlawson.com/2022/11/28/shadow-dom-and-accessibility-the-trouble-with-aria/)
 - Leo Balter's [Cross-root ARIA](https://github.com/leobalter/cross-root-aria-delegation/blob/main/explainer.md) explainer
 
-
 ## Accessibility controllers
 
 Where applicable, use [controllers](https://lit.dev/docs/api/controllers/) for accessible keyboard navigation as well as ARIA roles, states and properties. Examples of our @patternfly/pfe-core/controllers are listed below:
+
 - `internals-controller`: Attaches internals to a component so that ARIA roles, states and properties can be set internally and not altered by consumers.
 - `listbox-controller`: Sets keyboard navigation and ARIA roles, states, and properties for a listbox host and its options.
 - `roving-tabindex-controller`: Used for groups of elements that are more easily navigated with arrow keys instead of the <kbd>tab</kbd> key. This controller is preferred over aria-activedescendant, which will be challenging until there is a solution for cross-root ARIA.
 - `toggle-controller`: Sets keyboard navigation and ARIA roles, states, and properties for a popup with show/hide toggling.
 
-
 ## Authoring tool accessibility guidelines (ATAG)
 
-Help authors (and consumers) use the component in a manner that is accessible. The [Authoring Tool Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/atag/) (ATAG) 2.0 provide guidelines for content authoring tools. [ATAG 2.0 Part B](https://www.w3.org/TR/ATAG20/#part_b) is concerned with helping others create accessible content. While a web component itself is not an authoring tool, components can be used within content management systems and other authoring tools. So, we should develop our components in a way that consumers (whether developers or content authors using tools and templates that developers have created) can easily make accessible content with them. 
-- Place as much of the accessibility burden as possible on the component itself, rather than the consumer's use of it. 
+Help authors (and consumers) use the component in a manner that is accessible. The [Authoring Tool Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/atag/) (ATAG) 2.0 provide guidelines for content authoring tools. [ATAG 2.0 Part B](https://www.w3.org/TR/ATAG20/#part_b) is concerned with helping others create accessible content. While a web component itself is not an authoring tool, components can be used within content management systems and other authoring tools. So, we should develop our components in a way that consumers (whether developers or content authors using tools and templates that developers have created) can easily make accessible content with them.
+
+- Place as much of the accessibility burden as possible on the component itself, rather than the consumer's use of it.
 - Limit slots and properties so only a small-but-frequently-used number of combinations are possible. Then, create tests and demos to verify that these combinations are accessible.
 - If additional customizations are required, these can be achieved via a limited set of CSS properties and variables, where the consumer assumes responsibility for potential accessibility issues.

--- a/docs/accessibility/design.md
+++ b/docs/accessibility/design.md
@@ -2,7 +2,7 @@
 title: Design
 tags:
   - accessibility
-order: 20
+order: 60
 ---
 
 ## Overview

--- a/docs/accessibility/development.md
+++ b/docs/accessibility/development.md
@@ -2,7 +2,7 @@
 title: Development
 tags:
   - accessibility
-order: 30
+order: 70
 ---
 
 <script data-helmet type="module">
@@ -47,7 +47,7 @@ To make icon fonts accessible, you often have to re-hack what’s already a hack
 As with any other image, SVGs that are loaded into your page via an `<img>` tag should include alt attributes. This attribute should be descriptive for meaningful SVGs and null for decorative SVGs. In addition, we recommend adding a role="img" attribute to the `<img>` element for SVGs:
 
 ```html rhcodeblock
-<img src="logo.svg" alt="Image description" role="img">
+<img src="logo.svg" alt="Image description" role="img" />
 ```
 
 Inline `<svg>` elements (i.e., SVGs that are coded directly into the page source) cannot use the alt attribute. You must use some other means to describe or hide these images.
@@ -74,11 +74,8 @@ More complex `<svg>` elements may require additional descriptive information. On
 
 You can hide `<svg>` elements from assistive tech with an `aria-hidden="true"` attribute.
 
-
 ```html rh-code-block
-<svg aria-hidden="true">
-  ...
-</svg>
+<svg aria-hidden="true">...</svg>
 ```
 
 Carie Fisher explores several patterns (including the above) for embedding accessible SVGs in her 2021 [Smashing Magaine article][smashingmagainearticle].

--- a/docs/accessibility/index.md
+++ b/docs/accessibility/index.md
@@ -1,11 +1,10 @@
 ---
 title: Fundamentals
-tags: 
- - accessibility
-order: 0
+tags:
+  - accessibility
+order: 75
 importElements:
   - rh-blockquote
-
 ---
 
 <style>
@@ -34,7 +33,6 @@ The former may imply that someone is lacking in some way, and thus they are resp
 
 The World Wide Web Consortium’s Web Accessibility Initiative (WAI) has authored a [Diverse Abilities and Barriers](https://www.w3.org/WAI/people-use-web/abilities-barriers/) page that lists potential barriers that individuals of varying auditory, cognitive, learning, neurological, physical, speech, and visual abilities are likely to face.
 
-
 ### Personas and user stories
 
 Personas are fictionalized distillations of the varying types of users who may engage with your web properties. Using them is a common UX design technique that can be helpful for developing empathy and building inclusive experiences.
@@ -42,7 +40,6 @@ Personas are fictionalized distillations of the varying types of users who may e
 When writing, designing, or developing, you can put yourself in the mind of these personas to imagine what outcomes the users they represent might want from your experience and how successfully they can accomplish these goals. Using personas shifts accessibility left in your processes, helping you avoid and catch issues before they ever get to handoffs, QA, or even launch.
 
 WAI has designed a collection of [web user stories](https://www.w3.org/WAI/people-use-web/user-stories/) (e.g., a color-blind online shopper, a hard-of-hearing student, etc.) that you may find helpful to adapt as personas for your own web projects.
-
 
 ## Laws
 
@@ -61,6 +58,7 @@ Businesses open to the public are subject to Title III of the Americans with Dis
 Section 508 of the Rehabilitation Act of 1973 requires that accessible electronic and information technology be provided by all federal agencies—and, by extension, by any companies doing business with the federal government or its subcontractors.
 
 #### Section 504
+
 Under Section 504 of the Rehabilitation Act of 1973, entities receiving federal funding must offer equal access to all facilities and communications—including online communications. This law is most commonly referenced in regard to publicly-funded educational institutions (PreK-12 and post-secondary). But it can apply to any organization that receives federal assistance and any companies doing business with such entities.
 
 ### International

--- a/docs/accessibility/manual-testing.md
+++ b/docs/accessibility/manual-testing.md
@@ -5,7 +5,7 @@ permalink: /accessibility/manual-testing/index.html
 hasToc: false
 tags:
   - accessibility
-order: 60
+order: 80
 importElements:
   - rh-blockquote
 ---

--- a/docs/accessibility/resources.md
+++ b/docs/accessibility/resources.md
@@ -2,7 +2,7 @@
 title: Resources
 tags:
   - accessibility
-order: 100
+order: 90
 ---
 
 ## Fundamentals

--- a/docs/accessibility/screen-readers-computer.md
+++ b/docs/accessibility/screen-readers-computer.md
@@ -1,8 +1,7 @@
 ---
 title: "Computer screen readers"
 permalink: /accessibility/screen-readers-computer/index.html
-tags:
-  - accessibility
+
 order: 101
 ---
 

--- a/docs/accessibility/screen-readers-computer.md
+++ b/docs/accessibility/screen-readers-computer.md
@@ -1,17 +1,10 @@
 ---
-title: "Screen readers: computer"
-sidenavTitle: "Screen readers: computer"
+title: "Computer screen readers"
 permalink: /accessibility/screen-readers-computer/index.html
 tags:
   - accessibility
 order: 101
 ---
-
-On computers, screen reader testing often lets you perform two tests simultaneously. First, it ensures that all meaningful web content and interactions are available to assistive tech. Second, it helps you verify that your experiences are keyboard operable (which is a [WCAG requirement](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html)).
-
-After turning on your computer’s screen reader and opening your browser, use your keyboard to access the entire experience, top to bottom. Use the <kbd>Tab</kbd>, <kbd>Shift-Tab</kbd>, and <kbd>↑ → ↓ ←</kbd> keys to move among (and within) focusable elements like links, form controls, and interactive components. And you can then use other keys like <kbd>Space</kbd>, <kbd>Enter</kbd>, and <kbd>Escape</kbd> to interact with those elements.
-
-Each screen reader also has its own set of keyboard shortcuts to navigate and read non-interactive content within an experience. Different keypresses can start (or stop) reading the page, jump to the next heading element, move vertically and horizontally among table cells, and so on. Links to keyboard shortcut resources are included in each screen reader’s section, below.
 
 ## VoiceOver (macOS)
 

--- a/docs/accessibility/screen-readers-computer.md
+++ b/docs/accessibility/screen-readers-computer.md
@@ -4,7 +4,7 @@ sidenavTitle: "Screen readers: computer"
 permalink: /accessibility/screen-readers-computer/index.html
 tags:
   - accessibility
-order: 71
+order: 101
 ---
 
 On computers, screen reader testing often lets you perform two tests simultaneously. First, it ensures that all meaningful web content and interactions are available to assistive tech. Second, it helps you verify that your experiences are keyboard operable (which is a [WCAG requirement](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html)).

--- a/docs/accessibility/screen-readers-computer.md
+++ b/docs/accessibility/screen-readers-computer.md
@@ -1,0 +1,169 @@
+---
+title: "Screen readers: computer"
+sidenavTitle: "Screen readers: computer"
+permalink: /accessibility/screen-readers-computer/index.html
+tags:
+  - accessibility
+order: 71
+---
+
+On computers, screen reader testing often lets you perform two tests simultaneously. First, it ensures that all meaningful web content and interactions are available to assistive tech. Second, it helps you verify that your experiences are keyboard operable (which is a [WCAG requirement](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html)).
+
+After turning on your computer’s screen reader and opening your browser, use your keyboard to access the entire experience, top to bottom. Use the <kbd>Tab</kbd>, <kbd>Shift-Tab</kbd>, and <kbd>↑ → ↓ ←</kbd> keys to move among (and within) focusable elements like links, form controls, and interactive components. And you can then use other keys like <kbd>Space</kbd>, <kbd>Enter</kbd>, and <kbd>Escape</kbd> to interact with those elements.
+
+Each screen reader also has its own set of keyboard shortcuts to navigate and read non-interactive content within an experience. Different keypresses can start (or stop) reading the page, jump to the next heading element, move vertically and horizontally among table cells, and so on. Links to keyboard shortcut resources are included in each screen reader’s section, below.
+
+## VoiceOver (macOS)
+
+- VoiceOver is included with MacOS.
+- Commonly paired with: Safari
+- [Keyboard shortcuts (from Deque)](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts)
+
+### Setting up your Mac and Safari
+
+Before testing with VoiceOver, you may need to enable keyboard navigation—for both your Mac and Safari.
+
+To turn on keyboard navigation for your Mac:
+
+1. Go to the Keyboard section in System Settings.
+2. Turn on the "Keyboard navigation" switch within this section.
+
+(For MacOS versions before MacOS 13 Ventura, enter the Shortcuts tab panel in the System Settings' Keyboard section and check the "Use keyboard navigation..." checkbox.)
+
+In Safari, you may need the additional step of enabling the browser's tab navigation:
+
+1. Open Safari’s Preferences/Settings window
+2. Enter the Advanced tab.
+3. Check the "Press Tab to highlight each item on a webpage" checkbox.
+
+### Getting started with VoiceOver
+
+To toggle VoiceOver on and off, press <kbd>Command-F5</kbd>. Or, if you have a Touch ID keyboard, hold down <kbd>Command</kbd> and quickly press the <kbd>Touch ID</kbd> key three times.
+
+To customize VoiceOver settings (e.g., the voice), open the VoiceOver Utility on your computer (e.g., via <kbd>Command-Space</kbd> and then typing "voiceover utility").
+
+By default, the <kbd>Ctrl-Opt</kbd> keypress combo is what's called the <kbd>VO</kbd> modifier. You can execute many VoiceOver commands with this modifier. For example, <kbd>VO-H</kbd> (or <kbd>Ctrl-Opt-H</kbd>) launches VoiceOver Help (which can then be exited via <kbd>Esc</kbd>).
+
+### Using the transcript window and muting VoiceOver
+
+To visually reinforce what you’re hearing, VoiceOver’s transcript window reflects the content currently being read. If VoiceOver's audio is too distracting (e.g., maybe you're presenting it in a meeting and want to hear the other participants), you can even mute it via the "Mute speech" checkbox in the VoiceOver Utility’s Speech tab. The transcript window will continue to appear and display content as if it were being read aloud.
+
+While speech is muted, the shortcut for continually reading page content (<kbd>VO-A</kbd>) will be deactivated, though you can still use the <kbd>↑ → ↓ ←</kbd> keys to move through and test non-interactive content.
+
+While transcript windows can be helpful, there are cases where the audio may not match a transcript exactly. So, when testing, confirm any issues with the audio on.
+
+## NVDA (Windows)
+
+- [Download and install](https://www.nvaccess.org/download/) NVDA to use it. It’s free.
+- Commonly paired with: Firefox (and Chrome, if you don’t have access to JAWS)
+- [Keyboard shortcuts](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts) (from Deque)
+
+### Getting started
+
+You can start NVDA via any of the following methods:
+
+- Open it in the Windows Start menu.
+- Press the <kbd>Windows</kbd> key, type <code>NVDA</code> and then <kbd>Enter</kbd>.
+- Click the NVDA desktop shortcut icon (if available).
+
+When NVDA starts, a welcome dialog will appear. Here, you can specify what kind of keyboard you’re using, so NVDA knows what to use as your <kbd>NVDA</kbd> modifier key for keyboard shortcuts:
+
+- If your keyboard has an <kbd>Insert</kbd> key (most full Windows keyboards do), then you can leave "Use CapsLock as an NVDA modifier key" unchecked. <kbd>Insert</kbd> will be assigned as your <kbd>NVDA</kbd> modifier key.
+- If your keyboard does not have an <kbd>Insert</kbd> key (many laptop keyboards do not), check the "Use CapsLock…" checkbox. <kbd>CapsLock</kbd> will be assigned as your <kbd>NVDA</kbd> key.
+
+To customize NVDA’s settings, press <kbd>NVDA-N</kbd>. This brings up an options menu, which you can then navigate via arrows and the <kbd>Enter</kbd> key.
+
+To quit NVDA, press <kbd>NVDA-Q</kbd>. You can also quit NVDA and access settings via its system tray icon.
+
+### Displaying the speech viewer
+
+Like MacOS VoiceOver, NVDA offers an option for using the screen reader visually. This speech viewer keeps a running log of all content read during a session, for quick reference.
+
+To open the speech viewer:
+
+1. Press <kbd>NVDA-N</kbd> to open the app’s settings.
+2. Press <kbd>T</kbd> to open the tools menu.
+3. Arrow down to the "Speech Viewer" option and press <kbd>Enter</kbd>.
+
+The speech viewer window will appear on your screen. The viewer window has a "Show Speech Viewer on Startup" checkbox, which you can check to make sure it always appears when you run NVDA.
+
+As with VoiceOver’s transcript window, there are cases where audio may not match the speech viewer’s log exactly. So, when testing, confirm any issues with audio on.
+
+### Creating a portable copy
+
+One handy thing about NVDA is that you can create a portable copy to place on a flash drive and use on any Windows computer. This can be useful if you need to demonstrate something on someone else’s machine, or if you yourself switch computers.
+
+To make a portable copy:
+
+1. Start NVDA and open its settings (<kbd>NVDA-N</kbd>).
+2. Press <kbd>T</kbd> to open the tools menu.
+3. Arrow down to the "Create portable copy" option and press <kbd>Enter</kbd>.
+4. Choose a destination for this copy of NVDA.
+
+## JAWS (Windows)
+
+- [Download and install JAWS](https://support.freedomscientific.com/Downloads/JAWS) to use it. It’s commercial software with a trial mode.
+- Commonly paired with: Chrome
+- [Keyboard shortcuts (from the official Freedom Scientific site)](https://www.freedomscientific.com/training/jaws/hotkeys/)
+- [Keyboard shortcuts (from Deque)](https://dequeuniversity.com/screenreaders/jaws-keyboard-shortcuts)
+
+### Getting started
+
+You can start JAWS via any of the following methods:
+
+- Open it in the Windows Start menu.
+- Press the <kbd>Windows</kbd> key, type <code>JAWS</code>, and then <kbd>Enter</kbd>.
+- Click the JAWS desktop shortcut icon (if available).
+
+On keyboards with an <kbd>Insert</kbd> key, that key will be assigned as your <kbd>JAWS</kbd> modifier key for keyboard shortcuts. On keyboards without an <kbd>Insert</kbd> key, the <kbd>CapsLock</kbd> key will be your <kbd>JAWS</kbd> key. You can test this out by pressing <kbd>JAWS-F12</kbd> to read out the system time.
+
+To customize your JAWS settings, use its system tray menu:
+
+1. Open the system tray menu with your mouse or via keyboard shortcut (<kbd>Insert-J</kbd> or <kbd>CapsLock-Shift-Ctrl-J</kbd>).
+2. Press <kbd>O</kbd> for options.
+3. Pressing <kbd>B</kbd> for basic settings will then let you switch between keyboard types and adjust other options.
+
+**Note:** If you have a web browser running when you start JAWS, you may need to restart it before the screen reader will work properly with it.
+
+To quit JAWS, press <kbd>JAWS-F4</kbd>. If this keypress combination is unavailable (e.g., you don’t have function keys), you can quit JAWS and access settings via its system tray icon.
+
+### Using the JAWS text viewer
+
+JAWS has a text viewer that appears at the top of the screen and reflects much (though not all) of what is spoken. If it is not running by default on your machine, you can enable it via the JAWS system tray menu.
+
+1. Open the system tray menu with your mouse or via keyboard shortcut (<kbd>Insert-J</kbd> or <kbd>CapsLock-Shift-Ctrl-J</kbd>).
+2. Press <kbd>U</kbd> to open the utilities submenu.
+3. Press <kbd>V</kbd> to open the text viewer options.
+4. Select "Show Text Viewer" and press <kbd>Enter</kbd> to toggle the text viewer.
+
+Settings for the text viewer can also be opened via this same submenu.
+
+## Narrator (Windows)
+
+- Narrator is included with Windows.
+- Commonly paired with: Edge
+- [Keyboard shortcuts](https://dequeuniversity.com/screenreaders/narrator-keyboard-shortcuts) (from Deque)
+
+### Getting started
+
+To start and stop Narrator, press <kbd>Windows-Ctrl-Enter</kbd> on your keyboard. Starting Narrator via this shortcut also opens the Narrator dashboard, which includes usage guides and settings.
+
+<kbd>Insert</kbd> and <kbd>CapsLock</kbd> can both be assigned as Narrator modifier keys in its settings. To open Narrator settings when the dashboard is closed, press <kbd>Windows-Ctrl-N</kbd>.
+
+## Orca (Linux)
+
+- Orca is included with many Linux distros.
+- Commonly paired with: Firefox
+- Keyboard shortcuts (from Accessibility Support)
+
+### Getting started
+
+To start Orca for the first time and open its settings dialog, type `orca -s` in your terminal program.
+
+Within the settings app, you can indicate whether you are using a full or laptop keyboard, change voice options, etc. As with Windows screen readers, <kbd>Insert</kbd> is the default <kbd>Orca</kbd> modifier key used in keyboard shortcuts, but switching to laptop mode assigns <kbd>CapsLock</kbd> to <kbd>Orca</kbd>.
+
+Once you have the settings how you like them, you can just type `orca` in a terminal to start the screen reader in subsequent sessions.
+
+To stop Orca, press <kbd>Ctrl-C</kbd> in the same terminal window in which you started it. Or you can use the keyboard shortcut <kbd>Windows-Alt-S</kbd> (or the equivalent keys on your keyboard, like <kbd>Command-Opt-S</kbd> on a Mac) to toggle Orca on and off.
+
+**Note:** If you have a web browser running when you start Orca, you _must_ restart it before the screen reader will work properly with it.

--- a/docs/accessibility/screen-readers-mobile.md
+++ b/docs/accessibility/screen-readers-mobile.md
@@ -1,0 +1,56 @@
+---
+title: "Screen readers: mobile"
+sidenavTitle: "Screen readers: mobile"
+permalink: /accessibility/screen-readers-mobile/index.html
+tags:
+  - accessibility
+order: 72
+---
+
+On mobile devices, you will use touchscreen gestures and taps instead of a keyboard to navigate the page and activate interactive elements.
+For basic navigation, you can swipe right, left, up, and down with one finger to move forward and backward through the page, and then double-tap to activate form controls and links. Each platform has many other gestures for more advanced navigation. View the linked gesture shortcuts pages within each section for more guidance.
+
+## VoiceOver (iOS)
+
+- VoiceOver is included with iOS.
+- Commonly paired with: Safari
+- [Gesture shortcuts](https://dequeuniversity.com/screenreaders/voiceover-ios-shortcuts) (from Deque)
+
+### Getting started
+
+There are several ways to start and stop VoiceOver in iOS:
+
+- If you’ve added VoiceOver as an Accessibility Shortcut (by going to Settings → Accessibility → Accessibility Shortcut and checking "VoiceOver"), you can toggle it by pressing your side button three times in rapid succession. (On non-Face-ID devices, click the Home button three times, instead.)
+- If you’ve added it to Control Center (by going to Settings → Control Center and pressing the add symbol for "Accessibility Shortcuts"), you can toggle VoiceOver there.
+- If you have Siri enabled, you can say, "Turn VoiceOver on/off."
+- You can toggle it in your device’s Settings → Accessibility → VoiceOver section. (This is also where you can customize VoiceOver to your preferences.)
+
+### Using the Rotor
+
+One of VoiceOver’s most powerful tools is the Rotor. The Rotor is a virtual dial you can turn to let you navigate by categories like lines, words, links, form elements, headings, and so on.
+
+Turn the rotor on by placing two fingers on your screen (e.g., thumb and forefinger) and twisting them clockwise or counterclockwise (like turning a dial). VoiceOver will announce the currently selected category as you twist. For example, twist until you hear "Headings." If you now swipe up and down on the page, VoiceOver will move from heading to heading, and you can then swipe right and left to have the content around that heading read to you.
+
+The Rotor also includes an option for setting VoiceOver’s speaking rate, if you’d like to adjust that setting.
+
+## TalkBack (Android)
+
+- TalkBack is included with Android.
+- Commonly paired with: Chrome
+- [Gesture shortcuts](https://dequeuniversity.com/screenreaders/talkback-shortcuts) (from Deque)
+
+### Getting started
+
+There are several ways to start and stop TalkBack for Android:
+
+- Toggle Talkback by pressing and holding both the volume up and volume down buttons simultaneously for a few seconds.
+- If you have Google Assistant enabled, you can say, "Turn TalkBack on/off."
+- Go to Settings → Accessibility → TalkBack and select or deselect the "Use TalkBack" option. (This is also where you can adjust your screen reader preferences.)
+
+### Using reading controls
+
+Similar to iOS’s Rotor, Talkback’s reading controls let you navigate by categories like headings, links, or words. To change the current reading controls selection, quickly swipe up and then down (or vice versa) until TalkBack announces the category you want to use.
+
+Once you’ve selected a category, swipe up or down to navigate the page by that category, and then right or left to navigate content adjacent to the current heading, link, or whatever else you’ve navigated to.
+
+TalkBack’s speaking rate can also be adjusted within reading controls.

--- a/docs/accessibility/screen-readers-mobile.md
+++ b/docs/accessibility/screen-readers-mobile.md
@@ -4,7 +4,7 @@ sidenavTitle: "Screen readers: mobile"
 permalink: /accessibility/screen-readers-mobile/index.html
 tags:
   - accessibility
-order: 72
+order: 102
 ---
 
 On mobile devices, you will use touchscreen gestures and taps instead of a keyboard to navigate the page and activate interactive elements.

--- a/docs/accessibility/screen-readers-mobile.md
+++ b/docs/accessibility/screen-readers-mobile.md
@@ -1,8 +1,7 @@
 ---
 title: "Mobile screen readers"
 permalink: /accessibility/screen-readers-mobile/index.html
-tags:
-  - accessibility
+
 order: 102
 ---
 

--- a/docs/accessibility/screen-readers-mobile.md
+++ b/docs/accessibility/screen-readers-mobile.md
@@ -1,14 +1,10 @@
 ---
-title: "Screen readers: mobile"
-sidenavTitle: "Screen readers: mobile"
+title: "Mobile screen readers"
 permalink: /accessibility/screen-readers-mobile/index.html
 tags:
   - accessibility
 order: 102
 ---
-
-On mobile devices, you will use touchscreen gestures and taps instead of a keyboard to navigate the page and activate interactive elements.
-For basic navigation, you can swipe right, left, up, and down with one finger to move forward and backward through the page, and then double-tap to activate form controls and links. Each platform has many other gestures for more advanced navigation. View the linked gesture shortcuts pages within each section for more guidance.
 
 ## VoiceOver (iOS)
 

--- a/docs/accessibility/screen-readers.md
+++ b/docs/accessibility/screen-readers.md
@@ -55,7 +55,7 @@ Each screen reader also has its own set of keyboard shortcuts to navigate and re
   </rh-tile>
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#narrator-(windows)">Narrator (Windows)</a></h3>
-    Narrator is the built-in screen reader for Windows 10 and 11.
+    Narrator is the built-in screen reader for Windows.
   </rh-tile>
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#orca-(linux)">Orca (Linux)</a></h3>

--- a/docs/accessibility/screen-readers.md
+++ b/docs/accessibility/screen-readers.md
@@ -4,35 +4,24 @@ sidenavTitle: Screen reader testing
 permalink: /accessibility/screen-readers/index.html
 tags:
   - accessibility
-order: 70
+order: 100
 importElements:
   - rh-tile
 ---
 
-<script type="module" data-helmet>
-  import '@rhds/elements/rh-tile/rh-tile-group.js';
-  import '@rhds/elements/rh-tile/rh-tile.js';
-</script>
-
 <link rel="stylesheet"
       data-helmet
       href="/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-lightdom.css">
-<link rel="stylesheet"
-      data-helmet
-      href="/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-group.css">
-<style>
-rh-tile-group {
-display: flex;
-align-items: top;
-flex-wrap: wrap;
-column-gap: var(--rh-space-2xl, 32px);
-row-gap: var(--rh-space-2xl, 32px);
-margin-inline-end: var(--rh-space-md, 8px);
-}
 
-rh-tile {
-width: 320px;
-}
+<style>
+  rh-tile {
+    margin-block: var(--rh-space-3xl, 48px);
+    max-width: 320px;
+  }
+
+  rh-tile [slot="headline"] {
+    font-weight: var(--rh-font-weight-heading-bold, 700);
+  }
 </style>
 
 Our screen reader testing pages provide some quick guidance for starting, stopping, and changing the settings of various screen readers. They also offer screen-reader-specific bonus tips and links to third-party resources like keyboard/gesture shortcut guides.
@@ -59,7 +48,6 @@ But if you’re either pressed for time or have access to multiple operating sys
 - iOS: Safari and VoiceOver
 - Android: Chrome and TalkBack
 
-  <rh-tile-group>
     <rh-tile compact="">
       <h2 slot="headline"><a href="#top">Link1</a></h2>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -72,4 +60,3 @@ But if you’re either pressed for time or have access to multiple operating sys
       <h2 slot="headline"><a href="#top">Link3</a></h2>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     </rh-tile>
-  </rh-tile-group>

--- a/docs/accessibility/screen-readers.md
+++ b/docs/accessibility/screen-readers.md
@@ -45,7 +45,7 @@ Each screen reader also has its own set of keyboard shortcuts to navigate and re
 <nav class="grid xs-two-columns sm-three-columns">
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#voiceover-(macos)">VoiceOver (macOS)</a></h3>
-    VoiceOver is a screen reader that comes packaged with macOS.
+    VoiceOver is the built-in screen reader for macOS.
   </rh-tile>
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#nvda-(windows)">NVDA (Windows)</a></h3>
@@ -57,7 +57,7 @@ Each screen reader also has its own set of keyboard shortcuts to navigate and re
   </rh-tile>
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#narrator-(windows)">Narrator (Windows)</a></h3>
-    Narrator comes packaged with Windows 10 and 11.
+    Narrator is the built-in screen reader for Windows 10 and 11.
   </rh-tile>
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#orca-(linux)">Orca (Linux)</a></h3>
@@ -75,11 +75,11 @@ For basic navigation, you can swipe right, left, up, and down with one finger to
 <nav class="grid xs-two-columns sm-three-columns">
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-mobile/#voiceover-(ios)">VoiceOver (iOS)</a></h3>
-    VoiceOver comes preinstalled on iOS and iPadOS devices.
+    VoiceOver is the built-in screen reader for iOS and iPadOS devices.
   </rh-tile>
   <rh-tile compact="">
     <h3 slot="headline"><a href="/accessibility/screen-readers-mobile/#talkback-(android)">Talkback (Android)</a></h3>
-    TalkBack comes preinstalled on Android devices.
+    TalkBack is the built-in screen reader for most Android devices.
   </rh-tile>
 </nav>
 

--- a/docs/accessibility/screen-readers.md
+++ b/docs/accessibility/screen-readers.md
@@ -19,8 +19,6 @@ importElements:
   }
 </style>
 
-Here, we provide some quick guidance for starting, stopping, and changing the settings of various readers. Each how-to section offers screen-reader-specific bonus tips and links to third-party resources like keyboard/gesture shortcut guides.
-
 ## Why test with screen readers?
 
 When testing with screen readers, our goal is to verify that an assistive tech user will have an experience equivalent to that of any other user. Tests may include the following:
@@ -40,7 +38,7 @@ After turning on your computer’s screen reader and opening your browser, use y
 
 Each screen reader also has its own set of keyboard shortcuts to navigate and read non-interactive content within an experience. Different keypresses can start (or stop) reading the page, jump to the next heading element, move vertically and horizontally among table cells, and so on. Links to keyboard shortcut resources are included in each screen reader’s section.
 
-### How to use computer screen readers
+### Getting started with computer screen readers
 
 <nav class="grid xs-two-columns sm-three-columns">
   <rh-tile compact="">
@@ -70,7 +68,7 @@ Each screen reader also has its own set of keyboard shortcuts to navigate and re
 On mobile devices, you will use touchscreen gestures and taps instead of a keyboard to navigate the page and activate interactive elements.
 For basic navigation, you can swipe right, left, up, and down with one finger to move forward and backward through the page, and then double-tap to activate form controls and links. Each platform has many other gestures for more advanced navigation. View the linked gesture shortcuts pages within each section for more guidance.
 
-### How to use mobile screen readers
+### Getting started with mobile screen readers
 
 <nav class="grid xs-two-columns sm-three-columns">
   <rh-tile compact="">

--- a/docs/accessibility/screen-readers.md
+++ b/docs/accessibility/screen-readers.md
@@ -1,17 +1,43 @@
 ---
-title: Screen reader testing basics
-sidenavTitle: Screen reader basics
+title: Screen readers
+sidenavTitle: Screen reader testing
 permalink: /accessibility/screen-readers/index.html
 tags:
   - accessibility
 order: 70
+importElements:
+  - rh-tile
 ---
 
-## General info
+<script type="module" data-helmet>
+  import '@rhds/elements/rh-tile/rh-tile-group.js';
+  import '@rhds/elements/rh-tile/rh-tile.js';
+</script>
 
-This page provides some quick guidance for starting, stopping, and changing the settings of various screen readers. It also offers screen-reader-specific bonus tips and links to third-party resources like keyboard/gesture shortcut guides.
+<link rel="stylesheet"
+      data-helmet
+      href="/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-lightdom.css">
+<link rel="stylesheet"
+      data-helmet
+      href="/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-group.css">
+<style>
+rh-tile-group {
+display: flex;
+align-items: top;
+flex-wrap: wrap;
+column-gap: var(--rh-space-2xl, 32px);
+row-gap: var(--rh-space-2xl, 32px);
+margin-inline-end: var(--rh-space-md, 8px);
+}
 
-### Why test with screen readers?
+rh-tile {
+width: 320px;
+}
+</style>
+
+Our screen reader testing pages provide some quick guidance for starting, stopping, and changing the settings of various screen readers. They also offer screen-reader-specific bonus tips and links to third-party resources like keyboard/gesture shortcut guides.
+
+## Why test with screen readers?
 
 When testing with screen readers, our goal is to verify that an assistive tech user will have an experience equivalent to that of any other user. Tests may include the following:
 
@@ -19,7 +45,7 @@ When testing with screen readers, our goal is to verify that an assistive tech u
 2. Can you accomplish all the same tasks with and without assistive tech (e.g. navigating the site, submitting forms, adding items to a cart, etc.)?
 3. When page contents are read, are you presented with all the meaningful info you would expect as a visual user? (This includes status updates on dynamic pages.)
 
-### Browser and screen reader pairings
+## Browser and screen reader pairings
 
 If you can only test on one platform, it never hurts to try your screen reader with as many browsers as possible. For example, if you only have a Mac, go ahead and pair VoiceOver with Safari, Chrome, and Firefox.
 
@@ -33,215 +59,17 @@ But if you’re either pressed for time or have access to multiple operating sys
 - iOS: Safari and VoiceOver
 - Android: Chrome and TalkBack
 
-## Computer screen readers
-
-On computers, screen reader testing often lets you perform two tests simultaneously. First, it ensures that all meaningful web content and interactions are available to assistive tech. Second, it helps you verify that your experiences are keyboard operable (which is a [WCAG requirement](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html)).
-
-After turning on your computer’s screen reader and opening your browser, use your keyboard to access the entire experience, top to bottom. Use the <kbd>Tab</kbd>, <kbd>Shift-Tab</kbd>, and <kbd>↑ → ↓ ←</kbd> keys to move among (and within) focusable elements like links, form controls, and interactive components. And you can then use other keys like <kbd>Space</kbd>, <kbd>Enter</kbd>, and <kbd>Escape</kbd> to interact with those elements.
-
-Each screen reader also has its own set of keyboard shortcuts to navigate and read non-interactive content within an experience. Different keypresses can start (or stop) reading the page, jump to the next heading element, move vertically and horizontally among table cells, and so on. Links to keyboard shortcut resources are included in each screen reader’s section, below.
-
-### VoiceOver (macOS)
-
-- VoiceOver is included with MacOS.
-- Commonly paired with: Safari
-- [Keyboard shortcuts (from Deque)](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts)
-
-#### Setting up your Mac and Safari
-
-Before testing with VoiceOver, you may need to enable keyboard navigation—for both your Mac and Safari.
-
-To turn on keyboard navigation for your Mac:
-
-1. Go to the Keyboard section in System Settings.
-2. Turn on the "Keyboard navigation" switch within this section.
-
-(For MacOS versions before MacOS 13 Ventura, enter the Shortcuts tab panel in the System Settings' Keyboard section and check the "Use keyboard navigation..." checkbox.)
-
-In Safari, you may need the additional step of enabling the browser's tab navigation:
-
-1. Open Safari’s Preferences/Settings window
-2. Enter the Advanced tab.
-3. Check the "Press Tab to highlight each item on a webpage" checkbox.
-
-#### Getting started with VoiceOver
-
-To toggle VoiceOver on and off, press <kbd>Command-F5</kbd>. Or, if you have a Touch ID keyboard, hold down <kbd>Command</kbd> and quickly press the <kbd>Touch ID</kbd> key three times.
-
-To customize VoiceOver settings (e.g., the voice), open the VoiceOver Utility on your computer (e.g., via <kbd>Command-Space</kbd> and then typing "voiceover utility").
-
-By default, the <kbd>Ctrl-Opt</kbd> keypress combo is what's called the <kbd>VO</kbd> modifier. You can execute many VoiceOver commands with this modifier. For example, <kbd>VO-H</kbd> (or <kbd>Ctrl-Opt-H</kbd>) launches VoiceOver Help (which can then be exited via <kbd>Esc</kbd>).
-
-#### Using the transcript window and muting VoiceOver
-
-To visually reinforce what you’re hearing, VoiceOver’s transcript window reflects the content currently being read. If VoiceOver's audio is too distracting (e.g., maybe you're presenting it in a meeting and want to hear the other participants), you can even mute it via the "Mute speech" checkbox in the VoiceOver Utility’s Speech tab. The transcript window will continue to appear and display content as if it were being read aloud.
-
-While speech is muted, the shortcut for continually reading page content (<kbd>VO-A</kbd>) will be deactivated, though you can still use the <kbd>↑ → ↓ ←</kbd> keys to move through and test non-interactive content.
-
-While transcript windows can be helpful, there are cases where the audio may not match a transcript exactly. So, when testing, confirm any issues with the audio on.
-
-### NVDA (Windows)
-
-- [Download and install](https://www.nvaccess.org/download/) NVDA to use it. It’s free.
-- Commonly paired with: Firefox (and Chrome, if you don’t have access to JAWS)
-- [Keyboard shortcuts](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts) (from Deque)
-
-#### Getting started
-
-You can start NVDA via any of the following methods:
-
-- Open it in the Windows Start menu.
-- Press the <kbd>Windows</kbd> key, type <code>NVDA</code> and then <kbd>Enter</kbd>.
-- Click the NVDA desktop shortcut icon (if available).
-
-When NVDA starts, a welcome dialog will appear. Here, you can specify what kind of keyboard you’re using, so NVDA knows what to use as your <kbd>NVDA</kbd> modifier key for keyboard shortcuts:
-
-- If your keyboard has an <kbd>Insert</kbd> key (most full Windows keyboards do), then you can leave "Use CapsLock as an NVDA modifier key" unchecked. <kbd>Insert</kbd> will be assigned as your <kbd>NVDA</kbd> modifier key.
-- If your keyboard does not have an <kbd>Insert</kbd> key (many laptop keyboards do not), check the "Use CapsLock…" checkbox. <kbd>CapsLock</kbd> will be assigned as your <kbd>NVDA</kbd> key.
-
-To customize NVDA’s settings, press <kbd>NVDA-N</kbd>. This brings up an options menu, which you can then navigate via arrows and the <kbd>Enter</kbd> key.
-
-To quit NVDA, press <kbd>NVDA-Q</kbd>. You can also quit NVDA and access settings via its system tray icon.
-
-#### Displaying the speech viewer
-
-Like MacOS VoiceOver, NVDA offers an option for using the screen reader visually. This speech viewer keeps a running log of all content read during a session, for quick reference.
-
-To open the speech viewer:
-
-1. Press <kbd>NVDA-N</kbd> to open the app’s settings.
-2. Press <kbd>T</kbd> to open the tools menu.
-3. Arrow down to the "Speech Viewer" option and press <kbd>Enter</kbd>.
-
-The speech viewer window will appear on your screen. The viewer window has a "Show Speech Viewer on Startup" checkbox, which you can check to make sure it always appears when you run NVDA.
-
-As with VoiceOver’s transcript window, there are cases where audio may not match the speech viewer’s log exactly. So, when testing, confirm any issues with audio on.
-
-#### Creating a portable copy
-
-One handy thing about NVDA is that you can create a portable copy to place on a flash drive and use on any Windows computer. This can be useful if you need to demonstrate something on someone else’s machine, or if you yourself switch computers.
-
-To make a portable copy:
-
-1. Start NVDA and open its settings (<kbd>NVDA-N</kbd>).
-2. Press <kbd>T</kbd> to open the tools menu.
-3. Arrow down to the "Create portable copy" option and press <kbd>Enter</kbd>.
-4. Choose a destination for this copy of NVDA.
-
-### JAWS (Windows)
-
-- [Download and install JAWS](https://support.freedomscientific.com/Downloads/JAWS) to use it. It’s commercial software with a trial mode.
-- Commonly paired with: Chrome
-- [Keyboard shortcuts (from the official Freedom Scientific site)](https://www.freedomscientific.com/training/jaws/hotkeys/)
-- [Keyboard shortcuts (from Deque)](https://dequeuniversity.com/screenreaders/jaws-keyboard-shortcuts)
-
-#### Getting started
-
-You can start JAWS via any of the following methods:
-
-- Open it in the Windows Start menu.
-- Press the <kbd>Windows</kbd> key, type <code>JAWS</code>, and then <kbd>Enter</kbd>.
-- Click the JAWS desktop shortcut icon (if available).
-
-On keyboards with an <kbd>Insert</kbd> key, that key will be assigned as your <kbd>JAWS</kbd> modifier key for keyboard shortcuts. On keyboards without an <kbd>Insert</kbd> key, the <kbd>CapsLock</kbd> key will be your <kbd>JAWS</kbd> key. You can test this out by pressing <kbd>JAWS-F12</kbd> to read out the system time.
-
-To customize your JAWS settings, use its system tray menu:
-
-1. Open the system tray menu with your mouse or via keyboard shortcut (<kbd>Insert-J</kbd> or <kbd>CapsLock-Shift-Ctrl-J</kbd>).
-2. Press <kbd>O</kbd> for options.
-3. Pressing <kbd>B</kbd> for basic settings will then let you switch between keyboard types and adjust other options.
-
-**Note:** If you have a web browser running when you start JAWS, you may need to restart it before the screen reader will work properly with it.
-
-To quit JAWS, press <kbd>JAWS-F4</kbd>. If this keypress combination is unavailable (e.g., you don’t have function keys), you can quit JAWS and access settings via its system tray icon.
-
-#### Using the JAWS text viewer
-
-JAWS has a text viewer that appears at the top of the screen and reflects much (though not all) of what is spoken. If it is not running by default on your machine, you can enable it via the JAWS system tray menu.
-
-1. Open the system tray menu with your mouse or via keyboard shortcut (<kbd>Insert-J</kbd> or <kbd>CapsLock-Shift-Ctrl-J</kbd>).
-2. Press <kbd>U</kbd> to open the utilities submenu.
-3. Press <kbd>V</kbd> to open the text viewer options.
-4. Select "Show Text Viewer" and press <kbd>Enter</kbd> to toggle the text viewer.
-
-Settings for the text viewer can also be opened via this same submenu.
-
-### Narrator (Windows)
-
-- Narrator is included with Windows.
-- Commonly paired with: Edge
-- [Keyboard shortcuts](https://dequeuniversity.com/screenreaders/narrator-keyboard-shortcuts) (from Deque)
-
-#### Getting started
-
-To start and stop Narrator, press <kbd>Windows-Ctrl-Enter</kbd> on your keyboard. Starting Narrator via this shortcut also opens the Narrator dashboard, which includes usage guides and settings.
-
-<kbd>Insert</kbd> and <kbd>CapsLock</kbd> can both be assigned as Narrator modifier keys in its settings. To open Narrator settings when the dashboard is closed, press <kbd>Windows-Ctrl-N</kbd>.
-
-### Orca (Linux)
-
-- Orca is included with many Linux distros.
-- Commonly paired with: Firefox
-- Keyboard shortcuts (from Accessibility Support)
-
-#### Getting started
-
-To start Orca for the first time and open its settings dialog, type `orca -s` in your terminal program.
-
-Within the settings app, you can indicate whether you are using a full or laptop keyboard, change voice options, etc. As with Windows screen readers, <kbd>Insert</kbd> is the default <kbd>Orca</kbd> modifier key used in keyboard shortcuts, but switching to laptop mode assigns <kbd>CapsLock</kbd> to <kbd>Orca</kbd>.
-
-Once you have the settings how you like them, you can just type `orca` in a terminal to start the screen reader in subsequent sessions.
-
-To stop Orca, press <kbd>Ctrl-C</kbd> in the same terminal window in which you started it. Or you can use the keyboard shortcut <kbd>Windows-Alt-S</kbd> (or the equivalent keys on your keyboard, like <kbd>Command-Opt-S</kbd> on a Mac) to toggle Orca on and off.
-
-**Note:** If you have a web browser running when you start Orca, you _must_ restart it before the screen reader will work properly with it.
-
-## Mobile screen readers
-
-On mobile devices, you will use touchscreen gestures and taps instead of a keyboard to navigate the page and activate interactive elements.
-For basic navigation, you can swipe right, left, up, and down with one finger to move forward and backward through the page, and then double-tap to activate form controls and links. Each platform has many other gestures for more advanced navigation. View the linked gesture shortcuts pages within each section for more guidance.
-
-### VoiceOver (iOS)
-
-- VoiceOver is included with iOS.
-- Commonly paired with: Safari
-- [Gesture shortcuts](https://dequeuniversity.com/screenreaders/voiceover-ios-shortcuts) (from Deque)
-
-#### Getting started
-
-There are several ways to start and stop VoiceOver in iOS:
-
-- If you’ve added VoiceOver as an Accessibility Shortcut (by going to Settings → Accessibility → Accessibility Shortcut and checking "VoiceOver"), you can toggle it by pressing your side button three times in rapid succession. (On non-Face-ID devices, click the Home button three times, instead.)
-- If you’ve added it to Control Center (by going to Settings → Control Center and pressing the add symbol for "Accessibility Shortcuts"), you can toggle VoiceOver there.
-- If you have Siri enabled, you can say, "Turn VoiceOver on/off."
-- You can toggle it in your device’s Settings → Accessibility → VoiceOver section. (This is also where you can customize VoiceOver to your preferences.)
-
-#### Using the Rotor
-
-One of VoiceOver’s most powerful tools is the Rotor. The Rotor is a virtual dial you can turn to let you navigate by categories like lines, words, links, form elements, headings, and so on.
-
-Turn the rotor on by placing two fingers on your screen (e.g., thumb and forefinger) and twisting them clockwise or counterclockwise (like turning a dial). VoiceOver will announce the currently selected category as you twist. For example, twist until you hear "Headings." If you now swipe up and down on the page, VoiceOver will move from heading to heading, and you can then swipe right and left to have the content around that heading read to you.
-
-The Rotor also includes an option for setting VoiceOver’s speaking rate, if you’d like to adjust that setting.
-
-### TalkBack (Android)
-
-- TalkBack is included with Android.
-- Commonly paired with: Chrome
-- [Gesture shortcuts](https://dequeuniversity.com/screenreaders/talkback-shortcuts) (from Deque)
-
-#### Getting started
-
-There are several ways to start and stop TalkBack for Android:
-
-- Toggle Talkback by pressing and holding both the volume up and volume down buttons simultaneously for a few seconds.
-- If you have Google Assistant enabled, you can say, "Turn TalkBack on/off."
-- Go to Settings → Accessibility → TalkBack and select or deselect the "Use TalkBack" option. (This is also where you can adjust your screen reader preferences.)
-
-#### Using reading controls
-
-Similar to iOS’s Rotor, Talkback’s reading controls let you navigate by categories like headings, links, or words. To change the current reading controls selection, quickly swipe up and then down (or vice versa) until TalkBack announces the category you want to use.
-
-Once you’ve selected a category, swipe up or down to navigate the page by that category, and then right or left to navigate content adjacent to the current heading, link, or whatever else you’ve navigated to.
-
-TalkBack’s speaking rate can also be adjusted within reading controls.
+  <rh-tile-group>
+    <rh-tile compact="">
+      <h2 slot="headline"><a href="#top">Link1</a></h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </rh-tile>
+    <rh-tile compact="">
+      <h2 slot="headline"><a href="#top">Link2</a></h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </rh-tile>
+    <rh-tile compact="">
+      <h2 slot="headline"><a href="#top">Link3</a></h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </rh-tile>
+  </rh-tile-group>

--- a/docs/accessibility/screen-readers.md
+++ b/docs/accessibility/screen-readers.md
@@ -1,6 +1,6 @@
 ---
 title: Screen readers
-sidenavTitle: Screen reader testing
+sidenavTitle: Screen readers
 permalink: /accessibility/screen-readers/index.html
 tags:
   - accessibility
@@ -14,17 +14,12 @@ importElements:
       href="/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-lightdom.css">
 
 <style>
-  rh-tile {
-    margin-block: var(--rh-space-3xl, 48px);
-    max-width: 320px;
-  }
-
   rh-tile [slot="headline"] {
     font-weight: var(--rh-font-weight-heading-bold, 700);
   }
 </style>
 
-Our screen reader testing pages provide some quick guidance for starting, stopping, and changing the settings of various screen readers. They also offer screen-reader-specific bonus tips and links to third-party resources like keyboard/gesture shortcut guides.
+Here, we provide some quick guidance for starting, stopping, and changing the settings of various readers. Each how-to section offers screen-reader-specific bonus tips and links to third-party resources like keyboard/gesture shortcut guides.
 
 ## Why test with screen readers?
 
@@ -33,6 +28,60 @@ When testing with screen readers, our goal is to verify that an assistive tech u
 1. Can you use and understand the purpose of all interactive elements on the page?
 2. Can you accomplish all the same tasks with and without assistive tech (e.g. navigating the site, submitting forms, adding items to a cart, etc.)?
 3. When page contents are read, are you presented with all the meaningful info you would expect as a visual user? (This includes status updates on dynamic pages.)
+
+## Computer screen readers
+
+On computers, screen reader testing often lets you perform two tests simultaneously:
+
+1. It ensures that all meaningful web content and interactions are available to assistive tech.
+2. It helps you verify that your experiences are keyboard operable (which is a [WCAG requirement](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html)).
+
+After turning on your computer’s screen reader and opening your browser, use your keyboard to access the entire experience, top to bottom. Use the <kbd>Tab</kbd>, <kbd>Shift-Tab</kbd>, and <kbd>↑ → ↓ ←</kbd> keys to move among (and within) focusable elements like links, form controls, and interactive components. And you can then use other keys like <kbd>Space</kbd>, <kbd>Enter</kbd>, and <kbd>Escape</kbd> to interact with those elements.
+
+Each screen reader also has its own set of keyboard shortcuts to navigate and read non-interactive content within an experience. Different keypresses can start (or stop) reading the page, jump to the next heading element, move vertically and horizontally among table cells, and so on. Links to keyboard shortcut resources are included in each screen reader’s section.
+
+### How to use computer screen readers
+
+<nav class="grid xs-two-columns sm-three-columns">
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#voiceover-(macos)">VoiceOver (macOS)</a></h3>
+    VoiceOver is a screen reader that comes packaged with macOS.
+  </rh-tile>
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#nvda-(windows)">NVDA (Windows)</a></h3>
+    NVDA is a free, downloadable screen reader for Windows. 
+  </rh-tile>
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#jaws-(windows)">JAWS (Windows)</a></h3>
+    JAWS is a paid, downloadable screen reader for Windows.
+  </rh-tile>
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#narrator-(windows)">Narrator (Windows)</a></h3>
+    Narrator comes packaged with Windows 10 and 11.
+  </rh-tile>
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-computer/#orca-(linux)">Orca (Linux)</a></h3>
+    Orca comes packaged with GNOME and other desktop environments.
+  </rh-tile>
+</nav>
+
+## Mobile screen readers
+
+On mobile devices, you will use touchscreen gestures and taps instead of a keyboard to navigate the page and activate interactive elements.
+For basic navigation, you can swipe right, left, up, and down with one finger to move forward and backward through the page, and then double-tap to activate form controls and links. Each platform has many other gestures for more advanced navigation. View the linked gesture shortcuts pages within each section for more guidance.
+
+### How to use mobile screen readers
+
+<nav class="grid xs-two-columns sm-three-columns">
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-mobile/#voiceover-(ios)">VoiceOver (iOS)</a></h3>
+    VoiceOver comes preinstalled on iOS and iPadOS devices.
+  </rh-tile>
+  <rh-tile compact="">
+    <h3 slot="headline"><a href="/accessibility/screen-readers-mobile/#talkback-(android)">Talkback (Android)</a></h3>
+    TalkBack comes preinstalled on Android devices.
+  </rh-tile>
+</nav>
 
 ## Browser and screen reader pairings
 
@@ -47,16 +96,3 @@ But if you’re either pressed for time or have access to multiple operating sys
 - Linux: Firefox and Orca
 - iOS: Safari and VoiceOver
 - Android: Chrome and TalkBack
-
-    <rh-tile compact="">
-      <h2 slot="headline"><a href="#top">Link1</a></h2>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </rh-tile>
-    <rh-tile compact="">
-      <h2 slot="headline"><a href="#top">Link2</a></h2>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </rh-tile>
-    <rh-tile compact="">
-      <h2 slot="headline"><a href="#top">Link3</a></h2>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </rh-tile>


### PR DESCRIPTION
## What I did

1. Split the screen reader section into three pages
2. Reorganized the a11y sidenav items
3. Cleaned up some typos in the a11y section


## Testing Instructions

### Page splitting
1. Go to the main [screen reader page in the DP](https://deploy-preview-1954--red-hat-design-system.netlify.app/accessibility/screen-readers/).
2. Check the tile links in the "Computer screen reader" and "Mobile screen reader" sections and ensure they point to the appropriate page and heading.

### Sidenav re-org
1. Go to [any page in the DP](https://deploy-preview-1954--red-hat-design-system.netlify.app/accessibility/screen-readers/).
2. Check the sidenav and ensure all pages in the "Accessibility" section are listed alphabetically.
