### PR TITLE
fix(blockquote): fix center alignment, enforce blockquote font size and update Style docs

### DIFF
--- a/.changeset/thick-flowers-beam.md
+++ b/.changeset/thick-flowers-beam.md
@@ -1,5 +1,5 @@
 ---
-"@rhds/elements": patch
+"@rhds/elements": minor
 ---
 
-`<rh-blockquote>`: make quote content centered when `align="center"`
+`<rh-blockquote>`: fix center alignment, blockquote font size and update Style docs

--- a/.changeset/thick-flowers-beam.md
+++ b/.changeset/thick-flowers-beam.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-blockquote>`: make quote content centered when `align="center"`

--- a/elements/rh-blockquote/docs/00-overview.md
+++ b/elements/rh-blockquote/docs/00-overview.md
@@ -5,6 +5,5 @@
 - When you need to break up large portions of text
 
 <div id="overview-image-description" class="visually-hidden">
-  Image of a blockquote including a quote icon, quotation text, and citation 
-  text
+  A blockquote including a quote icon, quotation text, and citation text
 </div>

--- a/elements/rh-blockquote/docs/10-style.md
+++ b/elements/rh-blockquote/docs/10-style.md
@@ -39,14 +39,14 @@ also include the following optional elements:
 
 <rh-table>
 
-| Size              | Element               | Current value |
-|-------------------|-----------------------|---------------|
-| Default           | Text size - quotation | 20px, 1.25rem |
-| Default           | 30 (1.5)              |               |
-| Large             | 28px, 1.75rem         |               |
-| Large             | 36.4 (1.3)            |               |
-| Default and Large | 14px, 0.875rem        |               |
-| Default and Large | 21 (1.5)              |               |
+| Size              | Element                 | Current value  |
+|-------------------|-------------------------|----------------|
+| Default           | Text size - quotation   | 20px, 1.25rem  |
+| Default           | Line height - quotation | 30 (1.5)       |
+| Large             | Text size - quotation   | 28px, 1.75rem  |
+| Large             | Line height - quotation | 36.4 (1.3)     |
+| Default and Large | Text size - citation    | 14px, 0.875rem |
+| Default and Large | Line height - citation  | 21 (1.5)       |
 
 </rh-table>
 

--- a/elements/rh-blockquote/docs/10-style.md
+++ b/elements/rh-blockquote/docs/10-style.md
@@ -53,7 +53,7 @@ also include the following optional elements:
 ## Theme
 
 A blockquote is available on both light and dark backgrounds, and uses [themable
-tokens][/theming/color-palettes] to respond to it's color context.
+tokens](/theming/customizing/) to respond to it's color context.
 
 <rh-table>
 

--- a/elements/rh-blockquote/docs/10-style.md
+++ b/elements/rh-blockquote/docs/10-style.md
@@ -31,7 +31,7 @@ also include the following optional elements:
 ## Sizes
 
 <uxdot-example width-adjustment="872px">
-  <img alt="Image of two blockquotes, default size on the left and large size on the right"
+  <img alt="Two blockquotes, default size on the left and large size on the right"
        src="../blockquote-style-sizes.png"
        width="872"
        height="350">
@@ -68,7 +68,7 @@ tokens][/theming/color-palettes] to respond to it's color context.
 ### Light theme
 
 <uxdot-example width-adjustment="589px">
-  <img alt="Image of a light theme blockquote, red quote icon, black quotation text, and dark gray citation text"
+  <img alt="A light theme blockquote, red quote icon, black quotation text, and dark gray citation text"
        src="../blockquote-theme-light.png"
        width="589"
        height="177">
@@ -77,7 +77,7 @@ tokens][/theming/color-palettes] to respond to it's color context.
 ### Dark theme
 
 <uxdot-example color-palette="darkest" width-adjustment="589px">
-  <img alt="Image of a dark theme blockquote, red quote icon, white quotation text, and light gray citation text"
+  <img alt="A dark theme blockquote, red quote icon, white quotation text, and light gray citation text"
        src="../blockquote-theme-dark.png"
        width="589"
        height="177">
@@ -86,14 +86,14 @@ tokens][/theming/color-palettes] to respond to it's color context.
 ### Emphasis border
 
 <uxdot-example width-adjustment="872px">
-  <img alt="Image of two blockquotes, a red emphasis border on the left and a black emphasis border on the right"
+  <img alt="Two blockquotes, a red emphasis border on the left and a black emphasis border on the right"
        src="../blockquote-emphasis-theme-light.png"
        width="872"
        height="260">
 </uxdot-example>
 
 <uxdot-example color-palette="darkest" width-adjustment="872px">
-  <img alt="Image of two blockquotes, a red emphasis border on the left and a black emphasis border on the right"
+  <img alt="Two blockquotes, a red emphasis border on the left and a black emphasis border on the right"
        src="../blockquote-emphasis-theme-dark.png"
        width="872"
        height="260">
@@ -111,14 +111,14 @@ tokens][/theming/color-palettes] to respond to it's color context.
 ### Title and heading text
 
 <uxdot-example width-adjustment="872px">
-  <img alt="Image of two blockquotes, both with red title text and black header text"
+  <img alt="Two blockquotes, both with red title text and black header text"
        src="../blockquote-title-heading-theme-light.png"
        width="872"
        height="356">
 </uxdot-example>
 
 <uxdot-example color-palette="darkest" width-adjustment="872px">
-  <img alt="Image of two blockquotes, both with red title text and white header text"
+  <img alt="Two blockquotes, both with red title text and white header text"
        src="../blockquote-title-heading-theme-dark.png"
        width="872"
        height="356">
@@ -138,7 +138,7 @@ tokens][/theming/color-palettes] to respond to it's color context.
 The base elements in both sizes are stacked and left aligned by default, but they can be vertically centered if necessary.
 
 <uxdot-example width-adjustment="872px">
-  <img alt="Image of four blockquotes, two are left aligned and two are vertically centered, the quote icon is 20px tall"
+  <img alt="Four blockquotes, two are left aligned and two are vertically centered, the quote icon is 20px tall"
        src="../blockquote-configuration.png"
        width="872"
        height="615">
@@ -150,7 +150,7 @@ A blockquote was designed to be read from top to bottom. If certain optional ele
 
 <figure>
   <uxdot-example width-adjustment="872px">
-    <img alt="Image of a blockquote with numbers 1 - 4 on the right side going from top to bottom"
+    <img alt="A blockquote with numbers 1 - 4 on the right side going from top to bottom"
          src="../blockquote-configuration.png" 
          width="872"
          height="615">
@@ -172,7 +172,7 @@ Citation text has specific styles applied to it.
 
 <uxdot-example width-adjustment="349px">
   <img src="../blockquote-configuration-citation.png"
-       alt="Image of three citation text examples"
+       alt="Three citation text examples"
        width="349"
        height="181">
 </uxdot-example>
@@ -194,7 +194,7 @@ Space values are the same in both sizes and on all breakpoints.
 
 <uxdot-example width-adjustment="872px">
   <img src="../blockquote-space.png"
-       alt="Image of four blockquotes with spacing values in between"
+       alt="Four blockquotes with spacing values in between"
        width="872"
        height="642">
 </uxdot-example>

--- a/elements/rh-blockquote/docs/20-guidelines.md
+++ b/elements/rh-blockquote/docs/20-guidelines.md
@@ -8,7 +8,7 @@ Use the Default size for larger amounts of text and the Large size for smaller a
 
 <uxdot-example width-adjustment="872px">
   <img src="../blockquote-usage-sizes.png" 
-      alt="Image of two blockquotes, default size on the left and large size on the right with green check icons below" 
+      alt="Two blockquotes, default size on the left and large size on the right with green check icons below" 
       width="872" 
       height="307">
 </uxdot-example>
@@ -23,7 +23,7 @@ Both blockquote sizes can be left or center aligned.
 
 <uxdot-example width-adjustment="872px">
   <img src="../blockquote-alignment.png" 
-      alt="Image of two blockquotes, default and large sizes both vertically centered" 
+      alt="Two blockquotes, default and large sizes both vertically centered" 
       width="872" 
       height="267">  
 </uxdot-example>
@@ -35,14 +35,14 @@ A variety of extras including an emphasis border, logo, and text styles may be a
 
 <uxdot-example width-adjustment="750px">
   <img src="../blockquote-variations-emphasis-a-theme-light.png" 
-      alt="Image of a light theme blockquote with red emphasis border"
+      alt="A light theme blockquote with red emphasis border"
       width="750" 
       height="207">
 </uxdot-example>
 
 <uxdot-example width-adjustment="750px">
   <img src="../blockquote-variations-emphasis-b-theme-light.png" 
-      alt="Image of two light theme blockquotes, left example is default size with logo and right example is default size with title text and heading text" 
+      alt="Two light theme blockquotes, left example is default size with logo and right example is default size with title text and heading text" 
       width="750" 
       height="319">
 </uxdot-example>
@@ -51,14 +51,14 @@ A variety of extras including an emphasis border, logo, and text styles may be a
 
 <uxdot-example color-palette="darkest" width-adjustment="750px">
   <img src="../blockquote-variations-emphasis-a-theme-dark.png" 
-      alt="Image of a dark theme blockquote with red emphasis border" 
+      alt="A dark theme blockquote with red emphasis border" 
       width="750" 
       height="207">
 </uxdot-example>
 
 <uxdot-example color-palette="darkest" width-adjustment="750px">
   <img src="../blockquote-variations-emphasis-b-theme-dark.png" 
-      alt="Image of two dark theme blockquotes, left example is default size with logo and right example is default size with title text and heading text" 
+      alt="Two dark theme blockquotes, left example is default size with logo and right example is default size with title text and heading text" 
       width="872" 
       height="319">
 </uxdot-example>
@@ -70,14 +70,14 @@ Other elements including a video or card may also be added to a blockquote. They
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-video.png" 
-      alt="Image of blockquote with video to the right" 
+      alt="Blockquote with video to the right" 
       width="1000" 
       height="372">
 </uxdot-example>
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-card.png" 
-      alt="Image of blockquote with card to the right" 
+      alt="Blockquote with card to the right" 
       width="1000" 
       height="414">
 </uxdot-example>
@@ -91,14 +91,14 @@ A minimum width is hard to determine because a blockquote can be placed in a var
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-min-width-a.png" 
-      alt="Image of default size blockquote left aligned with a minimum width of 450px" 
+      alt="Default size blockquote left aligned with a minimum width of 450px" 
       width="2000" 
       height="474">
 </uxdot-example>
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-min-width-b.png" 
-      alt="Image of large size blockquote vertically centered with a minimum width of 450px" 
+      alt="Large size blockquote vertically centered with a minimum width of 450px" 
       width="1000" 
       height="243">
 </uxdot-example>
@@ -110,14 +110,14 @@ The maximum width of a blockquote anywhere is <code>752px</code> to avoid reader
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-max-width-a.png" 
-      alt="Image of default size blockquote left aligned with a maximum width of 752px" 
+      alt="Default size blockquote left aligned with a maximum width of 752px" 
       width="1000" 
       height="177">
 </uxdot-example>
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-max-width-b.png" 
-      alt="Image of large size blockquote vertically centered with a maximum width of 752px"
+      alt="Large size blockquote vertically centered with a maximum width of 752px"
       width="1000"
       height="205">
 </uxdot-example>
@@ -127,7 +127,7 @@ The maximum width of a blockquote anywhere is <code>752px</code> to avoid reader
 A Default size blockquote can be placed in a card if the text is short enough. Otherwise, keep blockquotes with lots of text in the page layout to avoid readability issues. A blockquote will get taller as containers and breakpoints get smaller, so take that into consideration as well.
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
-  <img src="../blockquote-card-a.png" alt="Image of default size blockquote in a card">
+  <img src="../blockquote-card-a.png" alt="Default size blockquote in a card">
 </uxdot-example>
 
 
@@ -142,14 +142,14 @@ When other elements are used with blockquotes, they are placed on the right. Som
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-video-grid.png" 
-      alt="Image of blockquote with video to the right and a grid overlaid on top" 
+      alt="Blockquote with video to the right and a grid overlaid on top" 
       width="1000" 
       height="372">
 </uxdot-example>
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-card-grid.png" 
-      alt="Image of blockquote with card to the right and a grid overlaid on top" 
+      alt="Blockquote with card to the right and a grid overlaid on top" 
       width="1000" 
       height="414">
 </uxdot-example>
@@ -161,28 +161,28 @@ As breakpoints get smaller, blockquote text sizes will be reduced based on the m
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-default-desktop.png" 
-      alt="Image of a default size blockquote for desktop" 
+      alt="A default size blockquote for desktop" 
       width="1000" 
       height="147">
 </uxdot-example>
 
 <uxdot-example width-adjustment="768px" variant="full" no-border alignment="left">
   <img src="../blockquote-default-tablet.png" 
-      alt="Image of a default size blockquote for tablet" 
+      alt="A default size blockquote for tablet" 
       width="768" 
       height="147">
 </uxdot-example>
 
 <uxdot-example width-adjustment="576px" variant="full" no-border alignment="left">
   <img src="../blockquote-default-mobile-large.png" 
-      alt="Image of a default size blockquote for large mobile screens" 
+      alt="A default size blockquote for large mobile screens" 
       width="576" 
       height="141">
 </uxdot-example>
 
 <uxdot-example width-adjustment="360px" variant="full" no-border alignment="left">
   <img src="../blockquote-default-mobile-small.png" 
-      alt="Image of a default size blockquote for small mobile screens" 
+      alt="A default size blockquote for small mobile screens" 
       width="360" 
       height="168">
 </uxdot-example>
@@ -192,28 +192,28 @@ As breakpoints get smaller, blockquote text sizes will be reduced based on the m
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-large-desktop.png" 
-      alt="Image of a large size blockquote for desktop" 
+      alt="A large size blockquote for desktop" 
       width="1000" 
       height="205">
 </uxdot-example>
 
 <uxdot-example width-adjustment="768px" variant="full" no-border alignment="left">
   <img src="../blockquote-large-tablet.png" 
-      alt="Image of a large size blockquote for tablet"
+      alt="A large size blockquote for tablet"
       width="768" 
       height="205">
 </uxdot-example>
 
 <uxdot-example width-adjustment="576px" variant="full" no-border alignment="left">
   <img src="../blockquote-large-mobile-large.png" 
-      alt="Image of a large size blockquote for large mobile screens" 
+      alt="A large size blockquote for large mobile screens" 
       width="576" 
       height="184">
 </uxdot-example>
 
 <uxdot-example width-adjustment="360px" variant="full" no-border alignment="left">
   <img src="../blockquote-large-mobile-small.png"
-      alt="Image of a large size blockquote for small mobile screens"
+      alt="A large size blockquote for small mobile screens"
       width="360" 
       height="267">
 </uxdot-example>
@@ -222,28 +222,28 @@ As breakpoints get smaller, blockquote text sizes will be reduced based on the m
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-desktop.png" 
-      alt="Image of a blockquote with video for desktop" 
+      alt="A blockquote with video for desktop" 
       width="1000" 
       height="372">
 </uxdot-example>
 
 <uxdot-example width-adjustment="768px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-tablet.png" 
-      alt="Image of a blockquote with video for tablet" 
+      alt="A blockquote with video for tablet" 
       width="768" 
       height="354">
 </uxdot-example>
 
 <uxdot-example width-adjustment="576px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-mobile-large.png" 
-      alt="Image of a blockquote with video for large mobile screens" 
+      alt="A blockquote with video for large mobile screens" 
       width="576" 
       height="586">
 </uxdot-example>
 
 <uxdot-example width-adjustment="360px" variant="full" no-border alignment="left">
   <img src="../blockquote-other-elements-mobile-small.png" 
-      alt="Image of a blockquote with video for small mobile screens"
+      alt="A blockquote with video for small mobile screens"
       width="360" 
       height="519">
 </uxdot-example>
@@ -257,7 +257,7 @@ The quote icon and citation text must always be included.
 
 <uxdot-example width-adjustment="780px" danger>
   <img src="../blockquote-best-practice-1.png" 
-      alt="Image of two blockquotes both missing elements which is incorrect usage" 
+      alt="Two blockquotes both missing elements which is incorrect usage" 
       width="780" 
       height="201">
 </uxdot-example>
@@ -268,7 +268,7 @@ Blockquotes that are too thin are sometimes hard to read.
 
 <uxdot-example width-adjustment="477px" danger>
   <img src="../blockquote-best-practice-2.png" 
-    alt="Image of two very thin blockquotes which is incorrect usage" 
+    alt="Two very thin blockquotes which is incorrect usage" 
     width="477"
     height="416">
 </uxdot-example>
@@ -279,7 +279,7 @@ Do not add an emphasis border to a centered blockquote.
 
 <uxdot-example width-adjustment="633px" danger>
   <img src="../blockquote-best-practice-3.png" 
-      alt="Image of a large size blockquote with an emphasis border on the left which is incorrect usage" 
+      alt="A large size blockquote with an emphasis border on the left which is incorrect usage" 
       width="633" 
       height="205">
 </uxdot-example>
@@ -289,7 +289,7 @@ Do not place any elements near centered blockquotes.
 
 <uxdot-example width-adjustment="872px" danger>
   <img src="../blockquote-best-practice-4.png" 
-      alt="Image of a vertically centered blockquote with a placeholder element next to it which is incorrect usage" 
+      alt="A vertically centered blockquote with a placeholder element next to it which is incorrect usage" 
       width="872" 
       height="208">
 </uxdot-example>

--- a/elements/rh-blockquote/docs/20-guidelines.md
+++ b/elements/rh-blockquote/docs/20-guidelines.md
@@ -106,18 +106,18 @@ A minimum width is hard to determine because a blockquote can be placed in a var
 
 ### Maximum width
 
-The maximum width of a blockquote anywhere is <code>750px</code> to avoid reader fatigue.
+The maximum width of a blockquote anywhere is <code>752px</code> to avoid reader fatigue.
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-max-width-a.png" 
-      alt="Image of default size blockquote left aligned with a maximum width of 750px" 
+      alt="Image of default size blockquote left aligned with a maximum width of 752px" 
       width="1000" 
       height="177">
 </uxdot-example>
 
 <uxdot-example width-adjustment="1000px" variant="full" no-border alignment="left">
   <img src="../blockquote-max-width-b.png" 
-      alt="Image of large size blockquote vertically centered with a maximum width of 750px"
+      alt="Image of large size blockquote vertically centered with a maximum width of 752px"
       width="1000"
       height="205">
 </uxdot-example>

--- a/elements/rh-blockquote/docs/40-accessibility.md
+++ b/elements/rh-blockquote/docs/40-accessibility.md
@@ -1,6 +1,5 @@
 ## Implementation
 
-- To provide context, include an <code>aria-label</code> attribute in the markup
 - Ensure the blockquote is not interactive and cannot receive focus (unless there are interactive elements)
 - Ensure that surrounding content can convey the purpose of a blockquote via assistive technologies
 - Using a blockquote for anything other than its intended purpose will be confusing for assistive technologies

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -20,7 +20,8 @@ blockquote {
 }
 
 blockquote ::slotted(p) {
-  margin: var(--rh-length-lg, 16px) 0;
+  margin: 0;
+  margin-block-end: var(--rh-length-lg, 16px);
 }
 
 figcaption {
@@ -35,6 +36,7 @@ figcaption p {
 
 #author {
   font-weight: var(--rh-font-weight-heading-bold, 700);
+  margin-block-start: var(--rh-space-lg, 16px);
 }
 
 rh-icon {

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -8,7 +8,7 @@
   font-weight: var(--rh-font-weight-heading-regular, 300);
 }
 
-@media (min-width: 700px) {
+@media (min-width: 768px) {
   :host {
     font-size: var(--rh-font-size-body-text-xl, 1.25rem);
   }

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -57,17 +57,17 @@ rh-icon {
   margin-inline: auto;
 }
 
-:host([align='center']) blockquote ::slotted(*) {
+:host([align='center']) blockquote ::slotted(p) {
   max-inline-size: none !important;
 }
 
-:host([size='large']) blockquote ::slotted(*) {
+:host([size='large']) blockquote ::slotted(p) {
   font-size: var(--rh-font-size-body-text-2xl, 1.5rem) !important;
   line-height: var(--rh-line-height-heading, 1.3);
 }
 
 @media (min-width: 768px) {
-  :host([size='large']) blockquote ::slotted(*) {
+  :host([size='large']) blockquote ::slotted(p) {
     font-size: var(--rh-font-size-heading-md, 1.75rem) !important;
   }
 }

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -1,7 +1,7 @@
 :host {
   color: var(--rh-color-text-primary);
   margin: 0 auto;
-  text-align: left;
+  text-align: start;
   font-size: var(--rh-font-size-body-text-lg, 1.125rem);
   font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Malayalam', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Thai', Helvetica, Arial, sans-serif);
   line-height: var(--rh-line-height-body-text, 1.5);
@@ -46,7 +46,7 @@ rh-icon {
 }
 
 :host([align='center']) #quote ::slotted(*) {
-  max-width: none !important;
+  max-inline-size: none !important;
 }
 
 :host([size='large']) {

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -45,6 +45,10 @@ rh-icon {
   text-align: center;
 }
 
+:host([align='center']) #quote ::slotted(*) {
+  max-width: none !important;
+}
+
 :host([size='large']) {
   font-size: var(--rh-font-size-body-text-2xl, 1.5rem);
   line-height: var(--rh-line-height-heading, 1.3);

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -25,6 +25,7 @@ figure {
 }
 
 blockquote ::slotted(p) {
+  font-size: var(--rh-font-size-body-text-xl, 1.25rem) !important;
   margin: 0;
   margin-block-end: var(--rh-length-lg, 16px);
 }
@@ -60,14 +61,14 @@ rh-icon {
   max-inline-size: none !important;
 }
 
-:host([size='large']) {
-  font-size: var(--rh-font-size-body-text-2xl, 1.5rem);
+:host([size='large']) #quote ::slotted(*) {
+  font-size: var(--rh-font-size-body-text-2xl, 1.5rem) !important;
   line-height: var(--rh-line-height-heading, 1.3);
 }
 
-  :host([size='large']) {
 @media (min-width: 768px) {
-    font-size: var(--rh-font-size-heading-md, 1.75rem);
+  :host([size='large']) #quote ::slotted(*) {
+    font-size: var(--rh-font-size-heading-md, 1.75rem) !important;
   }
 }
 

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -65,8 +65,8 @@ rh-icon {
   line-height: var(--rh-line-height-heading, 1.3);
 }
 
-@media (min-width: 700px) {
   :host([size='large']) {
+@media (min-width: 768px) {
     font-size: var(--rh-font-size-heading-md, 1.75rem);
   }
 }

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -57,17 +57,17 @@ rh-icon {
   margin-inline: auto;
 }
 
-:host([align='center']) #quote ::slotted(*) {
+:host([align='center']) blockquote ::slotted(*) {
   max-inline-size: none !important;
 }
 
-:host([size='large']) #quote ::slotted(*) {
+:host([size='large']) blockquote ::slotted(*) {
   font-size: var(--rh-font-size-body-text-2xl, 1.5rem) !important;
   line-height: var(--rh-line-height-heading, 1.3);
 }
 
 @media (min-width: 768px) {
-  :host([size='large']) #quote ::slotted(*) {
+  :host([size='large']) blockquote ::slotted(*) {
     font-size: var(--rh-font-size-heading-md, 1.75rem) !important;
   }
 }

--- a/elements/rh-blockquote/rh-blockquote.css
+++ b/elements/rh-blockquote/rh-blockquote.css
@@ -19,6 +19,11 @@ blockquote {
   margin: 0;
 }
 
+figure {
+  display: block;
+  max-inline-size: 752px;
+}
+
 blockquote ::slotted(p) {
   margin: 0;
   margin-block-end: var(--rh-length-lg, 16px);
@@ -45,6 +50,10 @@ rh-icon {
 
 :host([align='center']) {
   text-align: center;
+}
+
+:host([align='center']) figure {
+  margin-inline: auto;
 }
 
 :host([align='center']) #quote ::slotted(*) {


### PR DESCRIPTION
## What I did

1. Center quotes when using `align="center"`
    * Uses `::slotted(p)` to override any `max-inline-size`/`max-width` declarations in end user stylesheets.
1. Enforces a max width of 752px.
1. Update blockquote docs
1. Fixes font size for quote content (bigger!)

## Testing Instructions

1. View the [Centered Demo](https://deploy-preview-2112--red-hat-design-system.netlify.app/elements/blockquote/demo/centered/) in the DP.
3. Ensure the quote is centered.
4. Put in a much longer quote to see how it wraps (at 752px).
5. Make sure other `rh-blockquote` demos look A-OK.
6. Make sure the docs look good.

## Notes to Reviewers

~~Users are encouraged to handle the line length of their `rh-blockquote`'s themselves (likely by wrapping this in a `<div>` with a `max-width`). This component doesn't specify `max-width`'s.~~

More changes in this PR than originally anticipated. Make sure everything looks as it should.

Closes #2103 