### PR TITLE
fix: always load dependencies when updating

### DIFF
--- a/.changeset/deep-jobs-stay.md
+++ b/.changeset/deep-jobs-stay.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-cta>`: ensure the arrow icon always appears

--- a/.changeset/six-trees-train.md
+++ b/.changeset/six-trees-train.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+Theming: ensure themable elements always load the default theme

--- a/elements/rh-cta/rh-cta.ts
+++ b/elements/rh-cta/rh-cta.ts
@@ -110,12 +110,11 @@ export class RhCta extends LitElement {
   /** Icon set */
   @property({ attribute: 'icon-set' }) iconSet: IconSetName = 'ui';
 
-
-  protected override async getUpdateComplete(): Promise<boolean> {
-    if (this.icon || !this.variant) {
+  override async scheduleUpdate() {
+    if (this.icon || !this.variant && !customElements.get('rh-icon')) {
       await import('@rhds/elements/rh-icon/rh-icon.js');
     }
-    return super.getUpdateComplete();
+    super.scheduleUpdate();
   }
 
   #logger = new Logger(this);

--- a/lib/themable.ts
+++ b/lib/themable.ts
@@ -8,6 +8,7 @@ async function load() {
   const sheet = new CSSStyleSheet();
   sheet.replaceSync(cssText);
   document.adoptedStyleSheets = [...(document.adoptedStyleSheets ?? []), sheet];
+  initialized = true;
 }
 
 let p: Promise<void>;
@@ -28,9 +29,11 @@ export function themable<T extends Constructor<ReactiveElement>>(klass: T) {
   if (!initialized) {
     p ??= load();
     return class ThemableElement extends klass {
-      protected async getUpdateComplete(): Promise<boolean> {
-        await p;
-        return super.getUpdateComplete();
+      protected override async scheduleUpdate() {
+        if (!initialized) {
+          await p;
+        }
+        super.scheduleUpdate();
       }
     };
   }


### PR DESCRIPTION
## What I did

1. replace `getUpdateComplete` calls with `scheduleUpdate` calls in cta and `@themable`


## Testing Instructions

1. run dev server, open cta demo
2. observe that arrow appears

## Notes to Reviewers

`getUpdateComplete()` is only called when actually accessing `el.updateComplete`, and that doesn't happen during the normal lifecycle. therefore we override `scheduleUpdate` instead