### PR TITLE
Feat/lightdom css controller

### DIFF
--- a/docs/_includes/layouts/pages/element.11ty.ts
+++ b/docs/_includes/layouts/pages/element.11ty.ts
@@ -71,9 +71,9 @@ export default class ElementsPage extends Renderer<Context> {
     } = doc;
     const content = fileExists ? await this.renderFile(filePath, ctx) : '';
     const stylesheets = [
-      '/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css',
+      // '/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css',
       '/styles/samp.css',
-      ctx.doc.hasLightdom && `/assets/packages/@rhds/elements/elements/${tagName}/${tagName}-lightdom.css`,
+      // ctx.doc.hasLightdom && `/assets/packages/@rhds/elements/elements/${tagName}/${tagName}-lightdom.css`,
       isCodePage && '/styles/pages/code.css',
     ].filter(Boolean);
 
@@ -961,4 +961,3 @@ export default class ElementsPage extends Renderer<Context> {
     }
   }
 };
-

--- a/elements/rh-table/rh-table-lightdom.css
+++ b/elements/rh-table/rh-table-lightdom.css
@@ -1,4 +1,6 @@
 rh-table {
+  --_rhds-lightdom: rh-table;
+
   container: host / inline-size;
 
   & thead {

--- a/elements/rh-table/rh-table.ts
+++ b/elements/rh-table/rh-table.ts
@@ -1,3 +1,5 @@
+import type { ColorTheme } from '@rhds/elements/lib/context/color/consumer.js';
+
 import { LitElement, html, isServer } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -6,7 +8,8 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import { RequestSortEvent, RhSortButton } from './rh-sort-button.js';
 
-import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
+import { colorContextConsumer } from '@rhds/elements/lib/context/color/consumer.js';
+import { LightdomCSSController } from '@rhds/elements/lib/LightdomCSSController.js';
 
 import styles from './rh-table.css';
 
@@ -67,6 +70,8 @@ export class RhTable extends LitElement {
   get #summary(): HTMLElement | undefined {
     return this.querySelector('[slot="summary"]') as HTMLElement | undefined;
   }
+
+  #lightdom = new LightdomCSSController(this, import.meta.url);
 
   #internalColorPalette?: string | null;
 

--- a/lib/LightdomCSSController.ts
+++ b/lib/LightdomCSSController.ts
@@ -1,0 +1,50 @@
+import type { ReactiveController, ReactiveElement } from 'lit';
+
+import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
+import type { RHDSSSRController } from './ssr-controller.js';
+
+const handleAsText = (r: Response) => r.text();
+
+export class LightdomCSSController implements ReactiveController, RHDSSSRController {
+  isRHDSSSRController = true;
+
+  host: ReactiveElement;
+
+  #tagName: string;
+
+  /** URL to lightdom sheet, by convention it must be the tagName, with `-lightdom.css` suffix */
+  #url: URL;
+
+  #logger: Logger;
+
+  #computedStyles?: CSSStyleDeclaration;
+
+  constructor(
+    host: ReactiveElement,
+    /** import.meta.url from the element definition module */
+    url: string,
+  ) {
+    this.host = host;
+    this.#tagName = host.localName;
+    this.#url = new URL(`${this.#tagName}-lightdom.css`, url);
+    this.#logger = new Logger(host);
+    host.addController(this);
+  }
+
+  async hostConnected(): Promise<void> {
+    this.#computedStyles ??= getComputedStyle(this.host);
+    if (this.#computedStyles.getPropertyValue('--_rhds-lightdom') !== this.#tagName) {
+      const root = this.host.getRootNode();
+      if (root instanceof Document || root instanceof ShadowRoot) {
+        try {
+          const sheet = new CSSStyleSheet();
+          const css = await fetch(this.#url).then(handleAsText);
+          sheet.replaceSync(css);
+          root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
+        } catch (error) {
+          this.#logger.error(error);
+        }
+      }
+    }
+  };
+}

--- a/uxdot/uxdot-repo-status-checklist.ts
+++ b/uxdot/uxdot-repo-status-checklist.ts
@@ -17,8 +17,6 @@ export class UxdotRepoStatusChecklist extends UxdotRepoElement {
   render() {
     const status = this.getStatus(this.element!);
     return html`
-      <!-- TODO: remove lightdom after implementing auto-load-->
-      <link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">
       <div id="container">
         <rh-table>
           <table>

--- a/uxdot/uxdot-repo-status-list.ts
+++ b/uxdot/uxdot-repo-status-list.ts
@@ -15,8 +15,6 @@ export class UxdotRepoStatusList extends UxdotRepoElement {
   render() {
     const status = this.getStatus(this.element!);
     return html`
-      <!-- TODO: remove lightdom after implementing auto-load-->
-      <link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">
       <div id="container">
         <a href="#status-checklist" class="checklist">What do these mean?</a>
         <div id="inner-container">

--- a/uxdot/uxdot-repo-status-table.ts
+++ b/uxdot/uxdot-repo-status-table.ts
@@ -17,8 +17,6 @@ export class UxdotRepoStatusTable extends UxdotRepoElement {
   render() {
     const status = this.getStatus();
     return html`
-      <!-- TODO: remove lightdom after implementing auto-load-->
-      <link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">
       <div id="container">
         <rh-table>
           <table>

--- a/uxdot/uxdot-spacer-tokens-table.ts
+++ b/uxdot/uxdot-spacer-tokens-table.ts
@@ -48,8 +48,6 @@ export class UxdotSpacerTokensTable extends LitElement {
         .filter(Boolean);
 
     return html`
-      <!-- TODO: remove lightdom after implementing auto-load-->
-      <link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">
       <rh-table color-palette="${this.colorPalette}">
         <table>
           <caption>${this.caption}</caption>


### PR DESCRIPTION
## What I did

1. add new `LightdomCSSController` which auto-loads lightdom css
2. remove rh-table-lightdom.css from docs pages
3. add an `--_rhds-lightdom: rh-table` brand to the table lightdom stylesheet (required for the controller to work efficiently)


## Testing Instructions

1.

## Notes to Reviewers
The SSR story has yet TBD, it may be possible to automatically write lightdom sheets as styletags via the controller / element renderer