### PR TITLE
docs(elements-code): fixing accordion + table background colors

### DIFF
--- a/docs/styles/pages/code.css
+++ b/docs/styles/pages/code.css
@@ -5,8 +5,7 @@
 rh-accordion {
   rh-accordion-panel[expanded] {
     &::part(container) {
-      background-color: 
-        light-dark(var(--rh-color-surface-lighter), var(--rh-color-surface-darker));
+      background-color: light-dark(var(--rh-color-surface-lighter), var(--rh-color-surface-darker));
     }
 
     rh-table {

--- a/docs/styles/pages/code.css
+++ b/docs/styles/pages/code.css
@@ -5,7 +5,7 @@
 rh-accordion {
   rh-accordion-panel[expanded] {
     &::part(container) {
-      background-color:
+      background-color: 
         light-dark(var(--rh-color-surface-lighter), var(--rh-color-surface-darker));
     }
 

--- a/docs/styles/pages/code.css
+++ b/docs/styles/pages/code.css
@@ -6,16 +6,10 @@ rh-accordion {
   rh-accordion-panel[expanded] {
     &::part(container) {
       background-color:
-        light-dark(var(--rh-color-surface-lighter),
-          oklch(from var(--rh-color-surface-dark) calc(l * 0.82) c h));
+        light-dark(var(--rh-color-surface-lighter), var(--rh-color-surface-darker));
     }
 
     rh-table {
-      --rh-table-row-background-hover-color: #f8f8f8;
-
-      background-color:
-        light-dark(var(--rh-color-surface-lightest),
-          var(--rh-color-surface-darkest));
       margin: 0;
 
       tbody tr:last-child {


### PR DESCRIPTION
## What I did

1. Removed the background color from `<rh-table>` elements inside `<rh-accordion>` on the Elements' Code page.


## Testing Instructions

1. Go to an Element's Code page (like Accordion), scroll down to its slots/properties section, and see if the colors look right.


Closes #2250 
