### PR TITLE
fix(tile): pre-hydration link `::after` bug

### DIFF
--- a/.changeset/eleven-ways-beg.md
+++ b/.changeset/eleven-ways-beg.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-Fixes pre-hydration or non-JavaScript link bug
+`<rh-tile>`: Fix a bug where a Tile's link stretches beyond the bounds of the element when JavaScript doesn't load

--- a/.changeset/eleven-ways-beg.md
+++ b/.changeset/eleven-ways-beg.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+Fixes pre-hydration or non-JavaScript link bug

--- a/elements/rh-tile/rh-tile-lightdom.css
+++ b/elements/rh-tile/rh-tile-lightdom.css
@@ -1,3 +1,7 @@
+:where(rh-tile) {
+  position: relative;
+}
+
 rh-tile a {
   color: var(--_link-color) !important;
   text-decoration: var(--rh-tile-link-text-decoration, none) !important;


### PR DESCRIPTION
## What I did

1. Fixed non-JS issue where the `::after` pseudo-element stretches across the whole page


## Testing Instructions

1. View the [`<rh-tile>` demo](https://deploy-preview-2277--red-hat-design-system.netlify.app/elements/tile/demo/accented-tiles/) and the [homepage of the DP](https://deploy-preview-2277--red-hat-design-system.netlify.app/)
2. Disable JavaScript
3. Compare with [live demo](https://ux.redhat.com/elements/tile/demo/accented-tiles/) and/or the [live homepage](https://ux.redhat.com/) with JS off.
