### PR TITLE
feat(footer): href attribute for social links

### DIFF
--- a/.changeset/forty-colts-tie.md
+++ b/.changeset/forty-colts-tie.md
@@ -1,0 +1,26 @@
+---
+"@rhds/elements": minor
+---
+`<rh-footer>`: social link element can now take an `href` attribute instead of a slotted link. The previous behaviour will still work.
+
+Before:
+
+```html
+
+<rh-footer-social-link slot="social-links"
+                       icon="linkedin"><a href="https://www.linkedin.com/company/red-hat"
+                                          data-analytics-region="social-links-exit"
+                                          data-analytics-category="Footer|social-links"
+                                          data-analytics-text="LinkedIn">LinkedIn</a></rh-footer-social-link>
+```
+
+After:
+```html
+  <rh-footer-social-link slot="social-links"
+                         icon="linkedin"
+                         href="https://www.linkedin.com/company/red-hat"
+                         data-analytics-region="social-links-exit"
+                         data-analytics-category="Footer|social-links"
+                         data-analytics-text="LinkedIn"
+                         accessible-label="LinkedIn"></rh-footer-social-link>
+```

--- a/elements/rh-footer/demo/slotted-social-links.html
+++ b/elements/rh-footer/demo/slotted-social-links.html
@@ -2,34 +2,10 @@
   <a slot="logo" href="https://redhat.com/en" data-analytics-category="Footer" data-analytics-text="Logo">
     <img alt="Red Hat logo" src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg" loading="lazy" />
   </a>
-  <rh-footer-social-link slot="social-links"
-                         icon="linkedin"
-                         href="https://www.linkedin.com/company/red-hat"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="LinkedIn"
-                         accessible-label="LinkedIn"></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="youtube"
-                         href="https://www.youtube.com/user/RedHatVideos"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="YouTube"
-                         accessible-label="YouTube"></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="facebook"
-                         href="https://www.facebook.com/redhatinc"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="Facebook"
-                         accessible-label="Facebook"></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="x"
-                         href="https://twitter.com/RedHat"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="Twitter"
-                         accessible-label="X/Twitter"></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links" icon="linkedin"><a href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn">LinkedIn</a></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links" icon="youtube"><a href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube">YouTube</a></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links" icon="facebook"><a href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook">Facebook</a></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links" icon="x"><a href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Twitter">X/Twitter</a></rh-footer-social-link>
   <h3 slot="links" data-analytics-text="Products">Products</h3>
   <ul slot="links">
     <li><a href="https://redhat.com/en/technologies/linux-platforms/enterprise-linux" data-analytics-category="Footer|Products" data-analytics-text="Red Hat Enterprise Linux">Red Hat Enterprise Linux</a></li>

--- a/elements/rh-footer/rh-footer-social-link.css
+++ b/elements/rh-footer/rh-footer-social-link.css
@@ -8,10 +8,12 @@
   display: none !important;
 }
 
+a,
 ::slotted(a) {
   color: var(--_icon-color) !important;
 }
 
+a:is(:hover, :focus-within),
 ::slotted(a:is(:hover, :focus-within)) {
   color: var(--_icon-color-hover) !important;
 }

--- a/elements/rh-footer/rh-footer-social-link.ts
+++ b/elements/rh-footer/rh-footer-social-link.ts
@@ -8,6 +8,10 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import style from './rh-footer-social-link.css';
 
+/**
+ * Social media links for Red Hat Footer
+ * @slot - Optional icon for social link. Use only when suitable icon is unavailable with `<rh-icon>`
+ */
 @customElement('rh-footer-social-link')
 export class RhFooterSocialLink extends LitElement {
   static readonly styles = style;

--- a/elements/rh-footer/rh-footer-social-link.ts
+++ b/elements/rh-footer/rh-footer-social-link.ts
@@ -1,6 +1,6 @@
 import type { IconNameFor } from '@rhds/icons';
 
-import { LitElement, html } from 'lit';
+import { LitElement, html, isServer } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
@@ -15,6 +15,12 @@ export class RhFooterSocialLink extends LitElement {
   /** Icon for this social link e.g. `'facebook'` */
   @property() icon?: IconNameFor<'social'>;
 
+  /** Social link address */
+  @property() href?: string;
+
+  /** Textual label for the social link e.g. "Instagram" */
+  @property({ attribute: 'accessible-label' }) accessibleLabel?: string;
+
   #logger = new Logger(this);
 
   connectedCallback() {
@@ -23,12 +29,18 @@ export class RhFooterSocialLink extends LitElement {
   }
 
   render() {
-    return html`<slot></slot>`;
+    return html`
+      <a href="${this.href}" aria-label="${this.accessibleLabel}">
+        <slot>
+          <rh-icon set="social" icon="${this.icon}"></rh-icon>
+        </slot>
+      </a>
+    `;
   }
 
   updated() {
-    const oldDiv = this.querySelector('a');
-    if (oldDiv) {
+    let oldDiv;
+    if (!isServer && (oldDiv = this.querySelector('a'))) {
       const newDiv = oldDiv.cloneNode(true) as Element;
       // remove the _rendered content
       newDiv.querySelectorAll('[_rendered]').forEach(i => i.remove());


### PR DESCRIPTION
## What I did

1. allow users to specify a social link in the footer by adding an href attribute to the social link custom element, instead of slotted in a link element.
2. Analytics attributes on the host _should_ still work, so long as the latest click-to-eddl is loaded 🤞 
3. users must also include an `accessible-label` attribute
4. existing markup will still work
5. Even when using the slotted links, JavaScript is still necessary. (see the `updated` method in rh-footer-social link)


## Testing Instructions

1. see the modified rh-footer main demo
2. see the old rh-footer demo, now renamed to slotted social links

## Notes to Reviewers
