### PR TITLE
docs(chip): improve consistency and formatting

### DIFF
--- a/elements/rh-chip/docs/10-style.md
+++ b/elements/rh-chip/docs/10-style.md
@@ -80,7 +80,7 @@ The space in each chip is the same for both sizes. The `--rh-space-md` token is 
         height="294">
 </uxdot-example>
 
-The --rh-space-lg token is used when chips are stacked.
+The `--rh-space-lg` token is used when chips are stacked.
 
 <uxdot-example color-palette="lightest">
     <img src="../chip-style-space-b.svg"
@@ -95,8 +95,8 @@ The --rh-space-lg token is used when chips are stacked.
 
 Styles will change on hover depending on how a chip is used.
 
-- The Default and Selected chip borders change to --rh-border-width-md on hover
-- The Clear all chip border becomes visible and is --rh-border-width-sm on hover
+- The Default and Selected chip borders change to `--rh-border-width-md` on hover
+- The Clear all chip border becomes visible and is `--rh-border-width-sm` on hover
 - A disabled chip has no states
 
 <uxdot-example color-palette="lightest">
@@ -120,13 +120,13 @@ A focus ring wraps around the text and icon in both focus and active states. Hov
 <uxdot-example color-palette="lightest">
     <img src="../chip-style-interaction-states-focus-color-scheme-light.svg"
         alt="Three sets of two chips on a light color scheme each showing the focus state on the right and the normal state on the left."
-        width="712"
+        width="902"
         height="29">
 </uxdot-example>
 
 <uxdot-example color-palette="darkest">
     <img src="../chip-style-interaction-states-focus-color-scheme-dark.svg"
         alt="Three sets of two chips a dark color scheme each showing the focus state on the right and the normal state on the left."
-        width="712"
+        width="902"
         height="29">
 </uxdot-example>

--- a/elements/rh-chip/docs/20-guidelines.md
+++ b/elements/rh-chip/docs/20-guidelines.md
@@ -10,14 +10,14 @@ Although these elements look very similar, the following guidance should help cl
   <table>
     <thead>
       <tr>
-        <th scope="col" data-label="Element">Element</th>
-        <th scope="col" data-label="Use Cases">Use Cases</th>
+        <th scope="col" data-label="Element" style="width: 25%;">Element</th>
+        <th scope="col" data-label="Use cases">Use cases</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td data-label="Element">Chip</td>
-        <td data-label="Use Cases">
+        <td data-label="Use cases">
           <ul>
             <li>Almost the same as a checkbox</li>
             <li>Required to use more than one in a Chip group</li>
@@ -27,7 +27,7 @@ Although these elements look very similar, the following guidance should help cl
       </tr>
       <tr>
         <td data-label="Element">Badge</td>
-        <td data-label="Use Cases">
+        <td data-label="Use cases">
           <ul>
             <li>Reflect counts like number of objects, events, or unread items</li>
           </ul>
@@ -35,7 +35,7 @@ Although these elements look very similar, the following guidance should help cl
       </tr>
       <tr>
         <td data-label="Element">Tag</td>
-        <td data-label="Use Cases">
+        <td data-label="Use cases">
           <ul>
             <li>Can be used on its own</li>
             <li>Highlight an element on a page in order to draw attention to it</li>
@@ -78,12 +78,28 @@ Chip text displays exactly what is being filtered without truncation. This means
 ### Character count
 
 <rh-table>
-
-| Element                       | Character count |
-|-------------------------------|-----------------|
-| Legend                        | 25 (maximum)    |
-| Number of characters per chip | 2 (minimum)     |
-
+  <table>
+    <thead>
+      <tr>
+        <th scope="col" data-label="Element" style="width: 50%;">Element</th>
+        <th scope="col" data-label="Character count">Character count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-label="Element">Legend</td>
+        <td data-label="Character count">
+          25 (maximum)
+        </td>
+      </tr>
+      <tr>
+        <td data-label="Element">Number of characters per chip</td>
+        <td data-label="Character count">
+          2 (minimum)
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </rh-table>
 
 ## Interactivity
@@ -147,7 +163,7 @@ If a chip has a long string of text, it will break to two lines inside of the ch
       height="228">
 </uxdot-example>
 
-## Best Practices
+## Best practices
 
 ### Size of chips
 


### PR DESCRIPTION
## What I did

Made the following edits via feedback from Corey:

- `Style` page
    - Under the `Space` heading, apply `<code>` to `--rh-space-lg`
    - Under the `Hover` heading, apply `<code>` to `--rh-border-width-md` and `--rh-border-width-sm`
    - Under the `Focus and Active` heading, both images look small, so I think removing `width="712"` will display them in the correct size
- `Guidelines` page
    - Under the `Chip vs. Badge vs. Tag` heading, in the table, make the `Element` column 25% width and the `Use cases` column 75% width
        - Change `Use Cases` to `Use cases`
    - Under the `Character count` heading, in the table, make both `Element` and `Character` count columns 50% width
    - Change the `Best Practices` heading to `Best practices`

## Testing Instructions

1. Visit the [Style](https://deploy-preview-2260--red-hat-design-system.netlify.app/elements/chip/style/) and [Guidelines](https://deploy-preview-2260--red-hat-design-system.netlify.app/elements/chip/guidelines/) pages on the DP and verify the changes listed above have been made correctly.

## Notes to Reviewers

Related to #2198.