### PR TITLE
fix(code-block): prism client and prerendered syntax highlighting

### DIFF
--- a/.changeset/nasty-wolves-bake.md
+++ b/.changeset/nasty-wolves-bake.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-code-block>`: fixed client side and prerendered syntax highlighting via Prism
+`<rh-code-block>`: ensure that syntax colours and styles are applied when the element upgrades

--- a/.changeset/nasty-wolves-bake.md
+++ b/.changeset/nasty-wolves-bake.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-code-block>`: fixed client side and prerendered syntax highlighting via Prism

--- a/elements/rh-code-block/docs/30-code.md
+++ b/elements/rh-code-block/docs/30-code.md
@@ -26,7 +26,7 @@ use the correct mime type for your content, e.g. `text/html` for HTML content.
 
 <rh-alert state="warning">
  <h3 slot="header">Warning</h3>
-  <p>When slotting HTML content into the code-block, if that HTML content contains a `</script>` end tag, you must escape it.</p>
+  <p>When slotting HTML content into the code-block, if that HTML content contains a <code>&lt;/script&gt;</code> end tag, you must escape it.</p>
 </rh-alert>
 
 One approach to escaping script tags that is to close the containing `<script 

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -150,6 +150,7 @@ export class RhCodeBlock extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     this.#ro.observe(this);
+    this.#onSlotChange();
   }
 
   override disconnectedCallback() {


### PR DESCRIPTION
## What I did

1. Fix Prism syntax highlighting for client and prerendered demos of Code Block
2. Fixed an [empty `<code>` tag](https://github.com/user-attachments/assets/7c9ec5d0-8e2f-4736-822f-e135a816ebc8) on the Code sub page of Code Block's docs.

## Testing Instructions

1. Open the following demos:
    * [Client Side Highlighting](https://deploy-preview-1973--red-hat-design-system.netlify.app/elements/code-block/demo/client-side-highlighting/)
    * [Prerendered Prism Highlighting](https://deploy-preview-1973--red-hat-design-system.netlify.app/elements/code-block/demo/prerendered-prism-highlighting/)
1. Verify syntax highlighting works
1. Compare to demos on `main`:
    * [Client Side Highlighting](https://ux.redhat.com/elements/code-block/demo/client-side-highlighting/)
    * [Prerendered Prism Highlighting](https://ux.redhat.com/elements/code-block/demo/prerendered-prism-highlighting/)
1. Does it look fixed?

## Notes to Reviewers

Fixes #1969, but does not fix the issue noted about the Demos page. That appears to be in `rh-surface` and may require more consideration. 

Massive shout out to @zeroedin for pairing on this, discovering the root of this issue, and coming up with a fix.