### PR TITLE
docs(demos): removing double border inside demo card + code-block

### DIFF
--- a/uxdot/uxdot-demo.css
+++ b/uxdot/uxdot-demo.css
@@ -37,7 +37,7 @@ rh-card {
 }
 
 .code-tabs {
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
+  border: 0;
   border-radius: var(--rh-border-radius-default);
 
   &::part(tabs-container) {


### PR DESCRIPTION
## What I did

1. Removed the double border between the Demos' `rh-code-block` and `rh-card`


## Testing Instructions

1. Check demos "playground" in the DP
2. Compare to the live version
