### PR TITLE
fix(avatar): remove margin-block-end for `plain` variant mobile viewports

### DIFF
--- a/.changeset/warm-forks-switch.md
+++ b/.changeset/warm-forks-switch.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-avatar>`: corrected small viewport margin for `plain` variant avatars

--- a/elements/rh-avatar/rh-avatar.css
+++ b/elements/rh-avatar/rh-avatar.css
@@ -57,7 +57,7 @@
 }
 
 :host([layout='block']) :is(img, canvas, svg),
-#container.mobile :is(img, canvas, svg) {
+:host(:not([plain])) #container.mobile :is(img, canvas, svg) {
   margin-block-end: var(--rh-space-lg, 16px);
 }
 


### PR DESCRIPTION
## What I did

1.  Removed rule that added bottom margin to `plain` variant avatars

Closes #2149 

## Testing Instructions

1. View Deploy Preview

## Notes to Reviewers

This may cause the implementation to update their own CSS if they encountered this issue and removed the margin themselves.
