### PR TITLE
fix(pagination): Colors, right to left demo, and logical properties

### DIFF
--- a/elements/rh-pagination/demo/right-to-left.html
+++ b/elements/rh-pagination/demo/right-to-left.html
@@ -14,16 +14,6 @@
 
 <link rel="stylesheet" href="../rh-pagination-lightdom.css">
 
-<style>
-  #rtl-pagination {
-    gap: var(--rh-space-2xl, 32px);
-    padding: var(--rh-space-xl, 24px) var(--rh-space-4xl, 64px);
-    & rh-pagination {
-      justify-self: center;
-    }
-  }
-</style>
-
 <script type="module">
   import '@rhds/elements/rh-button/rh-button.js';
   import '@rhds/elements/rh-pagination/rh-pagination.js';

--- a/elements/rh-pagination/rh-pagination-lightdom.css
+++ b/elements/rh-pagination/rh-pagination-lightdom.css
@@ -121,10 +121,6 @@ rh-pagination:is([overflow='start'], [overflow='both']) li:first-child:after {
  * OPEN VARIANT
  *****************************************************************************/
 
-rh-pagination[variant|='open'] {
-  --_list-a-bg-color: transparent;
-}
-
 rh-pagination[variant|='open'] li > a:hover:after,
 rh-pagination[variant|='open'] li > a:focus:before,
 rh-pagination[variant|='open'] li > a:focus:after,
@@ -134,7 +130,10 @@ rh-pagination[variant|='open'] li > a[aria-current]:after {
   inset-block-end: -1px;
 }
 
+rh-pagination[variant|='open'] li > a {
+  --_list-a-bg-color: transparent;
+}
+
 rh-pagination[variant|='open'] li > a[aria-current] {
-  background-color: var(--_list-a-bg-color);
   border-color: transparent; /* NOTE: Keep active/hover borders in-line */
 }

--- a/elements/rh-pagination/rh-pagination-lightdom.css
+++ b/elements/rh-pagination/rh-pagination-lightdom.css
@@ -22,11 +22,11 @@ rh-pagination li > a {
   display: grid;
   font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Malayalam', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Thai', Helvetica, Arial, sans-serif);
   font-size: var(--rh-font-size-body-text-xl, 1.25rem);
-  height: var(--_link-size);
+  block-size: var(--_link-size);
   place-content: center;
   position: relative;
   text-decoration: none;
-  width: var(--_link-size);
+  inline-size: var(--_link-size);
 }
 
 rh-pagination[size='sm'] li > a {
@@ -51,7 +51,7 @@ rh-pagination li > a[aria-current]:after {
   inset-inline-start: -1px;
   position: absolute;
   inset-block-start: -1px;
-  width: 104%;
+  inline-size: 104%;
 }
 
 rh-pagination li > a:hover:after,
@@ -105,8 +105,8 @@ rh-pagination:is([overflow='start'], [overflow='both']) li:first-child {
 rh-pagination:is([overflow='end'], [overflow='both']) li:last-child:before,
 rh-pagination:is([overflow='start'], [overflow='both']) li:first-child:after {
   content: '…';
-  width: var(--_link-size);
-  height: var(--_link-size);
+  inline-size: var(--_link-size);
+  block-size: var(--_link-size);
   padding-inline-end: 4px;
   display: flex;
   align-items: center;

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -20,17 +20,23 @@
   gap: var(--rh-space-2xl, 32px) calc(var(--rh-space-xs, 4px) / 2);
   flex-wrap: wrap;
 
-  --rh-pagination-accent-color: var(--rh-color-interactive-primary-default);
+  /* stylelint-disable-next-line */
+  --rh-pagination-accent-color: var(--rh-color-interactive-primary-default, #0066cc);
   --_numeric-a-color: var(--rh-pagination-accent-color);
-  --_numeric-a-color-hover: var(--rh-color-interactive-primary-hover);
+  /* stylelint-disable-next-line */
+  --_numeric-a-color-hover: var(--rh-color-interactive-primary-hover, #003366);
   --_numeric-a-color-focus: var(--rh-pagination-accent-color);
   --_numeric-a-color-focus-outline: var(--rh-pagination-accent-color);
-  --_numeric-a-color-visited: var(--rh-color-interactive-primary-visited-default);
-  --_numeric-a-color-visited-hover: var(--rh-color-interactive-primary-visited-hover);
+  /* stylelint-disable-next-line */
+  --_numeric-a-color-visited: var(--rh-color-interactive-primary-visited-default, #5e40be);
+  /* stylelint-disable-next-line */
+  --_numeric-a-color-visited-hover: var(--rh-color-interactive-primary-visited-hover, #21134d);
   --_list-a-bg-color: var(--rh-color-surface-lighter, #f2f2f2);
-  --_list-a-current-page-border-color: var(--rh-color-border-subtle);
+  /* stylelint-disable-next-line */
+  --_list-a-current-page-border-color: var(--rh-color-border-subtle, #c7c7c7);
   --_list-a-current-page-bg-color: var(--rh-color-surface-lightest, #ffffff);
-  --_list-a-text-color: var(--rh-color-text-primary);
+  /* stylelint-disable-next-line */
+  --_list-a-text-color: var(--rh-color-text-primary, #151515);
   --_stepper-bg-color: var(--rh-color-surface-lighter, #f2f2f2);
   --_stepper-hover-focus-color: var(--rh-color-text-primary-on-dark, #ffffff);
   --_border-top-hover-color: var(--rh-color-gray-60, #4d4d4d);
@@ -177,7 +183,8 @@ input {
   width: var(--rh-length-4xl, 64px);
   font-size: var(--rh-font-size-body-text-md, 1rem);
   background: var(--rh-color-surface-lightest, #ffffff);
-  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+  /* stylelint-disable-next-line */
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, #c7c7c7);
   border-block-end-color: var(--rh-color-gray-40, #a3a3a3);
   box-sizing: border-box;
   padding-block: var(--rh-space-sm, 6px);

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -2,7 +2,7 @@
   --_stepper-size: var(--rh-length-3xl, 48px);
 
   display: block;
-  min-height: 4em;
+  min-block-size: 4em;
 }
 
 :host([size='sm']) {
@@ -61,39 +61,39 @@
 .visually-hidden {
   border: 0;
   clip: rect(0, 0, 0, 0);
-  height: 1px;
+  block-size: 1px;
   margin: -1px;
   overflow: hidden;
   padding: 0;
   position: absolute;
   white-space: nowrap;
-  width: 1px;
+  inline-size: 1px;
 }
 
 @container pagination (min-width: 344px) {
   .xxs-visually-hidden {
     border: 0;
     clip: rect(0, 0, 0, 0);
-    height: 1px;
+    block-size: 1px;
     margin: -1px;
     overflow: hidden;
     padding: 0;
     position: absolute;
     white-space: nowrap;
-    width: 1px;
+    inline-size: 1px;
   }
 }
 
 @container pagination (min-width: 768px) {
   .sm-visually-visible {
     clip: auto;
-    height: auto;
+    block-size: auto;
     margin: 0;
     overflow: visible;
     padding: 0;
     position: static;
     white-space: normal;
-    width: auto;
+    inline-size: auto;
   }
 }
 
@@ -118,11 +118,11 @@ svg {
   display: grid;
   font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Malayalam', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Thai', Helvetica, Arial, sans-serif);
   font-size: var(--rh-font-size-heading-xs, 1.25rem);
-  height: var(--_stepper-size);
+  block-size: var(--_stepper-size);
   place-content: center;
   position: relative;
   text-decoration: none;
-  width: var(--_stepper-size);
+  inline-size: var(--_stepper-size);
 }
 
 .stepper:focus {
@@ -137,10 +137,10 @@ svg {
 .stepper:focus:after {
   border-block-start-style: solid;
   content: '';
-  left: -1px;
+  inset-inline-start: -1px;
   position: absolute;
-  top: -1px;
-  width: 104%;
+  inset-block-start: -1px;
+  inline-size: 104%;
 }
 
 .stepper:hover:after,
@@ -155,7 +155,7 @@ svg {
 }
 
 .stepper svg {
-  height: 14px;
+  block-size: 14px;
 }
 
 :is(#next, #last) svg,
@@ -179,8 +179,8 @@ svg {
 }
 
 input {
-  height: var(--rh-length-2xl, 32px);
-  width: var(--rh-length-4xl, 64px);
+  block-size: var(--rh-length-2xl, 32px);
+  inline-size: var(--rh-length-4xl, 64px);
   font-size: var(--rh-font-size-body-text-md, 1rem);
   background: var(--rh-color-surface-lightest, #ffffff);
   /* stylelint-disable-next-line */
@@ -219,7 +219,7 @@ input:invalid:focus {
 
 #numeric-end {
   display: block;
-  width: 100%;
+  inline-size: 100%;
 }
 
 #numeric {
@@ -230,13 +230,13 @@ input:invalid:focus {
   gap: 0.5em;
   margin-block: 0;
   margin-inline: 0 var(--rh-space-lg, 16px);
-  min-height: var(--_stepper-size);
-  width: 100%;
+  min-block-size: var(--_stepper-size);
+  inline-size: 100%;
 }
 
 #numeric input {
   align-self: stretch;
-  height: auto;
+  block-size: auto;
 }
 
 #numeric a {


### PR DESCRIPTION
## What I did

1. Add fallback colors to fix incorrect colors from undefined color token variables
1. Fix background color being incorrectly applied to `<a>` tags in the `open` variant
1. Change `width`/`height`/`top`/`bottom` etc to use logical properties
1. Fix Right to Left demo layout

## Testing Instructions

1. First, view the [rh-pagination demo on uxdot](https://ux.redhat.com/elements/pagination/demo/).
1. Note the lack of proper colors
    * Active page borders
    * No border around stepper `<input>`
    * Link color incorrect 
1. Now view the rh-pagination demo from this DP.
    * Colors are correct as specified in [the docs](https://ux.redhat.com/elements/pagination/style/#variants)
1. Compare the [open variant demo on uxdot](https://ux.redhat.com/elements/pagination/demo/open/) vs the open variant on this DP. Make sure it matches specs.
1. Look at the [RTL demo on uxdot](https://ux.redhat.com/elements/pagination/demo/right-to-left/) (it's broken!). Now compare that to [this DP's RTL demo](#).

## Notes to Reviewers

Ensure that this is the proper way to handle adding fallback colors to things like `--rh-color-interactive-primary-default`.

Note: the [color context demo on uxdot](https://ux.redhat.com/elements/pagination/demo/color-context/) works because the component is wrapped in a `<rh-surface>`. These fallbacks are in place for when the component is not wrapped in a `<rh-surface>` component.