### PR TITLE
fix(tile): compact link icon layout

### DIFF
--- a/.changeset/clever-webs-appear.md
+++ b/.changeset/clever-webs-appear.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-tile>`: fixed layout of compact link tiles with icons

--- a/elements/rh-tile/demo/link-with-icon.html
+++ b/elements/rh-tile/demo/link-with-icon.html
@@ -1,0 +1,23 @@
+<rh-tile compact desaturated>
+  <h2 slot="headline"><a href="#top">Compact link tile</a></h2>
+  <rh-icon slot="icon" set="standard" icon="mug"></rh-icon>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eleifend elit set est egestat, a sollicitudn mauris tincidunt.</p>
+</rh-tile>
+
+<script type="module">
+  import '@rhds/elements/rh-tile/rh-tile.js';
+</script>
+
+<link rel="stylesheet" href="../rh-tile-lightdom.css">
+
+<style>
+  rh-tile {
+    max-width: 360px;
+    margin-inline-end: var(--rh-space-md, 8px);
+    margin-block-end: var(--rh-space-md, 8px);
+    & rh-icon {
+      color: var(--rh-color-brand-red);
+    }
+  }
+</style>
+

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -19,7 +19,11 @@
 #inner,
 #content {
   display: flex;
-  flex-flow: column;
+  flex-direction: column;
+}
+
+.compact #inner {
+  flex-direction: row;
 }
 
 #outer,


### PR DESCRIPTION
## What I did

1. fix layouts for `<rh-tile compact>` when there is a link and an icon


## Testing Instructions

1. check out the new `link-with-icon` demo, ensure it conforms to figma specs

## Notes to Reviewers

We might want to implement other patterns from the figma here, like compact with image and icon, different sized icons, etc. See [figma](https://www.figma.com/design/j7Rjo2W6PLloxOSXQOpll0/Red-Hat-Design-System-component-library-(v2.1.1)?node-id=4107-12907&node-type=frame&m=dev)

Thanks @tejas161 for reporting this issue
