### PR TITLE
fix(pagination): fix dark color scheme truncation ellipsis background color

### DIFF
--- a/.changeset/wise-bears-listen.md
+++ b/.changeset/wise-bears-listen.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-pagination>`: Fix ellipsis background color on dark color schemes

--- a/elements/rh-pagination/rh-pagination-lightdom.css
+++ b/elements/rh-pagination/rh-pagination-lightdom.css
@@ -106,7 +106,6 @@ rh-pagination {
     font-size: var(--rh-font-size-body-text-lg, 1.125rem);
     color: var(--rh-color-gray-40, #a3a3a3);
     justify-content: center;
-    background: var(--rh-color-surface-lightest, #ffffff);
     align-self: start;
   }
 


### PR DESCRIPTION
## What I did

1. As of Cubone, the ellipsis on the many pages demo on dark color schemes is white/light.
2. If you change to a dark scheme, everything else is dark while the ellipsis is white.
3. This PR makes the ellipsis's background transparent—thus, using the background color of the page/surface behind it.

Before:
![Screenshot of the white ellipsis](https://github.com/user-attachments/assets/7b97c6b8-156c-4a17-b942-864d2e9d667a)

After:
![Screenshot of the transparent ellipsis](https://github.com/user-attachments/assets/5a8f00ec-6708-4d8f-925b-18ec45c9f36e)

## Testing Instructions

1. Open the [Pagination Demo page](https://deploy-preview-2301--red-hat-design-system.netlify.app/elements/pagination/demos/#demo-many-pages) of the docs in the DP.
2. Change to a dark color scheme.
3. Scroll down to the "Many pages" pagination demo (if you're not already there).
4. Verify the ellipsis in the middle of the Many Pages demo has the correct background color (aka none at all).
5. Verify this change works in the full page demos too.
