### PR TITLE
bug(subnav): fixing color-context inheritance

### DIFF
--- a/elements/rh-subnav/rh-subnav.ts
+++ b/elements/rh-subnav/rh-subnav.ts
@@ -8,7 +8,7 @@ import { property } from 'lit/decorators/property.js';
 import { OverflowController } from '@patternfly/pfe-core/controllers/overflow-controller.js';
 
 import { colorContextConsumer, type ColorTheme } from '../../lib/context/color/consumer.js';
-import { colorContextProvider } from '../../lib/context/color/provider.js';
+import { colorContextProvider, type ColorPalette } from '../../lib/context/color/provider.js';
 
 import '@rhds/elements/rh-icon/rh-icon.js';
 
@@ -63,7 +63,7 @@ export class RhSubnav extends LitElement {
    * See [CSS Custom Properties](#css-custom-properties) for default values
    */
   @colorContextProvider()
-  @property({ reflect: true, attribute: 'color-palette' }) colorPalette = 'lighter';
+  @property({ reflect: true, attribute: 'color-palette' }) colorPalette?: ColorPalette;
 
   /**
    * Customize the default `aria-label` on the `<nav>` container.
@@ -109,9 +109,9 @@ export class RhSubnav extends LitElement {
   render() {
     const { scrollIconSet, scrollIconLeft, scrollIconRight } = this.constructor as typeof RhSubnav;
     const { showScrollButtons } = this.#overflow;
-    const { on = '' } = this;
+    const { on = 'light' } = this;
     return html`
-      <nav part="container" aria-label="${this.accessibleLabel}" class="${classMap({ [on]: !!on })}">${!showScrollButtons ? '' : html`
+      <nav part="container" aria-label="${this.accessibleLabel}" class="${classMap({ on: true, [on]: !!on })}">${!showScrollButtons ? '' : html`
         <button id="previous" tabindex="-1" aria-hidden="true"
                 ?disabled="${!this.#overflow.overflowLeft}"
                 @click="${this.#scrollLeft}">


### PR DESCRIPTION
## What I did

1. Fixed the `<rh-subnav>` color-context inheritance from parent elements


## Testing Instructions

1. Go to Subnav's color context demo
2. Check inheritance from the demo color-palette colors. Subnav should change to dark mode on dark themes.
3. Add `color-palette="darkest"` to `<rh-subnav>`, and test the demo color-palette colors. Subnav should remain in dark mode (with proper text/tab color contrast)
3. Add `color-palette="lightest"` to `<rh-subnav>`, and test the demo color-palette colors. Subnav should remain in light mode (with proper text/tab color contrast)

Not sure if we want to add in the documentation info missing in #1479 as well.


Closes #2188 
