### PR TITLE
fix(tabs): corrected hidden icons

### DIFF
--- a/.changeset/eighty-results-bow.md
+++ b/.changeset/eighty-results-bow.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tabs>`: corrected icons from being incorrectly hidden 
+  

--- a/elements/rh-tabs/demo/icons-and-text.html
+++ b/elements/rh-tabs/demo/icons-and-text.html
@@ -13,13 +13,13 @@
   <rh-tab slot="tab"> Server <rh-icon slot="icon"
              icon="server"></rh-icon></rh-tab>
   <rh-tab-panel>Server</rh-tab-panel>
-  <rh-tab slot="tab"> System <rh-icon slot="icon"
-             icon="laptop"></rh-icon></rh-tab>
+  <rh-tab slot="tab"> No Icon </rh-tab>
   <rh-tab-panel>System</rh-tab-panel>
 </rh-tabs>
 
 <script type="module">
   import '@rhds/elements/rh-tabs/rh-tabs.js';
+  import '@rhds/elements/rh-icon/rh-icon.js';
 </script>
 
 <style>

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -28,14 +28,6 @@
   display: none !important;
 }
 
-slot[name='icon'] {
-  display: block;
-}
-
-[part='icon'] {
-  margin-inline-end: var(--rh-space-md, 8px);
-}
-
 #button {
   margin: 0;
   font-family: inherit;
@@ -44,6 +36,7 @@ slot[name='icon'] {
   position: relative;
   display: flex;
   flex: 1;
+  gap: var(--rh-space-md, 8px);
   text-decoration: none;
   cursor: pointer;
   align-items: center;

--- a/elements/rh-tabs/rh-tab.ts
+++ b/elements/rh-tabs/rh-tab.ts
@@ -21,7 +21,6 @@ import {
 import { themable } from '@rhds/elements/lib/themable.js';
 
 import styles from './rh-tab.css';
-import { SlotController } from '@patternfly/pfe-core/controllers/slot-controller.js';
 
 export class TabExpandEvent extends Event {
   constructor(
@@ -76,8 +75,6 @@ export class RhTab extends LitElement {
   @consume({ context: rhTabsLastTabContext, subscribe: true })
   @state() private lastTab: RhTab | null = null;
 
-  #slots = new SlotController(this, 'icon', null);
-
   #internals = InternalsController.of(this, { role: 'tab' });
 
   override connectedCallback() {
@@ -100,7 +97,6 @@ export class RhTab extends LitElement {
            class="${classMap({ active, box, vertical, first, last })}">
         <slot name="icon"
               part="icon"
-              ?hidden="${this.#slots.hasSlotted('icon')}"
               @slotchange="${() => this.requestUpdate()}"></slot>
         <slot part="text"></slot>
       </div>

--- a/elements/rh-tabs/rh-tab.ts
+++ b/elements/rh-tabs/rh-tab.ts
@@ -36,7 +36,7 @@ export class TabExpandEvent extends Event {
  * @slot icon - Can contain an `<svg>` or `<rh-icon>`
  * @slot - Tab title text
  * @csspart button - element that contains the interactive part of a tab
- * @csspart icon - icon `<span>` element
+ * @csspart icon - `<rh-icon>` element
  * @csspart text - tile text `<span>` element
  * @cssprop {<color>} [--rh-tabs-link-color=#4d4d4d] - Tab link text color
  * @cssprop {<color>} [--rh-tabs-active-border-color=#ff442b] - Tab active border color
@@ -96,8 +96,7 @@ export class RhTab extends LitElement {
            ?disabled="${this.disabled}"
            class="${classMap({ active, box, vertical, first, last })}">
         <slot name="icon"
-              part="icon"
-              @slotchange="${() => this.requestUpdate()}"></slot>
+              part="icon"></slot>
         <slot part="text"></slot>
       </div>
     `;


### PR DESCRIPTION
## What I did

1. Corrected hidden icons on tabs. 
2. Removed SlotController

## Testing Instructions

1. View the[ icons demo](https://deploy-preview-2332--red-hat-design-system.netlify.app/elements/tabs/demo/icons-and-text/)

## Notes to Reviewers

This is likely a SlotController issue but in review of the code I just didn't feel great about the modification of the display rule on slot and by removing that and moving the margin from the icon to the gap rule on the button flex already gets the same effect if a icon is slotted or not.  
