### PR TITLE
fix(card): use `--rh-space` tokens

### DIFF
--- a/.changeset/moody-ears-clean.md
+++ b/.changeset/moody-ears-clean.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-card>`: corrected margins on small screens

--- a/elements/rh-card/rh-card.css
+++ b/elements/rh-card/rh-card.css
@@ -151,6 +151,12 @@
   margin-block-end: 0;
 }
 
+@container card (max-width: 767px) {
+  #body{
+    margin-block: var(--rh-space-xl, 24px);
+  }
+}
+
 @container card (min-width: 768px) {
   #header,
   #body,

--- a/elements/rh-card/rh-card.css
+++ b/elements/rh-card/rh-card.css
@@ -152,7 +152,7 @@
 }
 
 @container card (max-width: 767px) {
-  #body{
+  #body {
     margin-block: var(--rh-space-xl, 24px);
   }
 }


### PR DESCRIPTION

## What I did

Changed the margin-block value of the rh-card `#body` to --rh-space-xl in smaller containers."
Resolved: https://github.com/RedHat-UX/red-hat-design-system/issues/2207


## Testing Instructions

Verify the margin-block value in smaller containers
<img width="1439" alt="Screenshot 2025-03-15 at 3 58 38 PM" src="https://github.com/user-attachments/assets/490f1a06-b90a-4dce-b9af-8d7f8c5537d3" />
<img width="1439" alt="Screenshot 2025-03-15 at 3 58 49 PM" src="https://github.com/user-attachments/assets/877bebdd-47b6-42a2-8f79-6e31a15c72b6" />


## Notes to Reviewers
