### PR TITLE
fix(dialog): make video dialog close buttons white

### DIFF
--- a/.changeset/thirty-ends-greet.md
+++ b/.changeset/thirty-ends-greet.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-dialog>`: increase contrast of close button for video dialogs

--- a/elements/rh-dialog/rh-dialog.css
+++ b/elements/rh-dialog/rh-dialog.css
@@ -232,7 +232,7 @@
 }
 
 :host([type='video']) #close-button::part(icon) {
-  color: var(--rh-dialog-close-button-color, var(--rh-color-surface));
+  color: var(--rh-dialog-close-button-color, var(--rh-color-surface-lightest, #ffffff));
   filter: drop-shadow(1px 0 1px var(--_dialog-backdrop-bg-color));
 }
 


### PR DESCRIPTION
## What I did

1. Always make the close button / icon for video dialogs be white, especially on dark color schemes

Before:
![Screenshot of an invisible close button on rh-dialog video on top of a dark color scheme](https://github.com/user-attachments/assets/e8a65d41-785f-4a28-9b8c-2a69e1bb1622)

After:
![Screenshot of the fixed close button, which is white on a dark background](https://github.com/user-attachments/assets/258ed534-5e43-455c-a70f-03dd71aa52a9)

## Testing Instructions

1. View the [video dialog](https://deploy-preview-2303--red-hat-design-system.netlify.app/elements/dialog/demo/video-modal/) in the DP
2. Change the `<main>` element to a `<rh-surface color-palette="darkest">` via DevTools inspector.
3. Open the dialogs.
4. Verify the icon is white / visible against the black background.
5. Refresh the page and verify this also works on light color schemes.

## Notes to Reviewers

End users have the ability to change the color of their close button/icon via the `--rh-dialog-close-button-color` public variable, should they need to. 