### PR TITLE
chore: update the wireit dependency to a version for v2 caching api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "typescript": "^5.8.2",
         "typescript-transform-lit-css": "^2.0.2",
         "web-dev-server-plugin-lit-css": "^3.0.2",
-        "wireit": "^0.14.11"
+        "wireit": "^0.14.12"
       },
       "optionalDependencies": {
         "@esbuild/darwin-arm64": "^0.25.0",
@@ -28025,9 +28025,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.11.tgz",
-      "integrity": "sha512-edO3AiL1wYlBIapwx8e1OGEmsG37sv7qnRzx4YDsMPcKo+6NMOjWYcfRbaeoB1MzakLrnozWB2Q1q7Ko45NckA==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.12.tgz",
+      "integrity": "sha512-gNSd+nZmMo6cuICezYXRIayu6TSOeCSCDzjSF0q6g8FKDsRbdqrONrSZYzdk/uBISmRcv4vZtsno6GyGvdXwGA==",
       "dev": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -346,7 +346,7 @@
     "typescript": "^5.8.2",
     "typescript-transform-lit-css": "^2.0.2",
     "web-dev-server-plugin-lit-css": "^3.0.2",
-    "wireit": "^0.14.11"
+    "wireit": "^0.14.12"
   },
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "^0.25.0",


### PR DESCRIPTION
## What I did

1.  Updated the wireit dependency to `0.14.12`  

Ref: https://github.com/google/wireit/issues/1297 


## Testing Instructions

1.  Does the DP fail with cache issues?  

## Notes to Reviewers
