### PR TITLE
docs: code tabs in webkit

### DIFF
--- a/docs/patterns/tabs/patterns/code-tabs.html
+++ b/docs/patterns/tabs/patterns/code-tabs.html
@@ -44,7 +44,6 @@
     border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
     border-radius: var(--rh-border-radius-default);
     max-width: 56rem; /* warning: magic number */
-    overflow: hidden;
 
     & rh-tab-panel {
       padding: 0;

--- a/uxdot/uxdot-pattern.css
+++ b/uxdot/uxdot-pattern.css
@@ -77,10 +77,9 @@ h3,
   gap: var(--rh-space-lg, 16px);
 }
 
-rh-tabs {
+#code-tabs {
   border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
   border-radius: var(--rh-border-radius-default);
-  overflow: hidden;
   grid-area: code;
 
   & rh-tab-panel {


### PR DESCRIPTION
Closes #1993

## What I did

1. remove superfluous overflow property from code tabs pattern, which somehow fixes this problem :shrug: 


## Testing Instructions

1. https://ux.redhat.com/elements/code-block/code/
2. https://ux.redhat.com/theming/customizing/
3. https://ux.redhat.com/theming/color-palettes/

## Notes to Reviewers
