### PR TITLE
docs(home): fixing get started tiles

### DIFF
--- a/docs/index.njk
+++ b/docs/index.njk
@@ -40,6 +40,7 @@ title: Home
     <div class="grid xs-two-columns">
       <rh-tile>
         <img src="/assets/home/foundations.svg"
+            slot="image"
             alt="Foundations"
             width="300"
             height="131">
@@ -49,6 +50,7 @@ title: Home
 
       <rh-tile>
         <img src="/assets/home/elements.svg"
+            slot="image"
             alt="Elements"
             width="300"
             height="131">
@@ -58,6 +60,7 @@ title: Home
 
       <rh-tile>
         <img src="/assets/home/code-status.svg"
+            slot="image"
             alt="Code status"
             width="300"
             height="131">
@@ -67,6 +70,7 @@ title: Home
 
       <rh-tile>
         <img src="/assets/home/release-notes.svg"
+            slot="image"
             alt="Release notes"
             width="300"
             height="131">

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -44,7 +44,7 @@ title: Home
             alt="Foundations"
             width="300"
             height="131">
-        <h2 slot="headline"><a href="/foundations">Foundations</a></h2>
+        <h3 slot="headline"><a href="/foundations">Foundations</a></h3>
         <p>Design principles to help you create engaging layouts</p>
       </rh-tile>
 
@@ -54,7 +54,7 @@ title: Home
             alt="Elements"
             width="300"
             height="131">
-        <h2 slot="headline"><a href="/elements">Elements</a></h2>
+        <h3 slot="headline"><a href="/elements">Elements</a></h3>
         <p>Guidance to help you create interactive user interfaces</p>
       </rh-tile>
 
@@ -64,7 +64,7 @@ title: Home
             alt="Code status"
             width="300"
             height="131">
-        <h2 slot="headline"><a href="/design-code-status">Code status</a></h2>
+        <h3 slot="headline"><a href="/design-code-status">Code status</a></h3>
         <p>Track the status of our components and patterns</p>
       </rh-tile>
 
@@ -74,7 +74,7 @@ title: Home
             alt="Release notes"
             width="300"
             height="131">
-        <h2 slot="headline"><a href="/release-notes">Release notes</a></h2>
+        <h3 slot="headline"><a href="/release-notes">Release notes</a></h3>
         <p>Track the updates we're making to the design system</p>
       </rh-tile>
     </div>

--- a/docs/styles/pages/home.css
+++ b/docs/styles/pages/home.css
@@ -43,11 +43,6 @@
     container-name: get-started container;
   }
 
-  rh-tile > h2 {
-    font-size: var(--rh-font-size-heading-xs) !important;
-    margin-block-start: var(--rh-space-2xl) !important;
-  }
-
   #get-started > h2 {
     font-size: var(--rh-font-size-heading-lg);
     font-weight: var(--rh-font-weight-heading-medium);
@@ -60,11 +55,8 @@
     margin: 0 auto var(--rh-space-3xl);
   }
 
-  @container get-started (min-width: 768px) {
-    rh-tile h2 {
-      font-size: var(--rh-font-size-heading-sm) !important;
-      margin-block-start: var(--rh-space-2xl) !important;
-    }
+  rh-tile p {
+    margin-block: 0;
   }
 
   #contribute::part(header),


### PR DESCRIPTION
## What I did

1. Put the images in the `image` `slot` in Get Started tiles on the Docs Home, so that it looks better.


## Testing Instructions

1. Does it look cool?
