### PR TITLE
docs: destroy import map cache on error

### DIFF
--- a/docs/_includes/layouts/pages/element.11ty.ts
+++ b/docs/_includes/layouts/pages/element.11ty.ts
@@ -256,6 +256,11 @@ export default class ElementsPage extends Renderer<Context> {
 
   async #renderInstallation({ doc, cdnVersion = 'v1-alpha' }: Context) {
     const jspmMap = await this.#generateImportMap(doc.docsPage.tagName)
+        .catch(() => {
+          // try again
+          ElementsPage.assetCache.cache.destroy();
+          return this.#generateImportMap(doc.docsPage.tagName);
+        })
         .catch(error => {
           console.warn(error); // eslint-disable-line no-console
           return `Could not generate import map using JSPM: ${error.message}`;


### PR DESCRIPTION
Hopefully this will solve intermittent errors when generating the import map for element pages
