### PR TITLE
docs(cards+tiles): adding cards vs tiles context and cross links

### DIFF
--- a/elements/rh-card/docs/00-overview.md
+++ b/elements/rh-card/docs/00-overview.md
@@ -14,7 +14,7 @@
 
 <div id="guidelines-links">
   <rh-cta><a href="guidelines/#usage">Usage guidelines</a></rh-cta>
-  <rh-cta><a href="guidelines/#tile-vs.-card">Cards vs. tiles</a></rh-cta>
+  <rh-cta><a href="guidelines/#cards-vs.-tiles">Cards vs. tiles</a></rh-cta>
 </div>
 
 

--- a/elements/rh-card/docs/00-overview.md
+++ b/elements/rh-card/docs/00-overview.md
@@ -1,22 +1,9 @@
-<style>
-  #guidelines-links {
-    display: flex;
-    gap: var(--rh-space-lg);
-    flex-direction: column;
-    margin-block-start: var(--rh-space-3xl);
-  }
-</style>
-
 ## When to use
 
 - When you need to group content in a container
 - When you need to combine small previews of information along with one or more calls to action
 
-<div id="guidelines-links">
-  <rh-cta><a href="guidelines/#usage">Usage guidelines</a></rh-cta>
-  <rh-cta><a href="guidelines/#cards-vs.-tiles">Cards vs. tiles</a></rh-cta>
-</div>
-
+<rh-cta><a href="guidelines/#cards-vs.-tiles">Cards vs. tiles</a></rh-cta>
 
 <div id="overview-image-description" class="visually-hidden">
   Image of a card element

--- a/elements/rh-card/docs/00-overview.md
+++ b/elements/rh-card/docs/00-overview.md
@@ -1,3 +1,23 @@
+<style>
+  #guidelines-links {
+    display: flex;
+    gap: var(--rh-space-lg);
+    flex-direction: column;
+    margin-block-start: var(--rh-space-3xl);
+  }
+</style>
+
+## When to use
+
+- When you need to group content in a container
+- When you need to combine small previews of information along with one or more calls to action
+
+<div id="guidelines-links">
+  <rh-cta><a href="guidelines/#usage">Usage guidelines</a></rh-cta>
+  <rh-cta><a href="guidelines/#tile-vs.-card">Cards vs. tiles</a></rh-cta>
+</div>
+
+
 <div id="overview-image-description" class="visually-hidden">
   Image of a card element
 </div>

--- a/elements/rh-card/docs/20-guidelines.md
+++ b/elements/rh-card/docs/20-guidelines.md
@@ -21,7 +21,11 @@ see the [card patterns page](/patterns/card).
 
 ### Cards vs. tiles
 
-The main difference between a card and a [tile](/elements/tile/) is that cards can be used as content containers with or without links or other actions. Cards can also contain more than one calls to action, whereas tiles **must** perform only one action. Like tiles, however, cards can be grouped together.
+The main difference between a card and a [tile](/elements/tile/) is that cards may or may not contain links or other actions. Cards can even contain multiple calls to action.
+
+Tiles, on the other hand, must perform exactly one action. No more or less.
+
+Cards can be grouped together with other cards, and tiles can be grouped together with other tiles.
 
 
 ### Patterns

--- a/elements/rh-card/docs/20-guidelines.md
+++ b/elements/rh-card/docs/20-guidelines.md
@@ -19,6 +19,10 @@ see the [card patterns page](/patterns/card).
 
 </rh-alert>
 
+### Cards vs. tiles
+
+The main difference between a card and a [tile](/elements/tile/) is that cards can be used as content containers with or without links or other actions. Cards can also contain more than one calls to action, whereas tiles **must** perform only one action. Like tiles, however, cards can be grouped together.
+
 
 ### Patterns
 

--- a/elements/rh-tile/docs/00-overview.md
+++ b/elements/rh-tile/docs/00-overview.md
@@ -1,22 +1,10 @@
-<style>
-  #guidelines-links {
-    display: flex;
-    gap: var(--rh-space-lg);
-    flex-direction: column;
-    margin-block-start: var(--rh-space-3xl);
-  }
-</style>
-
 ## When to use
 
 - When you need to group content in a **linked** container
 - When you need an alternative to a group of cards with the same calls to action
 - When you need to group content for a radio button or checkbox in a form
 
-<div id="guidelines-links">
-  <rh-cta><a href="guidelines/#usage">Usage guidelines</a></rh-cta>
-  <rh-cta><a href="guidelines/#tiles-vs.-cards">Tiles vs. cards</a></rh-cta>
-</div>
+<rh-cta><a href="guidelines/#tiles-vs.-cards">Tiles vs. cards</a></rh-cta>
 
 <div id="overview-image-description" class="visually-hidden">
   Example of a default link tile and a selectable tile

--- a/elements/rh-tile/docs/00-overview.md
+++ b/elements/rh-tile/docs/00-overview.md
@@ -15,7 +15,7 @@
 
 <div id="guidelines-links">
   <rh-cta><a href="guidelines/#usage">Usage guidelines</a></rh-cta>
-  <rh-cta><a href="guidelines/#tile-vs.-card">Tiles vs. cards</a></rh-cta>
+  <rh-cta><a href="guidelines/#tiles-vs.-cards">Tiles vs. cards</a></rh-cta>
 </div>
 
 <div id="overview-image-description" class="visually-hidden">

--- a/elements/rh-tile/docs/00-overview.md
+++ b/elements/rh-tile/docs/00-overview.md
@@ -1,8 +1,22 @@
+<style>
+  #guidelines-links {
+    display: flex;
+    gap: var(--rh-space-lg);
+    flex-direction: column;
+    margin-block-start: var(--rh-space-3xl);
+  }
+</style>
+
 ## When to use
 
-- When you need to group content in a linked container
+- When you need to group content in a **linked** container
 - When you need an alternative to a group of cards with the same calls to action
 - When you need to group content for a radio button or checkbox in a form
+
+<div id="guidelines-links">
+  <rh-cta><a href="guidelines/#usage">Usage guidelines</a></rh-cta>
+  <rh-cta><a href="guidelines/#tile-vs.-card">Tiles vs. cards</a></rh-cta>
+</div>
 
 <div id="overview-image-description" class="visually-hidden">
   Example of a default link tile and a selectable tile

--- a/elements/rh-tile/docs/20-guidelines.md
+++ b/elements/rh-tile/docs/20-guidelines.md
@@ -5,8 +5,11 @@ are two types, link tiles and selectable tiles. Both can be used in groups or in
 
 ### Tiles vs. cards
 
-The primary distinguishing factor between a tile and a [card](/elements/card/) is that each tile **must** perform only one action, because its whole surface is interactive (e.g., can be clicked). A tile also has the ability to be used as selectable
-items in a form. Tiles can be grouped together like cards, however.
+The primary distinguishing factor between a tile and a [card](/elements/card/) is that each tile **must** perform only one action, because its whole surface is interactive (e.g., can be clicked).
+
+Tiles also have the ability to be used as selectable items in a form.
+
+Tiles can be grouped together with other tiles, and cards can be grouped together with other cards.
 
 ## Variants
 

--- a/elements/rh-tile/docs/20-guidelines.md
+++ b/elements/rh-tile/docs/20-guidelines.md
@@ -3,10 +3,10 @@
 A tile can be used when a clickable container is needed to provide one call to action or show one form input option. It can be grouped with similarly-structured and styled tiles in a tile group. There
 are two types, link tiles and selectable tiles. Both can be used in groups or individually, except for a selectable tile with a radio button, which always has to be grouped.
 
-### Tile vs. card
+### Tiles vs. cards
 
-The primary distinguishing factor between a tile and a card is that each tile can perform only one action because the whole surface is clickable. A tile also has the ability to be used as selectable
-items in a form. Tiles can be grouped together like card, however.
+The primary distinguishing factor between a tile and a [card](/elements/card/) is that each tile **must** perform only one action, because its whole surface is interactive (e.g., can be clicked). A tile also has the ability to be used as selectable
+items in a form. Tiles can be grouped together like cards, however.
 
 ## Variants
 


### PR DESCRIPTION
## What I did

1. Added some cards vs tiles content to explain the difference between each


## Testing Instructions

1. Check out Tile's ["When to use"](https://deploy-preview-2245--red-hat-design-system.netlify.app/elements/tile/#when-to-use) section and ["Usage"](https://deploy-preview-2245--red-hat-design-system.netlify.app/elements/tile/guidelines/#usage) guidelines section
2. Check out Card's ["When to use"](https://deploy-preview-2245--red-hat-design-system.netlify.app/elements/card/#when-to-use) section and ["Usage"](https://deploy-preview-2245--red-hat-design-system.netlify.app/elements/card/guidelines/#usage) guidelines section

Closes: #2113 