### PR TITLE
docs(footer): add default slot description for `<rh-footer-social-link>`

### DIFF
--- a/elements/rh-footer/rh-footer-social-link.ts
+++ b/elements/rh-footer/rh-footer-social-link.ts
@@ -8,6 +8,12 @@ import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import style from './rh-footer-social-link.css';
 
+/**
+ * Displays a linked icon to a social media property
+ * @summary Displays a linked icon to a social media property
+ * @slot    - Add an anchor tag linking to a social media property
+*/
+
 @customElement('rh-footer-social-link')
 export class RhFooterSocialLink extends LitElement {
   static readonly styles = style;


### PR DESCRIPTION
## What I did

1. Added a description for the `<rh-footer-social-link>` default slot

## Testing Instructions

1. View the [Code docs](https://deploy-preview-2224--red-hat-design-system.netlify.app/elements/footer/code/#rh-footer-social-link-apis) for rh-footer
2. Scroll down to `<rh-footer-social-link>` (or click the link above)
3. Verify the description makes sense / looks good.

## Notes to Reviewers

Closes #2181 