### PR TITLE
docs(foundations): adding usage of black color content

### DIFF
--- a/docs/foundations/color/usage/index.md
+++ b/docs/foundations/color/usage/index.md
@@ -48,7 +48,9 @@ standards website][brandstandards] if you have brand questions.
 
 Red is our primary brand color. Red is also a strong color, so **use it as an accent**, not to fill large areas.
 
-<uxdot-example>{% include './color-usage-brand-red.svg' %}</uxdot-example>
+<uxdot-example>
+  {% include './color-usage-brand-red.svg' %}
+</uxdot-example>
 
 ### Red orange
 

--- a/docs/foundations/color/usage/index.md
+++ b/docs/foundations/color/usage/index.md
@@ -62,7 +62,7 @@ For danger or error states, use `red orange`.
 
 In the Red Hat Design System, we limit the use of [pure black](/tokens/color/#rh-color-black) (`#000000`) to our logo, graphics, and illustrations, since it can cause visual vibrations when used in large quantities or when set in contrast to pure white.
 
-Therefore, where "black" is needed on all other UI elements (e.g., text, surfaces, or background colors, etc.) please use our [darkest gray color](/tokens/color/#rh-color-gray-95) (`#151515`).
+Therefore, where "black" is needed on all other UI elements (e.g., text, surfaces, background colors, etc.) please use our [darkest gray color](/tokens/color/#rh-color-gray-95) (`#151515`).
 
 ## Backgrounds
 

--- a/docs/foundations/color/usage/index.md
+++ b/docs/foundations/color/usage/index.md
@@ -58,6 +58,12 @@ For danger or error states, use `red orange`.
   {% include './color-usage-red-orange.svg' %}
 </uxdot-example>
 
+## Use of black
+
+In the Red Hat Design System, we limit the use of [pure black](/tokens/color/#rh-color-black) (`#000000`) to our logo, graphics, and illustrations, since it can cause visual vibrations when used in large quantities or when set in contrast to pure white.
+
+Therefore, where "black" is needed on all other UI elements (e.g., text, surfaces, or background colors, etc.) please use our [darkest gray color](/tokens/color/#rh-color-gray-95) (`#151515`).
+
 ## Backgrounds
 
 ### Canvas


### PR DESCRIPTION
## What I did

1. Added content under Foundations > Color > Usage about using black.


## Testing Instructions

1. Checkout the new "Use of black" section, and make sure it reads well.


Closes https://github.com/RedHat-UX/red-hat-design-system/issues/2208
