### PR TITLE
[POC] feat(navigation-secondary): poc for details summary

### DIFF
--- a/elements/rh-navigation-secondary-dsd/README.md
+++ b/elements/rh-navigation-secondary-dsd/README.md
@@ -1,0 +1,11 @@
+# Navigation Secondary Dsd
+Add a description of the component here.
+
+## Usage
+Describe how best to use this web component along with best practices.
+
+```html
+<rh-navigation-secondary-dsd>
+
+</rh-navigation-secondary-dsd>
+```

--- a/elements/rh-navigation-secondary-dsd/demo/rh-navigation-secondary-dsd.html
+++ b/elements/rh-navigation-secondary-dsd/demo/rh-navigation-secondary-dsd.html
@@ -1,0 +1,93 @@
+<rh-navigation-secondary-dsd>
+  <a href="#" slot="logo" id="logo-id" aria-current="page">
+    Red Hat Ansible Automation Platform
+  </a>
+  <ul slot="nav" aria-labelledby="logo-id">
+    <li>
+      <rh-navigation-secondary-dsd-dropdown>
+        <span slot="summary">Dropdown</span>
+        <rh-navigation-secondary-dsd-menu visible>
+          <rh-navigation-secondary-dsd-menu-section>
+            <h3 slot="header">Section</h3>
+            <ul slot="links">
+              <li><a href="#">Link</a></li>
+              <li><a href="#">Link</a></li>
+              <li><a href="#">Link</a></li>
+            </ul>
+            <rh-cta slot="cta" href="#">Section CTA</rh-cta>
+          </rh-navigation-secondary-dsd-menu-section>
+          <rh-navigation-secondary-dsd-menu-section>
+            <h3 slot="header">Section</h3>
+            <ul slot="links">
+              <li><a href="#">Link</a></li>
+              <li><a href="#">Link</a></li>
+              <li><a href="#">Link</a></li>
+            </ul>
+            <rh-cta slot="cta" href="#">Section CTA</rh-cta>
+          </rh-navigation-secondary-dsd-menu-section>
+        </rh-navigation-secondary-dsd-menu>
+      </rh-navigation-secondary-dsd-dropdown>
+    </li>
+    <li>
+      <rh-navigation-secondary-dsd-dropdown>
+        <span slot="summary">Dropdown 2</span>
+        <rh-navigation-secondary-dsd-menu visible>
+          <ul>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+          </ul>
+        </rh-navigation-secondary-dsd-menu>
+      </rh-navigation-secondary-dsd-dropdown>
+    </li>
+    <li><a href="#">Link</a></li>
+    <li><a href="#">Link</a></li>
+  </ul>
+  <rh-cta slot="cta" href="#">Call to Action</rh-cta>
+</rh-navigation-secondary-dsd>
+
+<div id="lipsum">
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sagittis, ex eget congue consectetur, odio lorem tincidunt risus, eget viverra mauris nunc id quam. In eu risus et tortor luctus vehicula. Suspendisse scelerisque posuere est at imperdiet. Aliquam ut tempor ante. Sed ac egestas mauris, in pretium diam. Nam et faucibus felis. Fusce in porttitor sem. Proin commodo mi enim, sed molestie nunc dictum accumsan. Integer a suscipit lorem, a ornare turpis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam non ornare arcu. Donec vitae rhoncus metus, eget bibendum diam. Ut tincidunt arcu non risus maximus accumsan. Praesent vel purus purus.
+  </p>
+  <p>
+    Vestibulum fringilla augue a lorem maximus imperdiet. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse et augue sit amet arcu aliquam fringilla. Mauris vehicula, lacus non ultricies laoreet, purus mauris hendrerit quam, nec tincidunt velit leo id neque. Nam consectetur mauris pulvinar mattis posuere. Proin in nisl sed mauris dignissim vehicula. Nulla ut elit sodales, tempor ante ut, rutrum ipsum. Pellentesque tempus in nisl a egestas. Fusce ornare urna et orci vehicula, in euismod libero cursus. Cras non interdum sem, ut condimentum quam. Nam vestibulum quam massa, cursus interdum diam facilisis quis. Praesent ut quam ut augue varius tempor.
+  </p>
+  <p>
+    Nunc ac hendrerit justo, a placerat urna. Nam finibus posuere leo eget vulputate. In lectus nisi, porta vitae orci in, pharetra consectetur leo. Cras ultricies orci et dolor hendrerit tincidunt. Etiam eget mauris neque. Ut a sollicitudin enim. Curabitur at risus ultrices, faucibus elit sit amet, dictum odio. Mauris tristique viverra massa, at bibendum eros vulputate nec.
+  </p>
+  <p>
+    Nam risus sapien, lacinia id massa sit amet, faucibus finibus nisi. Mauris interdum scelerisque sapien. Vestibulum tincidunt ac turpis sed tristique. Integer ac magna quis neque venenatis tristique. Vivamus elementum dolor quis massa sollicitudin tincidunt. Nulla accumsan, nibh eu rutrum porta, libero leo vehicula odio, ut luctus enim nibh tempor mauris. Suspendisse pellentesque erat varius erat efficitur, id condimentum sapien congue. Quisque sit amet magna rutrum, posuere lorem vel, auctor dolor. Donec et magna libero. Mauris ut lacinia magna. Donec dignissim sapien id sem eleifend fermentum. Nullam semper eros ac mattis lobortis. Nulla facilisi.
+  </p>
+  <p>
+    In hac habitasse platea dictumst. Fusce sed tempor metus. Proin condimentum turpis at eros posuere, sed vestibulum turpis faucibus. Sed ornare urna odio, vitae suscipit enim tempor eu. Fusce vitae magna ac augue accumsan facilisis. In hac habitasse platea dictumst. Proin vehicula risus sed odio finibus, at semper lectus consequat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer neque tortor, lacinia sit amet sagittis eget, scelerisque et nunc. Cras congue luctus cursus. Sed vitae ipsum dui. In non risus porttitor libero dapibus interdum at ut lacus. Sed finibus suscipit rhoncus. Aliquam erat volutpat. Sed nec accumsan dolor.
+  </p>
+</div>
+
+
+
+<link rel="stylesheet" href="../rh-navigation-secondary-dsd-lightdom.css">
+<style>
+   #lipsum {
+    margin-block: 0;
+    margin-inline: auto;
+    padding: var(--rh-space-lg);
+    max-width: 60rem;
+    line-height: var(--rh-line-height-body-text);
+
+    p {
+      margin: var(--rh-space-lg);
+    }
+  }
+</style>
+
+<script type="module">
+  import '@rhds/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.js';
+  import '@rhds/elements/rh-cta/rh-cta.js';
+  import '@rhds/elements/rh-surface/rh-surface.js';
+</script>
+
+

--- a/elements/rh-navigation-secondary-dsd/docs/00-overview.md
+++ b/elements/rh-navigation-secondary-dsd/docs/00-overview.md
@@ -1,0 +1,2 @@
+## When to use
+

--- a/elements/rh-navigation-secondary-dsd/docs/30-code.md
+++ b/elements/rh-navigation-secondary-dsd/docs/30-code.md
@@ -1,0 +1,1 @@
+### System Integration

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd---backup.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd---backup.css
@@ -1,0 +1,188 @@
+:host {
+  --_max-height: max-content;
+  --_min-height: 80px;
+  --_nav-max-height: var(--_max-height, max-content);
+  --_nav-min-height: var(--_min-height, 80px);
+  --_inline-padding: var(--rh-space-lg);
+
+  display: block;
+  position: sticky;
+  inset-block-start: 0;
+  container: navigation-secondary / inline-size;
+  border-block-end: var(--rh-border-width-sm, 1px) solid transparent;
+  box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
+  width: 100%;
+  min-height: var(--_min-height);
+  height: var(--_max-height);
+}
+
+#container {
+  display: block;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
+
+  @container navigation-secondary (min-width: 567px) {
+    --_inline-padding: var(--rh-space-xl);
+  }
+
+  @container navigation-secondary (min-width: 567px) {
+    --_inline-padding: var(--rh-space-2xl);
+  }
+}
+
+#bar {
+  position: absolute;
+  display: grid;
+  /* stylelint-disable-next-line rhds/no-unknown-token-name */
+  z-index: var(--rh-navigation-secondary-z-index, 102);
+  grid-template-areas:
+    'logo hamburger'
+    'nav nav';
+  grid-template-columns: 1fr min-content;
+  grid-template-rows:
+    minmax(var(--_nav-min-height), var(--_nav-max-height))
+    max-content
+    max-content;
+  background-color: var(--rh-color-surface-lighter);
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
+}
+
+#logo {
+  grid-area: logo;
+  display: flex;
+  align-items: center;
+  font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Malayalam', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Thai', Helvetica, Arial, sans-serif);
+  font-weight: var(--rh-font-weight-heading-medium);
+  line-height: var(--rh-line-height-heading);
+  padding-inline-start: var(--_inline-padding);
+  /* stylelint-disable-next-line rhds/no-unknown-token-name */
+  max-width: var(--rh-navigation-secondary-logo-max-width, 10em);
+
+  & slot[name='logo']::slotted(*) {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    color: var(--rh-color-text-primary) !important;
+    padding-block: var(--rh-space-lg, 16px);
+  }
+
+  @container (min-width: 567px) {
+    padding-inline-start: var(--_inline-padding);
+  }
+}
+
+#nav-container {
+  grid-area: nav;
+}
+
+#cta {
+  grid-area: cta;
+  display: flex;
+  gap: var(--rh-space-sm);
+  height: 100%;
+  align-items: center;
+
+  @container navigation-secondary (min-width: 992px) {
+    padding-block: 0;
+    padding-inline: 0 var(--_inline-padding);
+  }
+}
+
+#hamburger {
+  display: contents;
+
+  & summary {
+    --rh-icon-size: 12px;
+
+    cursor: pointer;
+    grid-area: hamburger;
+    display: flex;
+    gap: var(--rh-space-sm);
+    height: 100%;
+    align-items: center;
+    margin-inline-end: var(--_inline-padding);
+    padding-inline: 16px;
+
+    &::marker {
+      display: none;
+    }
+  }
+
+  & #nav-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--rh-space-2xl);
+    width: -webkit-fill-available;
+    width: -moz-available;
+    width: fill-available;
+
+    /* the color-surface token has a fallback for no JS scenarios */
+    /* stylelint-disable-next-line rhds/token-values */
+    background-color: var(--rh-color-surface, var(--rh-color-surface-lightest, #ffffff));
+
+    & slot[name='nav']::slotted(ul) {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+  }
+
+  &[open] {
+    & summary {
+      background-color: var(--rh-color-surface-lightest);
+
+      rh-icon {
+        rotate: 180deg;
+      }
+    }
+
+    & #nav-container {
+      padding-block: var(--rh-space-2xl);
+      padding-inline: var(--_inline-padding);
+      box-shadow: var(--rh-box-shadow-sm);
+    }
+  }
+}
+
+/* loads when JS isn't loaded and wide viewport */
+#container:not(.compact) {
+  #bar {
+    @container navigation-secondary (min-width: 992px) {
+      grid-template-areas: 'logo nav cta';
+      grid-template-columns: max-content 1fr max-content;
+      grid-template-rows: minmax(var(--_min-height), var(--_max-height)) max-content max-content;
+    }
+  }
+
+  #nav-container {
+    padding-inline: var(--rh-space-md) 0;
+
+    & > slot[name='nav']::slotted(ul) {
+      display: flex;
+      flex-direction: row;
+      gap: 0;
+      height: 100%;
+      align-items: center;
+      margin: 0;
+      padding: 0;
+    }
+  }
+
+  #hamburger {
+    & rh-surface {
+      & > slot[name='nav']::slotted(ul) {
+        gap: 0;
+        flex-direction: row;
+        align-items: center;
+        margin-block: 0;
+        margin-inline: var(--rh-space-md) 0;
+      }
+    }
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-dropdown.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-dropdown.css
@@ -1,0 +1,93 @@
+:host {
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+
+details {
+  border-inline-start: var(--rh-border-width-lg) solid transparent;
+  border-inline-end: var(--rh-border-width-sm) solid transparent;
+  width: 100%;
+
+  & > summary {
+    --rh-icon-size: 12px;
+
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    height: max-content;
+    color: var(--_nav-link-color) !important;
+    font-size: var(--rh-font-size-body-text-md, 1rem);
+    font-weight: 400;
+    padding: var(--rh-space-lg, 16px) var(--rh-space-xl, 24px);
+    text-decoration: none !important;
+    text-align: center;
+    justify-content: space-between;
+
+    &::marker {
+      display: none;
+    }
+  }
+
+  #details-content {
+    background-color: var(--rh-color-surface-lightest);
+  }
+
+  &[open] {
+    border-inline-start-color: var(--rh-color-text-brand-on-light);
+    border-inline-end-color: var(--rh-color-border-subtle-on-light);
+    box-shadow: var(--rh-box-shadow-sm);
+
+    & summary {
+      rh-icon {
+        rotate: 180deg;
+      }
+    }
+  }
+}
+
+:host(:defined) {
+  & details {
+    @container (min-width: 992px) {
+      height: 100%;
+    }
+
+    & > summary {
+      @container (min-width: 992px) {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        padding-block: 0;
+        padding-inline: var(--rh-space-md);
+        gap: var(--rh-space-sm);
+      }
+    }
+
+    & > #details-content {
+      @container (min-width: 992px) {
+        position: absolute;
+        inset-inline: 0;
+        padding: 0;
+        box-shadow: var(--rh-box-shadow-sm);
+        max-height: calc(100vh - var(--rh-space-4xl) - var(--_nav-min-height));
+        /* stylelint-disable-next-line rhds/no-unknown-token-name */
+        z-index: var(--rh-navigation-secondary-z-index, 103);
+      }
+    }
+
+    &[open] {
+      @container (min-width: 992px) {
+        border-inline-start-color: transparent;
+        border-inline-end-color: transparent;
+        box-shadow: unset;
+      }
+
+      & summary {
+        @container (min-width: 992px) {
+          background-color: var(--rh-color-surface-lightest);
+        }
+      }
+    }
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-dropdown.ts
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-dropdown.ts
@@ -1,0 +1,94 @@
+import { LitElement, html, isServer } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+import { state } from 'lit/decorators/state.js';
+import { query } from 'lit/decorators/query.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import { observes } from '@patternfly/pfe-core/decorators.js';
+import { SlotController } from '@patternfly/pfe-core/controllers/slot-controller.js';
+import { ComposedEvent } from '@patternfly/pfe-core/core.js';
+
+import '@rhds/elements/rh-surface/rh-surface.js';
+
+import styles from './rh-navigation-secondary-dsd-dropdown.css';
+
+
+export class NavigationSecondaryDsdDropdownEvent extends ComposedEvent {
+  constructor(
+    public open: boolean,
+    public toggle: RhNavigationSecondaryDsdDropdown,
+  ) {
+    super('expand-request');
+  }
+}
+
+/* Note breaking changes
+  - Removal of part[container] as the element has switched to a details > summary
+  - Changing the slot names to reflect this change to details > summary (removal of menu opting for default slot)
+  - Changing API of expanded to reflect the details summary open attribute
+  - Changing the exported Event property to reflect the open attribute instead of reflected
+  - Addition of a public close method
+  - Addition of a public open method
+*/
+
+@customElement('rh-navigation-secondary-dsd-dropdown')
+export class RhNavigationSecondaryDsdDropdown extends LitElement {
+  static readonly styles = [styles];
+
+  private _slots = new SlotController(this, { slots: ['link', 'menu'] });
+
+  private _highlight = false;
+
+  private _mo = new MutationObserver(this._mutationsCallback.bind(this));
+
+  @query('details') _details!: HTMLDetailsElement;
+
+  @state() _open = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    if (!isServer) {
+      this._mo.observe(this, { attributeFilter: ['aria-current'], childList: true, subtree: true });
+    }
+  }
+
+  render() {
+    const classes = { 'highlight': this._highlight };
+    return html`
+      <details @toggle="${this._detailsToggle}" class="${classMap(classes)}">
+        <summary>
+          <slot name="summary"></slot>
+          <rh-icon icon="caret-down" set="ui"></rh-icon>
+        </summary>
+        <div id="details-content"><slot></slot></div>
+      </details>
+    `;
+  }
+
+
+  private _detailsToggle() {
+    this._open = this._details.open;
+    this.dispatchEvent(new NavigationSecondaryDsdDropdownEvent(this._open, this));
+  }
+
+  private _mutationsCallback() {
+    // if the [aria-current-page] link is a child of the default slot ensure the state of the highlight
+    const [dropdownMenu] = this._slots.getSlotted<HTMLElement>('');
+    this._highlight = dropdownMenu.querySelector('[aria-current="page"]') ? true : false;
+    this.requestUpdate();
+  }
+
+  public close() {
+    this._details.open = false;
+  }
+
+  public open() {
+    this._details.open = true;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rh-navigation-secondary-dsd-dropdown': RhNavigationSecondaryDsdDropdown;
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-lightdom.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-lightdom.css
@@ -1,0 +1,72 @@
+rh-navigation-secondary-dsd {
+  & > [slot='nav'] {
+    & > li {
+      max-width: 100%;
+      border-block-start: var(--rh-border-width-sm) solid var(--rh-color-border-subtle-on-light);
+
+      &:last-of-type {
+        border-block-end: var(--rh-border-width-sm) solid var(--rh-color-border-subtle-on-light);
+      }
+
+      & > a {
+        list-style: none;
+        display: flex;
+        align-items: center;
+        height: 100%;
+        color: var(--_nav-link-color) !important;
+        font-size: var(--rh-font-size-body-text-md);
+        font-weight: 400;
+        padding: var(--rh-space-lg) var(--rh-space-xl);
+        text-decoration: none !important;
+        text-align: center;
+        border-inline-start: var(--rh-border-width-lg) solid transparent;
+        border-inline-end: var(--rh-border-width-sm) solid transparent;
+        border-block-start: var(--rh-border-width-lg) solid transparent;
+
+        &[aria-current='page'] {
+          border-block-start-color: var(--rh-color-brand-red);
+        }
+      }
+
+      & rh-navigation-secondary-dsd-dropdown {
+        border-block-start: var(--rh-border-width-lg) solid transparent;
+
+        &[aria-current='page'] {
+          border-block-start-color: var(--rh-color-brand-red);
+        }
+      }
+    }
+  }
+
+  & > [slot='logo'] {
+    border-block-start: var(--rh-border-width-lg) solid transparent;
+
+    &[aria-current='page'] {
+      border-block-start-color: var(--rh-color-brand-red);
+    }
+  }
+
+  /* explict if defined only if js loaded */
+  &:defined {
+    & > [slot='nav'] {
+      & > li {
+        @container (min-width: 992px) {
+          border-block-start: none;
+          height: 100%;
+          align-items: center;
+          display: flex;
+
+          &:last-of-type {
+            border-block-end: none;
+          }
+        }
+      }
+
+      & > a {
+        @container (min-width: 992px) {
+          padding: 0;
+        }
+      }
+    }
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu-section.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu-section.css
@@ -1,0 +1,39 @@
+:host {
+  display: block;
+}
+
+section {
+  & slot[name='header']::slotted(:is(h1,h2,h3,h4,h5,h6)) {
+    font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Malayalam', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Thai', Helvetica, Arial, sans-serif) !important;
+    padding: 0 !important;
+    font-size: var(--rh-font-size-body-text-md, 1rem) !important;
+    font-weight: 500 !important;
+    margin: 0 0 var(--rh-space-lg, 16px) !important;
+
+    @container (min-width: 992px) {
+      padding: 0 !important;
+    }
+  }
+
+  & slot[name='links']::slotted(:is(ul, ol)) {
+    list-style: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: var(--rh-font-size-body-text-md, 1rem);
+
+    @container (min-width: 992px) {
+      padding: 0 !important;
+      margin: 0 !important;
+    }
+  }
+
+  & slot[name='cta']::slotted(*) {
+    padding: var(--rh-space-xl, 24px) 0 0;
+
+    &:last-of-type {
+      padding: var(--rh-space-xl, 24px) 0;
+    }
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu-section.ts
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu-section.ts
@@ -1,0 +1,74 @@
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+
+import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
+import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
+
+import { isHeadingElement } from '../../lib/functions.js';
+
+import styles from './rh-navigation-secondary-dsd-menu-section.css';
+
+/**
+ * A menu section which auto upgrades accessibility for headers and sibling list
+ * @summary 'A menu section which auto upgrades accessibility for headers and sibling list'
+ * @slot header     - Adds a header tag to section, expects `<h1> | <h2> | <h3> | <h4> | <h5> | <h6>` element
+ * @slot links      - Adds a ul tag to section, expects `<ul> | <ol>` element
+ * @slot cta        - Adds a section level CTA, expects `<rh-cta>` element
+ * @csspart container    - container, <section> element
+ */
+@customElement('rh-navigation-secondary-dsd-menu-section')
+export class RhNavigationSecondaryDsdMenuSection extends LitElement {
+  static readonly styles = [styles];
+
+  #logger = new Logger(this);
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    this.#updateAccessibility();
+  }
+
+  render() {
+    return html`
+      <section part="container">
+        <slot name="header"></slot>
+        <slot name="links"></slot>
+        <slot name="cta"></slot>
+      </section>
+    `;
+  }
+
+  /**
+   * Finds all list elements `<ul>, <ol>` and if the list does not have an
+   * `aria-labelledby` attribute finds the previousElementSibling header
+   * `<h1-6>` tags if available assigns an id or uses preexisting id
+   * to that header, then uses that id to the list on the `aria-labelledby`.
+   */
+  #updateAccessibility() {
+    const lists = this.querySelectorAll(':is([slot="links"]):is(ul, ol)');
+
+    for (const list of lists) {
+      if (!list.hasAttribute('aria-labelledby')) {
+        const header = isHeadingElement(list.previousElementSibling) ?
+          list.previousElementSibling
+          : null;
+        if (!header) {
+          return this.#logger.warn(
+            'This links set doesn\'t have a valid header associated with it.'
+          );
+        } else {
+          // add an ID to the header if we need it
+          header.id ||= getRandomId('rh-navigation-secondary-menu-section');
+          // add that header id to the aria-labelledby tag
+          list.setAttribute('aria-labelledby', header.id);
+        }
+      }
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rh-navigation-secondary-dsd-menu-section': RhNavigationSecondaryDsdMenuSection;
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu.css
@@ -1,0 +1,95 @@
+:host {
+  display: block;
+}
+
+#container {
+  color: var(--rh-color-text-primary-on-light, #151515);
+  background-color: var(--rh-color-surface-lightest, #ffffff);
+
+  &:not(.visible) {
+    display: none;
+  }
+}
+
+#sections {
+  padding: var(--rh-space-xl, 24px);
+}
+
+:host(:defined) {
+  #container {
+    &.visible {
+      @container (min-width: 992px) {
+        position: absolute;
+        inset-inline: 0;
+        padding:
+          var(--rh-space-4xl, 64px)
+          var(--rh-space-2xl, 32px)
+          var(--rh-space-3xl, 48px);
+        box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
+        z-index: -1;
+        max-height: calc(100vh - (var(--rh-space-4xl, 64px)) - var(--_nav-min-height));
+        overflow-y: scroll;
+      }
+
+      @container (min-width: 1200px) {
+        padding: var(--rh-space-3xl, 48px) var(--rh-space-2xl, 32px);
+      }
+
+      @container (min-width: 1440px) {
+        padding: var(--rh-space-3xl, 48px) var(--rh-space-4xl, 64px);
+      }
+    }
+  }
+
+  #sections {
+    @container (min-width: 992px) {
+      padding: 0;
+      max-width: var(--rh-navigation-secondary-menu-content-max-width, 1136px);
+      margin: auto;
+    }
+  }
+
+  #full-width {
+    @container (min-width: 1600px) {
+      margin: auto;
+    }
+  }
+}
+
+:host([layout='fixed-width']) {
+  #sections {
+    padding: var(--rh-space-2xl, 32px);
+  }
+}
+
+:host([layout='fixed-width']:defined) {
+  #container {
+    @container (min-width: 992px) {
+      position: absolute;
+      inset: var(--_nav-height) auto auto auto;
+      margin-top: 0;
+      padding: 0;
+    }
+  }
+}
+
+:host(:not([type='fixed-width'])) {
+  #sections {
+    display: grid;
+    grid-template-columns:
+      var(--rh-navigation-secondary-menu-section-grid,
+        repeat(auto-fit,
+        minmax(15.5rem, 1fr)));
+    grid-template-rows: auto;
+    gap: var(--rh-navigation-secondary-menu-section-grid-gap, var(--rh-space-2xl, 32px));
+  }
+}
+
+::slotted(:is(ul, ol)) {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--rh-font-size-body-text-md, 1rem);
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu.ts
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-menu.ts
@@ -1,0 +1,72 @@
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+import { property } from 'lit/decorators/property.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
+
+import styles from './rh-navigation-secondary-dsd-menu.css';
+
+/**
+ * Dropdown menu for secondary nav, available in full-width and fixed-with sizes
+ * @summary 'Dropdown menu for secondary nav, available in full-width and fixed-with sizes'
+ * @slot                  - Optional `<rh-navigation-secondary-menu-section>` elements or content following [design guidelines](../guidelines/#expandable-tray)
+ * @csspart container     - container - `<div>` element, wrapper for menus
+ * @csspart full-width    - container - `<div>` element, wrapper for full-width menus
+ * @csspart fixed-width   - container - `<div>` element, wrapper for fixed-width menus
+ * @csspart sections      - container - `<div>` element, wrapper for menu sections
+ * @cssprop  [--rh-navigation-secondary-menu-section-grid=repeat(auto-fit, minmax(15.5rem, 1fr))]
+ *          grid-template-columns for menu sections
+ * @cssprop  {<length>} [--rh-navigation-secondary-menu-section-grid-gap=32px]
+ *           grid-gap for menu sections
+ * @cssprop  {<length>} [--rh-navigation-secondary-menu-content-max-width=1136px]
+ *           max-width for menu content
+ */
+@customElement('rh-navigation-secondary-dsd-menu')
+export class RhNavigationSecondaryDsdMenu extends LitElement {
+  static readonly styles = [styles];
+
+  /**
+   * Layout (default: full-width)
+   * Secondary nav menus by default are always full-width, but can be set to fixed-width for special cases.
+   */
+  @property({ reflect: true }) layout: 'fixed-width' | 'full-width' = 'full-width';
+
+  // #screenSize = new ScreenSizeController(this);
+
+  /**
+   * `visible` toggles on click (default: true)
+   *  @deprecated
+   */
+  @property({ type: Boolean, reflect: false }) visible = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.id ||= getRandomId('rh-navigation-secondary-menu');
+  }
+
+  render() {
+    const { visible } = this;
+
+    return html`
+      <div id="container" class="${classMap({ visible })}">${this.layout === 'full-width' ? html`
+        <div id="full-width" part="full-width">
+          <div id="sections" part="sections">
+            <slot></slot>
+          </div>
+        </div>` : html`
+        <div id="fixed-width" part="fixed-width">
+          <div id="sections" part="sections">
+            <slot></slot>
+          </div>
+        </div>`}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rh-navigation-secondary-dsd-menu': RhNavigationSecondaryDsdMenu;
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-overlay.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-overlay.css
@@ -1,0 +1,22 @@
+:host {
+  position: fixed;
+
+  --_gray-90-rgb: var(--rh-color-gray-90-rgb, 31 31 31);
+
+  background-color: rgb(var(--_gray-90-rgb) / var(--rh-opacity-80, 80%));
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+
+  /* TODO remove --rh-secondary-nav-overlay-z-index for v2 */
+  /* stylelint-disable-next-line */
+  z-index: var(--rh-navigation-secondary-overlay-z-index, var(--rh-secondary-nav-overlay-z-index, -1));
+}
+
+:host([open]) {
+  display: block;
+}
+
+:host(:not([open])) {
+  display: none;
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-overlay.ts
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd-overlay.ts
@@ -1,0 +1,21 @@
+import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+import { property } from 'lit/decorators/property.js';
+
+import styles from './rh-navigation-secondary-dsd-overlay.css';
+
+/**
+ * @summary An overlay element to cover content with an opacity when navigation is expanded.
+ */
+@customElement('rh-navigation-secondary-dsd-overlay')
+export class RhNavigationSecondaryDsdOverlay extends LitElement {
+  static readonly styles = [styles];
+
+  @property({ type: Boolean, reflect: true }) open = false;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rh-navigation-secondary-dsd-overlay': RhNavigationSecondaryDsdOverlay;
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.css
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.css
@@ -1,0 +1,172 @@
+:host {
+  --_max-height: max-content;
+  --_min-height: 80px;
+  --_nav-max-height: var(--_max-height, max-content);
+  --_nav-min-height: var(--_min-height, 80px);
+  --_inline-padding: var(--rh-space-lg);
+
+  display: block;
+  position: sticky;
+  inset-block-start: 0;
+  container: navigation-secondary / inline-size;
+  border-block-end: var(--rh-border-width-sm, 1px) solid transparent;
+  box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
+  width: 100%;
+  min-height: var(--_min-height);
+  height: var(--_max-height);
+}
+
+#container {
+  display: block;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
+
+  @container navigation-secondary (min-width: 567px) {
+    --_inline-padding: var(--rh-space-xl);
+  }
+
+  @container navigation-secondary (min-width: 567px) {
+    --_inline-padding: var(--rh-space-2xl);
+  }
+
+  #bar {
+    position: absolute;
+    display: grid;
+    /* stylelint-disable-next-line rhds/no-unknown-token-name */
+    z-index: var(--rh-navigation-secondary-z-index, 102);
+    grid-template-areas:
+      'logo hamburger'
+      'nav nav';
+    grid-template-columns: 1fr min-content;
+    grid-template-rows:
+      minmax(var(--_nav-min-height), var(--_nav-max-height))
+      max-content
+      max-content;
+    background-color: var(--rh-color-surface-lighter);
+    width: -webkit-fill-available;
+    width: -moz-available;
+    width: fill-available;
+
+    #logo {
+      grid-area: logo;
+      display: flex;
+      align-items: center;
+      font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Malayalam', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Thai', Helvetica, Arial, sans-serif);
+      font-weight: var(--rh-font-weight-heading-medium);
+      line-height: var(--rh-line-height-heading);
+      padding-inline-start: var(--_inline-padding);
+      /* stylelint-disable-next-line rhds/no-unknown-token-name */
+      max-width: var(--rh-navigation-secondary-logo-max-width, 10em);
+
+      & slot[name='logo']::slotted(*) {
+        display: flex;
+        align-items: center;
+        height: 100%;
+        color: var(--rh-color-text-primary) !important;
+        padding-block: var(--rh-space-lg, 16px);
+      }
+
+      @container (min-width: 567px) {
+        padding-inline-start: var(--_inline-padding);
+      }
+    }
+
+    #hamburger {
+      display: contents;
+
+      & summary {
+        --rh-icon-size: 12px;
+
+        cursor: pointer;
+        grid-area: hamburger;
+        display: flex;
+        gap: var(--rh-space-sm);
+        height: 100%;
+        align-items: center;
+        margin-inline-end: var(--_inline-padding);
+        padding-inline: 16px;
+
+        &::marker {
+          display: none;
+        }
+      }
+
+      & #nav-container {
+        grid-area: nav;
+        display: flex;
+        flex-direction: column;
+        gap: var(--rh-space-2xl);
+        width: -webkit-fill-available;
+        width: -moz-available;
+        width: fill-available;
+        background-color: var(--rh-color-surface-lightest);
+
+        & slot[name='nav']::slotted(ul) {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+        }
+      }
+
+      &[open] {
+        & summary {
+          background-color: var(--rh-color-surface-lightest);
+
+          rh-icon {
+            rotate: 180deg;
+          }
+        }
+
+        & #nav-container {
+          padding-block: var(--rh-space-2xl);
+          padding-inline: var(--_inline-padding);
+          box-shadow: var(--rh-box-shadow-sm);
+        }
+      }
+    }
+  }
+
+  /* wide viewport and js enabled */
+  &:not(.compact) {
+    #bar {
+      grid-template-areas: 'logo nav';
+      grid-template-columns: max-content 1fr;
+      grid-template-rows: minmax(var(--_min-height), var(--_max-height)) max-content max-content;
+      column-gap: var(--rh-space-2xl);
+
+      #hamburger {
+        & summary {
+          display: none;
+        }
+
+        #nav-container {
+          flex-direction: row;
+          background-color: var(--rh-color-surface-lighter);
+          justify-content: space-between;
+
+          & slot[name='nav']::slotted(ul) {
+            flex-direction: row;
+          }
+        }
+
+        #cta {
+          display: flex;
+          height: 100%;
+          align-content: center;
+          padding-inline-end: var(--_inline-padding);
+        }
+
+        &[open] {
+          #nav-container {
+            padding: 0;
+            box-shadow: none;
+          }
+        }
+      }
+    }
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.ts
+++ b/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.ts
@@ -1,0 +1,288 @@
+import { LitElement, html, isServer } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+import { state } from 'lit/decorators/state.js';
+import { query } from 'lit/decorators/query.js';
+import { property } from 'lit/decorators/property.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import { ComposedEvent } from '@patternfly/pfe-core/core.js';
+import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
+
+import { DirController } from '../../lib/DirController.js';
+import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
+import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
+
+import '@rhds/elements/rh-surface/rh-surface.js';
+
+import {
+  RhNavigationSecondaryDsdDropdown,
+  NavigationSecondaryDsdDropdownEvent,
+} from './rh-navigation-secondary-dsd-dropdown.js';
+import './rh-navigation-secondary-dsd-menu.js';
+import './rh-navigation-secondary-dsd-menu-section.js';
+import './rh-navigation-secondary-dsd-overlay.js';
+
+import styles from './rh-navigation-secondary-dsd.css';
+
+export class SecondaryNavDsdOverlayChangeEvent extends ComposedEvent {
+  constructor(
+    public open: boolean,
+    public toggle: HTMLElement
+  ) {
+    super('overlay-change');
+  }
+}
+
+export type NavPalette = Extract<ColorPalette, (
+  | 'lighter'
+  | 'dark'
+)>;
+
+/**
+ * Navigation Secondary Dsd
+ * @slot - Place element content here
+ */
+@customElement('rh-navigation-secondary-dsd')
+export class RhNavigationSecondaryDsd extends LitElement {
+  static readonly styles = [styles];
+
+  private static instances = new Set<RhNavigationSecondaryDsd>();
+
+  static {
+    if (!isServer) {
+      globalThis.addEventListener('keyup', (event: KeyboardEvent) => {
+        const { instances } = RhNavigationSecondaryDsd;
+        for (const instance of instances) {
+          instance._onKeyup(event);
+        }
+      }, { capture: false });
+    }
+  }
+
+  static isDropdown(element: Element | null): element is RhNavigationSecondaryDsdDropdown {
+    return element instanceof RhNavigationSecondaryDsdDropdown;
+  }
+
+  @state()
+  private _compact = true;
+
+  @state()
+  private _overlayState = false;
+
+  @state()
+  private _hamburgerState = false;
+
+  @query('#hamburger')
+  private _hamburger!: HTMLDetailsElement;
+
+  private ro?: ResizeObserver;
+
+  private _internals = InternalsController.of(this, { role: 'navigation' });
+
+  private _dir = new DirController(this);
+
+  /**
+   * Color palette darker | lighter (default: lighter)
+   */
+  @colorContextProvider()
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette: NavPalette = 'lighter';
+
+  /**
+   * Sets color theme based on parent context
+   */
+  @colorContextConsumer() private on?: ColorTheme;
+
+  private _openDropdowns = new Set<RhNavigationSecondaryDsdDropdown>();
+
+  /**
+   * Customize the default `aria-label` on the `<nav>` container.
+   * Defaults to "secondary" if no attribute/property is set.
+  */
+  @property({ attribute: 'accessible-label' }) accessibleLabel = 'secondary';
+
+  constructor() {
+    super();
+    if (!isServer) {
+      // TODO: Perf look into debouncing the resize observer
+      this.ro = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          const old = this._compact;
+          const cs = globalThis.getComputedStyle(entry.target);
+          const [integerWidth] = cs.width.split('px');
+          const newState = parseInt(integerWidth) <= 992;
+          this._compact = newState;
+          // only run if state changes
+          if (old !== newState) {
+            if (this._compact && this._openDropdowns.size === 0) {
+              this._closeHamburger();
+            } else {
+              this._openHamburger();
+            }
+            this._toggleOverlay();
+          }
+        }
+      });
+    }
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    if (!isServer) {
+      this.ro?.observe(this);
+      this.addEventListener('expand-request', this._onExpandRequest);
+      this._upgradeAccessibility();
+      this._internals.ariaLabel = this.accessibleLabel;
+    }
+  }
+
+  disconnectedCallback(): void {
+    if (!isServer) {
+      this.ro?.disconnect();
+    }
+  }
+
+  render() {
+    const { on = '' } = this;
+    const rtl = this._dir.dir === 'rtl';
+    const classes = { [on]: !!on, on: true, compact: this._compact, rtl };
+    return html`
+      <nav id="container" class="${classMap(classes)}">
+        <div id="bar">
+          <div id="logo"><slot name="logo"></slot></div>
+          <details id="hamburger" @toggle="${this._hamburgerToggle}">
+            <summary>
+              <slot name="mobile-nav">Menu</slot>
+              <rh-icon icon="caret-down" set="ui"></rh-icon>
+            </summary>
+            <div id="nav-container" color-palette="lightest">
+              <slot name="nav"></slot>
+              <div id="cta">
+                <slot name="cta"></slot>
+              </div>
+            </div>
+          </details>
+        </div>
+      </nav>
+      <rh-navigation-secondary-dsd-overlay
+          ?open="${this._overlayState}"
+          @click="${this._onOverlayClick}"
+      ></rh-navigation-secondary-dsd-overlay> 
+    `;
+  }
+
+  private _onKeyup(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'Tab':
+        this._onTabKeyup(event);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private _onTabKeyup(event: KeyboardEvent) {
+    // mobile menu is not open so do nothing
+    if (!this._hamburgerState) {
+      return;
+    }
+    const { target } = event;
+    if (!this.contains(target as HTMLElement)) {
+      // close hamburger
+      this._closeHamburger();
+      this._toggleOverlay();
+    }
+  }
+
+  private _onExpandRequest(event: Event) {
+    if (event instanceof NavigationSecondaryDsdDropdownEvent) {
+      if (event.open) {
+        this.close();
+        this._openDropdowns.add(event.toggle);
+      } else {
+        this._openDropdowns.delete(event.toggle);
+      }
+      this._toggleOverlay();
+    }
+  }
+
+  private async _openHamburger() {
+    this._hamburgerState = true;
+    await this.updateComplete;
+    this._hamburger.open = true;
+  }
+
+  private async _closeHamburger() {
+    this._hamburgerState = false;
+    await this.updateComplete;
+    this._hamburger.open = false;
+  }
+
+  private _hamburgerToggle() {
+    this._hamburgerState = this._hamburger.open;
+    this._toggleOverlay();
+  }
+
+  private _onOverlayClick() {
+    this.close();
+    if (this._hamburgerState && this._compact) {
+      this._closeHamburger();
+    }
+    this._toggleOverlay();
+  }
+
+  private _upgradeAccessibility() {
+    // remove role="navigation" from host on upgrade
+    this.removeAttribute('role');
+    // remove aria-labelledby from slotted `<ul>` on upgrade
+    this.querySelector(':is([slot="nav"]):is(ul)')?.removeAttribute('aria-labelledby');
+    this._internals.ariaLabel = this.accessibleLabel;
+  }
+
+  private _toggleOverlay() {
+    const old = this._overlayState;
+
+    // compact overlay is based on hamburger menu state
+    if (this._compact) {
+      this._overlayState = this._hamburgerState;
+    } else {
+      // wide overlay is based on open dropdown set size
+      this._overlayState = this._openDropdowns.size > 0 ? true : false;
+    }
+
+    if (old !== this._overlayState) {
+      this.dispatchEvent(
+        new SecondaryNavDsdOverlayChangeEvent(this._overlayState, this._hamburger)
+      );
+    }
+  }
+
+  public open(index: number): void {
+    const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="nav"]');
+    if (slot) {
+      const [slotted] = slot.assignedElements({ flatten: true });
+      const dropdowns = slotted?.querySelectorAll('rh-navigation-secondary-dsd-dropdown');
+      if (dropdowns.length === 0) {
+        return;
+      }
+      if (this._compact) {
+        this._openHamburger();
+      }
+      const dropdown = dropdowns[index];
+      dropdown.open();
+    }
+  }
+
+  public close(): void {
+    for (const dropdown of this._openDropdowns) {
+      // close all dropdowns in set
+      dropdown.close();
+      this._openDropdowns.delete(dropdown);
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rh-navigation-secondary-dsd': RhNavigationSecondaryDsd;
+  }
+}

--- a/elements/rh-navigation-secondary-dsd/test/rh-navigation-secondary-dsd.e2e.ts
+++ b/elements/rh-navigation-secondary-dsd/test/rh-navigation-secondary-dsd.e2e.ts
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import { PfeDemoPage } from '@patternfly/pfe-tools/test/playwright/PfeDemoPage.js';
+import { SSRPage } from '@patternfly/pfe-tools/test/playwright/SSRPage.js';
+
+const tagName = 'rh-navigation-secondary-dsd';
+
+test.describe(tagName, () => {
+  test('snapshot', async ({ page }) => {
+    const componentPage = new PfeDemoPage(page, tagName);
+    await componentPage.navigate();
+    await componentPage.snapshot();
+  });
+
+  test('ssr', async ({ browser }) => {
+    const fixture = new SSRPage({
+      tagName,
+      browser,
+      demoDir: new URL('../demo/', import.meta.url),
+      importSpecifiers: [
+        `@patternfly/elements/${tagName}/${tagName}.js`,
+      ],
+    });
+    await fixture.snapshots();
+  });
+});

--- a/elements/rh-navigation-secondary-dsd/test/rh-navigation-secondary-dsd.spec.ts
+++ b/elements/rh-navigation-secondary-dsd/test/rh-navigation-secondary-dsd.spec.ts
@@ -1,0 +1,21 @@
+import { expect, html } from '@open-wc/testing';
+import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
+import { RhNavigationSecondaryDsd } from '@rhds/elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.js';
+
+describe('<rh-navigation-secondary-dsd>', function() {
+  describe('simply instantiating', function() {
+    let element: RhNavigationSecondaryDsd;
+    it('imperatively instantiates', function() {
+      expect(document.createElement('rh-navigation-secondary-dsd')).to.be.an.instanceof(RhNavigationSecondaryDsd);
+    });
+
+    it('should upgrade', async function() {
+      element = await createFixture<RhNavigationSecondaryDsd>(html`<rh-navigation-secondary-dsd></rh-navigation-secondary-dsd>`);
+      const klass = customElements.get('rh-navigation-secondary-dsd');
+      expect(element)
+        .to.be.an.instanceOf(klass)
+        .and
+        .to.be.an.instanceOf(RhNavigationSecondaryDsd);
+    });
+  })
+});

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -250,6 +250,7 @@ export default async function(eleventyConfig: UserConfig) {
       'elements/rh-table/rh-table.js',
       'elements/rh-tag/rh-tag.js',
       'elements/rh-cta/rh-cta.js',
+      'elements/rh-navigation-secondary-dsd/rh-navigation-secondary-dsd.js',
     ],
   });
 


### PR DESCRIPTION

## Proof of concept for `navigation-secondary` served as a DSD template

## What this POC is

- Adds `details > summary` as the key component for the hamburger menu of `navigation-secondary`
- Enables `navigation-secondary` to be used as a DSD fragment (or SSR'd) that can be hydrated on the client.
- Removes CLS from load as the initial load of the hamburger is closed due to usage of the `details > summary` standard mechanism.
- Enables navigation to function as a collapsed menu even under no JS scenarios, either through failure of proper load or user preference (not a condition to support but still works for).
- Shifts from `@media` queries to `@container` queries.  Likely improvements can be made to the implementation of a resize observer in lieu of using Screensize controller which only works with `matchMedia`
- A proving ground for ideas on how to better support `navigation-primary` in the future as a mission critical component.

##  What this POC is not

- This is a breaking change.  Not an incremental update to `navigation-secondary`.  
- Does not solve for every possible use/state, such as when used as standard component implementation and not the DSD artifact, if JS fails the details summary is not exposed therefore content ends up hidden for dropdowns.  However such use case is deemed a choice by implementation for this POC.  There maybe some workarounds we can do like a fallback slot for a link in case of NO JS scenarios, this hasn't been fully explored.
- Does not solve for the distribution of the DSD artifact.