### PR TITLE
chore: add redirect to enable v1 docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,12 @@
   NODE_OPTIONS = "--max_old_space_size=8192"
 
 [[redirects]]
+  from = '/v1/*'
+  to = 'https://v1--red-hat-design-system.netlify.app/:splat'
+  status = 200
+  force = true
+
+[[redirects]]
   from = '/components/get-started/*'
   to = '/get-started/'
 [[redirects]]


### PR DESCRIPTION
## What I did

1. Add redirect to netlify.toml to enable v1 docs


## Testing Instructions

1.

## Notes to Reviewers
