### PR TITLE
docs: fix get started dev/design cross-link 404s

### DIFF
--- a/docs/get-started/designers.md
+++ b/docs/get-started/designers.md
@@ -18,9 +18,9 @@ tags:
 </script>
 
 {#
-  the .page-designers rule allows for spacing of "sections" while only using
-  headers which are converted to uxdot-copy-permalink
-  TODO: determine if this is how we want to do this
+the .page-designers rule allows for spacing of "sections" while only using
+headers which are converted to uxdot-copy-permalink
+TODO: determine if this is how we want to do this
 #}
 
 <style data-helmet>
@@ -62,17 +62,16 @@ Welcome to the **Red Hat Design System** (RHDS) for digital experiences. If you
 need to design something using our design system, you have come to the right
 place.
 
-Follow these steps to get started and e-mail 
+Follow these steps to get started and e-mail
 [design-system@redhat.com][designsystemredhatcom] or connect with us
 on Slack if you have any questions along the way.
 
-
 ## Explore brand standards
 
-Our [Brand standards][brandstandards] are the source code of the Red Hat brand. 
-Using brand standards as the starting point for every project ensures that every 
-interaction with Red Hat reflects our brand personality, brand strategy, and 
-consistent visual language. Consistency is how we create authentic relationships 
+Our [Brand standards][brandstandards] are the source code of the Red Hat brand.
+Using brand standards as the starting point for every project ensures that every
+interaction with Red Hat reflects our brand personality, brand strategy, and
+consistent visual language. Consistency is how we create authentic relationships
 and credibility with our customers, partners, and contributors.
 
 <uxdot-example variant="full">
@@ -263,16 +262,16 @@ prioritize building them in.
 
 Use these resources to help you stay aligned to our brand and design system while working.
 
--   [Brand standards][brandstandards]
--   [Foundations][foundations], [elements][elements], and
-    [patterns][patterns]
--   Reference existing pages so you can see how brand and design system
-    assets are being used
-    -   [redhat.com home page][redhatcomhomepage]
-    -   [Product page][productpage]
-    -   [Resource article page][resourcearticlepage]
-    -   [Catalog SERP][catalogserp]
-    -   [Product trial page][producttrialpage]
+- [Brand standards][brandstandards]
+- [Foundations][foundations], [elements][elements], and
+  [patterns][patterns]
+- Reference existing pages so you can see how brand and design system
+  assets are being used
+  - [redhat.com home page][redhatcomhomepage]
+  - [Product page][productpage]
+  - [Resource article page][resourcearticlepage]
+  - [Catalog SERP][catalogserp]
+  - [Product trial page][producttrialpage]
 
 ## Frequently asked questions
 
@@ -326,7 +325,7 @@ For questions, additional support, or training, e-mail
 
 <uxdot-feedback>
   <h2>Developers</h2>
-  <p>To get started using our design system as a developer, go to the <a href="get-started/developers">Developers</a> page.</p>
+  <p>To get started using our design system as a developer, go to the <a href="/get-started/developers">Developers</a> page.</p>
 </uxdot-feedback>
 
 [brandstandards]: https://www.redhat.com/en/about/brand/standards

--- a/docs/get-started/developers/contributing.md
+++ b/docs/get-started/developers/contributing.md
@@ -14,7 +14,6 @@ subnav:
   import '@rhds/elements/rh-tag/rh-tag.js';
 </script>
 
-
 <style data-helmet>
   rh-code-block + rh-code-block {
     margin-block-start: var(--rh-spacer-2xl, 32px);
@@ -23,11 +22,11 @@ subnav:
 
 ## Install Project
 
-A quick start guide for installing the local development tools needed for 
+A quick start guide for installing the local development tools needed for
 contributing to the Red Hat Design System.
 
 1. [Install Git][installgit] for your system.
-2. [Install Node Version Manager][installnodeversionmanager] for your system.  
+2. [Install Node Version Manager][installnodeversionmanager] for your system.
 3. Clone the Red Hat Design System repository from Github.
 
 ```shell rhcodeblock
@@ -42,20 +41,20 @@ cd red-hat-design-system
 
 ### 5. Get the proper Node version
 
-Run [Node Version Manager's][nodeversionmanagers] `use` command to switch to 
+Run [Node Version Manager's][nodeversionmanagers] `use` command to switch to
 the projects [Node][node] version.
 
 ```shell rhcodeblock
 nvm use
 ```
 
-If prompted, follow the instructions for installing specific version of Node 
-[used by this project][usedbythisproject] on your system, which will look 
+If prompted, follow the instructions for installing specific version of Node
+[used by this project][usedbythisproject] on your system, which will look
 similar to the following:
 
 > `You need to run "nvm install v20.10.0" to install it before using it.`
 
-### 6. Install dependencies 
+### 6. Install dependencies
 
 Install project dependencies, run `npm ci`
 
@@ -65,24 +64,25 @@ npm ci
 
 ## Development Servers
 
-RHDS repo comes with two dev servers, one for working on elements, the other 
+RHDS repo comes with two dev servers, one for working on elements, the other
 for working on patterns and docs.
 
 ### Running both servers
+
 Start the development servers `npm start`.
 
 ```shell rhcodeblock
 npm start
 ```
 
-Two servers will start, if no other processes are using port `:8000` or 
-`:8080` the element development server will load on `:8000` and the 
-documentation server will load on `:8080`. The element server will auto open 
-a browser window, the documentation server however will not.  
+Two servers will start, if no other processes are using port `:8000` or
+`:8080` the element development server will load on `:8000` and the
+documentation server will load on `:8080`. The element server will auto open
+a browser window, the documentation server however will not.
 
 ### Running them separately
 
-To run these servers independently you can use the commands `npm run dev` and 
+To run these servers independently you can use the commands `npm run dev` and
 `npm run serve`.
 
 ```shell rhcodeblock
@@ -96,6 +96,7 @@ npm run serve
 ## Creating a new element
 
 ### 1. Scaffolding
+
 Run the new element generator command `npm run new`
 
 ```shell rhcodeblock
@@ -103,14 +104,16 @@ npm run new
 ```
 
 ### 2. Element name
-You will be prompted for a element name.  For Red Hat Design System elements 
- use prefix `rh-` followed by the elements name e.g: `rh-element-name`.
+
+You will be prompted for a element name. For Red Hat Design System elements
+use prefix `rh-` followed by the elements name e.g: `rh-element-name`.
 
 ### 3. Generated files
-A new folder will be created in the `./elements/rh-element-name` directory 
- with the name of the element you chose.
 
- The following files will also be created for you:
+A new folder will be created in the `./elements/rh-element-name` directory
+with the name of the element you chose.
+
+The following files will also be created for you:
 
 - `./elements/rh-element-name/demo/rh-element-name.html`
 - `./elements/rh-element-name/demo/rh-element-name.js`
@@ -128,8 +131,8 @@ A new folder will be created in the `./elements/rh-element-name` directory
 
 ### 4. Develop your element
 
-For more information please read our [Wiki][wiki] page on [adding new 
-components][addingnewcomponents] 
+For more information please read our [Wiki][wiki] page on [adding new
+components][addingnewcomponents]
 
 ## Testing
 
@@ -146,9 +149,9 @@ npm run test -- -- ./elements/rh-element-name/test/rh-element-name.spec.ts
 ```
 
 The project uses [Mocha][mocha] and [Chai][chai] and are run via
-[Web Test Runner][webtestrunner]. For more detailed information about testing 
-and how we write tests please see our [Testing][testing] page on the Wiki and 
-our [introduction to testing RHDS 
+[Web Test Runner][webtestrunner]. For more detailed information about testing
+and how we write tests please see our [Testing][testing] page on the Wiki and
+our [introduction to testing RHDS
 components][introductiontotestingrhdscomponents] with Chai A11y aXe and
 `a11ySnapshot`.
 
@@ -156,16 +159,16 @@ components][introductiontotestingrhdscomponents] with Chai A11y aXe and
 
 Please read our Developer Guidelines section of our [Wiki][wiki]
 
-  - [Custom Element API Style Guide][customelementapistyleguide]
-  - [Shadow DOM][shadowdom]
-  - [HTML Formatting][htmlformatting]
-  - [CSS][css]
-  - [JSDoc][jsdoc]
+- [Custom Element API Style Guide][customelementapistyleguide]
+- [Shadow DOM][shadowdom]
+- [HTML Formatting][htmlformatting]
+- [CSS][css]
+- [JSDoc][jsdoc]
 
 ## Contributing
 
-When your code is ready to push to our repository, please open a Pull 
-Request/Merge Request. You may first need to request access. Please reach out to 
+When your code is ready to push to our repository, please open a Pull
+Request/Merge Request. You may first need to request access. Please reach out to
 us on Slack `#red-hat-design-system`
 <rh-tag color="red" variant="outline">Internal Red Hat only</rh-tag> or
 [open an issue][openanissue].
@@ -175,7 +178,7 @@ Before pushing your code please read our
 
 <uxdot-feedback>
   <h2>Designers</h2>
-  <p>To get started using our design system as a designer, go to the <a href="get-started/designers">Designers</a> page.</p>
+  <p>To get started using our design system as a designer, go to the <a href="/get-started/designers">Designers</a> page.</p>
 </uxdot-feedback>
 
 [addingnewcomponents]: https://github.com/RedHat-UX/red-hat-design-system/wiki/Adding-New-Components

--- a/docs/get-started/developers/index.md
+++ b/docs/get-started/developers/index.md
@@ -51,13 +51,11 @@ order: 20
   }
 </style>
 
-
 ## Introduction
 
 Welcome to the **Red Hat Design System** (RHDS) for digital experiences. If you need to develop something using our design system, you have come to the right place.
 
 Read this section to get started and e-mail [design-system@redhat.com](mailto:design-system@redhat.com) or connect with us on Slack if you have any questions along the way.
-
 
 ## Learn about our design system
 
@@ -102,7 +100,6 @@ Our design system libraries and the documentation website offer assets and guida
     </rh-cta>
   </rh-card>
 </div>
-
 
 ## About Web Components
 
@@ -170,7 +167,7 @@ We anticipate that if HTML modules and CSS modules become widely implemented in 
 
 <uxdot-feedback>
   <h2>Designers</h2>
-  <p>To get started using our design system as a designer, go to the <a href="get-started/designers">Designers</a> page.</p>
+  <p>To get started using our design system as a designer, go to the <a href="/get-started/designers">Designers</a> page.</p>
 </uxdot-feedback>
 
 [ce]: https://html.spec.whatwg.org/dev/custom-elements.html#custom-elements

--- a/docs/get-started/developers/installation.md
+++ b/docs/get-started/developers/installation.md
@@ -18,8 +18,8 @@ subnav:
 
 ## How to install
 
-There are three ways you can install the Red Hat Design System's web components: 
-CDN, NPM, or JSPM. Each element's "Code" page includes the same installation 
+There are three ways you can install the Red Hat Design System's web components:
+CDN, NPM, or JSPM. Each element's "Code" page includes the same installation
 information with code snippets that are specific to that element.
 
 ### Red Hat CDN
@@ -32,13 +32,13 @@ information with code snippets that are specific to that element.
     installation process please connect with us on Slack.</p>
 </rh-alert>
 
-The recommended way to load RHDS is via the Red Hat Digital Experience CDN, and 
+The recommended way to load RHDS is via the Red Hat Digital Experience CDN, and
 using an [import map][importmap].
 
-If you have full control over the page you are using, add an import map to the 
-`<head>`, pointing to the CDN, or update any existing import map. If you are not 
-responsible for the page's `<head>`, request that the page owner makes the 
-change on your behalf. 
+If you have full control over the page you are using, add an import map to the
+`<head>`, pointing to the CDN, or update any existing import map. If you are not
+responsible for the page's `<head>`, request that the page owner makes the
+change on your behalf.
 
 ```html rhcodeblock
 <script type="importmap">
@@ -51,18 +51,17 @@ change on your behalf.
 </script>
 ```
 
-Once the import map is established, you can load the element with the following 
-module, containing a [bare module specifier][barespec]. The example below shows 
+Once the import map is established, you can load the element with the following
+module, containing a [bare module specifier][barespec]. The example below shows
 how you'd load in <`rh-button>`.
-
 
 ```html rhcodeblock
 <script type="module">
-  import '@rhds/elements/rh-button/rh-button.js';
+  import "@rhds/elements/rh-button/rh-button.js";
 </script>
 ```
 
-Note that modules may be placed in the `<head>`. Since they are deferred by 
+Note that modules may be placed in the `<head>`. Since they are deferred by
 default, they will not block rendering.
 
 ### NPM
@@ -73,16 +72,15 @@ Install RHDS using your team's preferred NPM package manager.
 npm install @rhds/elements
 ```
 
-Once that's been accomplished, you will need to use a bundler to resolve the 
-bare module specifiers and optionally optimize the package for your site's 
-particular use case and needs. Comprehensive guides to bundling are beyond the 
+Once that's been accomplished, you will need to use a bundler to resolve the
+bare module specifiers and optionally optimize the package for your site's
+particular use case and needs. Comprehensive guides to bundling are beyond the
 scope of this page; read more about bundlers on their websites:
 
 - [Rollup][rollup]
 - [esbuild][esbuild]
 - [Parcel][parcel]
 - [Webpack][webpack]
-
 
 ### JSPM
 
@@ -92,7 +90,7 @@ scope of this page; read more about bundlers on their websites:
     them for <strong>development purposes only</strong>!</p>
 </rh-alert>
 
-Add an [import map][importmap] to the `<head>`, pointing to the CDN, or update 
+Add an [import map][importmap] to the `<head>`, pointing to the CDN, or update
 any existing import map.
 
 ```html rhcodeblock
@@ -105,31 +103,33 @@ any existing import map.
   }
 </script>
 ```
-Once the import map is established, you can load the element with the following 
-module, containing a [bare module specifier][barespec]. The example below shows 
-how you'd load in <`rh-button>`.
 
+Once the import map is established, you can load the element with the following
+module, containing a [bare module specifier][barespec]. The example below shows
+how you'd load in <`rh-button>`.
 
 ```html rhcodeblock
 <script type="module">
-  import '@rhds/elements/rh-button/rh-button.js';
+  import "@rhds/elements/rh-button/rh-button.js";
 </script>
 ```
 
-Note that Modules may be placed in the `<head>`. Since they are deferred by 
+Note that Modules may be placed in the `<head>`. Since they are deferred by
 default, they will not block rendering.
 
 ### Lightdom CSS
 
-Some elements require you to load "Lightdom CSS" stylesheets, which are necessary 
-for styling deeply slotted child elements. In some cases, these may also help reduce 
-some [Cumulative Layout Shift (CLS)][cls] experience before the element has fully 
-initialized, but are not intended to be used without initializing the element or by 
+Some elements require you to load "Lightdom CSS" stylesheets, which are necessary
+for styling deeply slotted child elements. In some cases, these may also help reduce
+some [Cumulative Layout Shift (CLS)][cls] experience before the element has fully
+initialized, but are not intended to be used without initializing the element or by
 themselves to prevent CLS.
 
 ```html rhcodeblock
-<link rel="stylesheet"
-      href="https://www.redhatstatic.com/dx/v1/@rhds/elements@1.4.5/rh-footer/rh-footer-lightdom.css">
+<link
+  rel="stylesheet"
+  href="https://www.redhatstatic.com/dx/v1/@rhds/elements@1.4.5/rh-footer/rh-footer-lightdom.css"
+/>
 ```
 
 <rh-alert>Note: a future version of RHDS will remove the requirement to manually
@@ -137,22 +137,24 @@ load these stylesheets</rh-alert>
 
 ### Lightdom CSS shims
 
-Some elements have provided an *optional* `-lightdom-shim.css` file to aid in limiting 
-[CLS][cls] as much as possible, by styling some parts of the element before it has fully 
-initialized (i.e., `:not(:defined)`). These "shims" are inherently different than the 
-required "Lightdom CSS" mentioned above, and are only a temporary stop-gap until 
-[Delcarative Shadow DOM][dsd] is more widely available; at which point the shims will 
+Some elements have provided an _optional_ `-lightdom-shim.css` file to aid in limiting
+[CLS][cls] as much as possible, by styling some parts of the element before it has fully
+initialized (i.e., `:not(:defined)`). These "shims" are inherently different than the
+required "Lightdom CSS" mentioned above, and are only a temporary stop-gap until
+[Delcarative Shadow DOM][dsd] is more widely available; at which point the shims will
 no longer be needed and will become deprecated.
 
 ```html rhcodeblock
-<link rel="stylesheet"
-      href="https://www.redhatstatic.com/dx/v1/@rhds/elements@1.4.5/rh-cta/rh-cta-lightdom-shim.css">
+<link
+  rel="stylesheet"
+  href="https://www.redhatstatic.com/dx/v1/@rhds/elements@1.4.5/rh-cta/rh-cta-lightdom-shim.css"
+/>
 ```
 
 <uxdot-feedback>
   <h2>Designers</h2>
   <p>To get started using our design system as a designer, go to the <a 
-    href="get-started/designers">Designers</a> page.</p>
+    href="/get-started/designers">Designers</a> page.</p>
 </uxdot-feedback>
 
 [rollup]: https://rollupjs.org/

--- a/docs/get-started/developers/tokens.md
+++ b/docs/get-started/developers/tokens.md
@@ -25,16 +25,15 @@ npm i @rhds/tokens
 
 ## Usage
 
-We use [style-dictionary][styledictionary] to transform our tokens into multiple 
+We use [style-dictionary][styledictionary] to transform our tokens into multiple
 formats and helpers.
-
 
 ### Import global CSS
 
 Apply defaults to the document root by importing the global stylesheet:
 
 ```html rhcodeblock
-<link rel="stylesheet" href="/url/to/@rhds/tokens/css/global.css">
+<link rel="stylesheet" href="/url/to/@rhds/tokens/css/global.css" />
 <style>
   :is(h1, h2, h3, h4, h5, h6) {
     font-family: var(--rh-font-family-heading);
@@ -44,7 +43,7 @@ Apply defaults to the document root by importing the global stylesheet:
 
 ### Reset the shadowroot
 
-Reset a component's styles (preventing inheritance) by adding resetStyles to its 
+Reset a component's styles (preventing inheritance) by adding resetStyles to its
 static Constructible Style Sheet list:
 
 ```js rhcodeblock
@@ -67,41 +66,36 @@ export class RhJazzHands extends LitElement {
 Import tokens as JavaScript objects:
 
 ```js rhcodeblock
-import { tokens } from '@rhds/tokens';
-const template = html`
-  <span style="color: ${tokens.get('--rh-color-blue-300')}">I'm blue</span>
-`;
+import { tokens } from "@rhds/tokens";
+const template = html` <span style="color: ${tokens.get("--rh-color-blue-300")}">I'm blue</span> `;
 ```
 
 Or tree-shakable imports:
 
 ```js rhcodeblock
-import { ColorBlue300 } from '@rhds/tokens/values.js';
-const template = html`
-  <span style="color: ${ColorBlue300}">I'm blue</span>
-`;
+import { ColorBlue300 } from "@rhds/tokens/values.js";
+const template = html` <span style="color: ${ColorBlue300}">I'm blue</span> `;
 ```
 
 ## Plugins
 
 ### Using editor snippets
 
-Editor snippets complete prefixes like `--rh-color-brand` to their CSS custom 
+Editor snippets complete prefixes like `--rh-color-brand` to their CSS custom
 properties, complete with fallback.
 
 ```css rhcodeblock
 color: var(--rh-color-brand, #ee0000);
 ```
 
-They also provide reverse lookup. For example,  if you want to choose between 
-all the tokens with the  value `#e00`, you can do so by completing the prefix 
+They also provide reverse lookup. For example, if you want to choose between
+all the tokens with the value `#e00`, you can do so by completing the prefix
 `e00`.
 
-#### Load snippets in VSCode 
+#### Load snippets in VSCode
 
-Download the VSIX bundle that’s linked at the bottom of our [“Release 
+Download the VSIX bundle that’s linked at the bottom of our [“Release
 v1.0.0”][releasev100] page.
-
 
 #### Load snippets in Neovim
 
@@ -116,23 +110,21 @@ require 'luasnip.loaders.from_vscode'.lazy_load { paths = {
 
 ### Stylelint plugin
 
-Install the stylelint plugin to automatically correct token values in your 
+Install the stylelint plugin to automatically correct token values in your
 files.
 
 See the [Stylelint Plugin README][stylelintpluginreadme] for more info.
-
 
 ### 11ty plugin
 
 The experimental 11ty plugin lets you display token values in an 11ty site.
 
-
 ### vim-hexokinase
 
-Vim users can load the [vim-hexokinase][vimhexokinase] plugin to display color 
+Vim users can load the [vim-hexokinase][vimhexokinase] plugin to display color
 swatches next to their encoded values in their editor.
 
-Use the following config (lua syntax, for Neovim users) to configure hexokinase 
+Use the following config (lua syntax, for Neovim users) to configure hexokinase
 to display color values next to color aliases like `{color.brand.red}`.
 
 ```lua rhcodeblock
@@ -156,7 +148,7 @@ vim.g.Hexokinase_palettes = {
 
 <uxdot-feedback>
   <h2>Designers</h2>
-  <p>To get started using our design system as a designer, go to the <a href="get-started/designers">Designers</a> page.</p>
+  <p>To get started using our design system as a designer, go to the <a href="/get-started/designers">Designers</a> page.</p>
 </uxdot-feedback>
 
 [styledictionary]: https://amzn.github.io/style-dictionary/

--- a/docs/get-started/developers/usage.md
+++ b/docs/get-started/developers/usage.md
@@ -17,17 +17,17 @@ subnav:
 
 ## Usage
 
-Now that you've installed the Red Hat Design System, here's more information 
+Now that you've installed the Red Hat Design System, here's more information
 about how to use the web components.
 
 ### Using react wrappers
 
-React wrappers make it possible to use web components within React JSX files. 
+React wrappers make it possible to use web components within React JSX files.
 Follow the steps below to learn how.
 
 #### 1. Initial setup
 
-We'll bootstrap our React app using [Vite][vite]. It's possible to use other 
+We'll bootstrap our React app using [Vite][vite]. It's possible to use other
 tools for this, but that is out of the scope of this tutorial.
 
 ```sh rhcodeblock
@@ -46,15 +46,15 @@ npm install @lit-labs/react
 
 #### 3. Import elements and patterns
 
-After installing the `@lit/react` library, you can import elements and patterns 
+After installing the `@lit/react` library, you can import elements and patterns
 to your file. Below is an example of importing `<rh-button>` and `<rh-card>`, and
 managing app state between them using react.
 
 ```js rhcodeblock
-import { useState } from 'react';
-import { Button } from '@rhds/elements/react/rh-button/rh-button.js';
-import { Badge } from '@rhds/elements/react/rh-badge/rh-badge.js';
-import { Card } from '@rhds/elements/react/rh-card/rh-card.js';
+import { useState } from "react";
+import { Button } from "@rhds/elements/react/rh-button/rh-button.js";
+import { Badge } from "@rhds/elements/react/rh-badge/rh-badge.js";
+import { Card } from "@rhds/elements/react/rh-card/rh-card.js";
 export function App() {
   const [clicks, setClicks] = useState(0);
   return (
@@ -65,13 +65,13 @@ export function App() {
         Increment!
       </Button>
     </Card>
-  )
+  );
 }
 ```
 
 ### Using RHDS elements with Vue
 
-To get web components to work with Vue, it’s pretty easy and straightforward. 
+To get web components to work with Vue, it’s pretty easy and straightforward.
 Follow the steps below to use web components in a Vue app.
 
 #### 1. Initial setup
@@ -85,8 +85,8 @@ import App from "./App.vue";
 
 #### 2. Import elements and patterns
 
-Add the import statements to the top of the `<script>` tag in the file in which 
-you're using web components. Below is an example of importing `<rh-card>` to a 
+Add the import statements to the top of the `<script>` tag in the file in which
+you're using web components. Below is an example of importing `<rh-card>` to a
 file called `HelloWorld.vue`.
 
 ```js rhcodeblock
@@ -106,7 +106,7 @@ export default {
 
 <uxdot-feedback>
   <h2>Designers</h2>
-  <p>To get started using our design system as a designer, go to the <a href="get-started/designers">Designers</a> page.</p>
+  <p>To get started using our design system as a designer, go to the <a href="/get-started/designers">Designers</a> page.</p>
 </uxdot-feedback>
 
 [vite]: https://vitejs.dev/guide/#scaffolding-your-first-vite-project


### PR DESCRIPTION
## What I did

1. Updated the `href="get-started/..."` links to `href="/get-started/..."` (added the prepending slash) at the bottom the Designer and Developer Get started pages.


## Testing Instructions

1. Click the "go to the Developers/Designers page" links at the bottom of each of the following pages.
2. Ensure they point to the correct destination, and not a 404 page.

- [/get-started/designers/](https://deploy-preview-2247--red-hat-design-system.netlify.app/get-started/designers/) (links to developers page)
- [/get-started/developers/](https://deploy-preview-2247--red-hat-design-system.netlify.app/get-started/developers/) (links to designers page)
- [/get-started/developers/installation/](https://deploy-preview-2247--red-hat-design-system.netlify.app/get-started/developers/installation/) (links to designers page)
- [/get-started/developers/usage/](https://deploy-preview-2247--red-hat-design-system.netlify.app/get-started/developers/usage/) (links to designers page)
- [/get-started/developers/tokens/](https://deploy-preview-2247--red-hat-design-system.netlify.app/get-started/developers/tokens/) (links to designers page)
- [/get-started/developers/contributing/](https://deploy-preview-2247--red-hat-design-system.netlify.app/get-started/developers/contributing/) (links to designers page)

![Go to developers screencap](https://github.com/user-attachments/assets/f5183693-ae4c-4ff3-8022-01e99f95c94d)
![Go to designers screencap](https://github.com/user-attachments/assets/da6989d4-a5db-4331-a08b-40844c45fe74)


