### PR TITLE
docs(uxdot-best-practice): change Do/Don't heading space and icons

### DIFF
--- a/uxdot/uxdot-best-practice.css
+++ b/uxdot/uxdot-best-practice.css
@@ -17,7 +17,7 @@ span {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--rh-space-sm);
+  gap: var(--rh-space-md);
 }
 
 #do span {

--- a/uxdot/uxdot-best-practice.ts
+++ b/uxdot/uxdot-best-practice.ts
@@ -13,7 +13,7 @@ export class UxdotBestPractice extends LitElement {
 
   render() {
     const { variant } = this;
-    const icon = variant === 'do' ? 'check-circle' : 'close-circle';
+    const icon = variant === 'do' ? 'check-circle-fill' : 'close-circle-fill';
     const title = variant === 'do' ? 'Do' : 'Don\'t';
     return html`
       <figure id="container">


### PR DESCRIPTION
## What I did

- Changed icons to their fill versions
- Used `--rh-space-md` for gap between icon and text

## Testing Instructions

1. Check any updated "Best practices" section, like [`<rh-health-index>`'s](https://deploy-preview-2034--red-hat-design-system.netlify.app/elements/health-index/guidelines/#best-practices) in the DP

## Notes to Reviewers
This addresses @coreyvickery's [comment](https://github.com/RedHat-UX/red-hat-design-system/issues/1449#issuecomment-2442352122) in #1449