### PR TITLE
docs(a11y): adding guidance for opening links in new windows

### DIFF
--- a/docs/accessibility/content.md
+++ b/docs/accessibility/content.md
@@ -217,7 +217,7 @@ In addition to the best practices for all microcopy, adhere to the following bes
 - Use the same link text for links that go to the same place.
 - Use different link text for links that go to different places.
 - If you absolutely must use URLs as link text, try to choose short and easy-to-read URLs (e.g., “redhat.com” instead of "https://www.redhat.com/").
-- Links that point to external sites, [open new windows/tabs](/accessibility/design/#opening-links-in-new-windows), or launch other media should indicate this behavior to all visitors (both users and non-users of assistive tech alike)
+- Links that point to external sites, [open new windows/tabs](/accessibility/design/#opening-links-in-new-windows), or launch other media should indicate this behavior to all visitors (both users and non-users of assistive tech alike).
 
 #### Avoid the following when creating links
 

--- a/docs/accessibility/content.md
+++ b/docs/accessibility/content.md
@@ -217,7 +217,7 @@ In addition to the best practices for all microcopy, adhere to the following bes
 - Use the same link text for links that go to the same place.
 - Use different link text for links that go to different places.
 - If you absolutely must use URLs as link text, try to choose short and easy-to-read URLs (e.g., “redhat.com” instead of "https://www.redhat.com/").
-- Links that point to external sites, open new windows/tabs, or launch other media should indicate this behavior to all visitors (both users and non-users of assistive tech alike)
+- Links that point to external sites, [open new windows/tabs](/accessibility/design/#opening-links-in-new-windows), or launch other media should indicate this behavior to all visitors (both users and non-users of assistive tech alike)
 
 #### Avoid the following when creating links
 

--- a/docs/accessibility/design.md
+++ b/docs/accessibility/design.md
@@ -141,15 +141,15 @@ Links should appear clickable and focusable. And, when possible, [links][linkfou
 
 #### Opening links in new windows
 
-Avoid opening links in new windows or tabs, as this [takes control away](#user-control) from the user. There are only a few exceptions where it may be acceptable to open links in new windows or tabs:
+Avoid opening links in new windows or tabs, as this [takes control away](#user-control) from the user. There are only a few exceptions where it may be acceptable to open links in new windows/tabs:
 
-- A link might interrupt an ongoing process (e.g., filling out a form) where navigating away would lose the user's progress.
-- A link provides help or assistance that could would take the user away from a step in the current experience, like search results.
-- A link leads to a file or document that isn't a web page or web application, like a PDF.
+- When a link might interrupt an ongoing process (e.g., filling out a form) where navigating away would lose the user's progress.
+- When a link provides help or assistance that could would take the user away from a step in the current experience, like search results.
+- When a link leads to a file or document that isn't a web page or web application, like a PDF.
 
 In the first two cases above, such experience interruptions may be better handled through tooltips, popovers, or modals/dialogs.
 
-If a link must open in a new window, indicate this both visually and non-visually. Text is preferred, but an icon (with text alternative for assistive tech users) can be used to announce that a new window will open.
+If a link must open in a new window, indicate this both [visually][externallinks] and non-visually. Text is preferred, but an icon (with text alternative for assistive tech users) can be used to announce that a new window will open.
 
 ### Target size
 
@@ -196,6 +196,7 @@ Text should never be justified. Justified text is aligned to the left and right 
 
 [coloraccessibility]: /foundations/color/accessibility/
 [colorcontrast]: https://www.tpgi.com/color-contrast-checker/
+[externallinks]: foundations/interactions/links/#external-pages
 [linkfoundations]: /foundations/interactions/links/
 [paragraphspacing]: https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html
 [rhbutton]: /elements/button/

--- a/docs/accessibility/design.md
+++ b/docs/accessibility/design.md
@@ -144,7 +144,7 @@ Links should appear clickable and focusable. And, when possible, [links][linkfou
 Avoid opening links in new windows or tabs, as this [takes control away](#user-control) from the user. There are only a few exceptions where it may be acceptable to open links in new windows/tabs:
 
 - When a link might interrupt an ongoing process (e.g., filling out a form) where navigating away would lose the user's progress.
-- When a link provides help or assistance that could would take the user away from a step in the current experience, like search results.
+- When a link provides help or assistance that would take the user away from a step in the current experience, like search results.
 - When a link leads to a file or document that isn't a web page or web application, like a PDF.
 
 In the first two cases above, such experience interruptions may be better handled through tooltips, popovers, or modals/dialogs.

--- a/docs/accessibility/design.md
+++ b/docs/accessibility/design.md
@@ -25,7 +25,7 @@ The contents of a page should be arranged in a meaningful order. Here are some t
 
 Elements that repeat across a site (e.g., navigation and site search) should appear in consistent locations and with consistent ordering. That said, it’s okay if some elements within repeating sections (e.g., individual items in a navigation menu) change and shift by necessity, depending on context.
 
-For repeating sections that come before a page’s main content (e.g., a navigation menu at the top of the site), there must be a means for keyboard users to bypass them and get to the unique content. Such "[skip links](https://webaim.org/techniques/skipnav/)" may be hidden by default, but you will want to design how they appear onscreen upon receiving keyboard focus.
+For repeating sections that come before a page’s main content (e.g., a navigation menu at the top of the site), there must be a means for keyboard users to bypass them and get to the unique content. Such "[skip links][webaimskipnav]" may be hidden by default, but you will want to design how they appear onscreen upon receiving keyboard focus.
 
 If one element has the same function as another, both should be labeled the same way. For example, a call to action for the Contact page should have consistent text labels.
 
@@ -35,11 +35,11 @@ If one element has the same function as another, both should be labeled the same
 
 When presenting meaningful information or indicating the location of interactive elements, do not rely upon color alone in your designs. Users with vision impairments or even situational concerns (e.g., a poor monitor, viewing a display in bright sunlight, etc.) may be unable to discern these color cues. So, ensure you use non-color indicators, as well.
 
-For specific information on how we use color accessibly, visit [our Foundations page](/foundations/color/accessibility/) on the topic.
+For specific information on how we use color accessibly, visit [our Foundations page][coloraccessibility] on the topic.
 
 ### Contrast
 
-We strive to adhere to [WCAG 2.1 AA contrast ratio standards](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum). Our text, links, interface elements, etc. are designed with sufficient contrast when used on top of surfaces, image backgrounds with low contrast, and near adjacent colors.
+We strive to adhere to [WCAG 2.1 AA contrast ratio standards][wcagcontrast]. Our text, links, interface elements, etc. are designed with sufficient contrast when used on top of surfaces, image backgrounds with low contrast, and near adjacent colors.
 
 #### Text
 
@@ -58,7 +58,7 @@ When possible, you should underline inline text links that may appear within blo
 
 If you can’t add underlines to your inline links, and color is the _only_ way you can distinguish these links from non-link text within a paragraph or list, the contrast ratio between a link and its surrounding text _must_ be at least 3:1 in both visited and unvisited states. And underlines or other non-color cues must also then be used to signify when the link receives hover.
 
-Our [Interactions section](/foundations/interactions/links/) has specific information on styling links for Red Hat experiences.
+Our [Interactions section][linkfoundations] has specific information on styling links for Red Hat experiences.
 
 #### Graphical objects and UI components
 
@@ -68,7 +68,7 @@ Non-color cues must be also used to signify when an object or component receives
 
 #### Layering
 
-It is acceptable to layer colors with the same hue, saturation, or lightness on white, black, or gray. However, layering them near or on top of each other might cause vibration. If you need to layer colors, follow [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/Understanding/) requirements.
+It is acceptable to layer colors with the same hue, saturation, or lightness on white, black, or gray. However, layering them near or on top of each other might cause vibration. If you need to layer colors, follow [WCAG 2.1 AA][wcag21aa] requirements.
 
 <uxdot-example width-adjustment=”1140px”>
   <img src="/assets/color/color-a11y-color-contrast-layering.svg"
@@ -79,7 +79,7 @@ It is acceptable to layer colors with the same hue, saturation, or lightness on 
 
 #### Further help
 
-TPGi’s [Colour Contrast Analyzer](https://www.tpgi.com/color-contrast-checker/) for Windows and Mac computers can help you identify colors and gauge their contrast from one another.
+TPGi’s [Colour Contrast Analyzer][colorcontrast] for Windows and Mac computers can help you identify colors and gauge their contrast from one another.
 
 ## Imagery
 
@@ -129,11 +129,27 @@ Essential information should not be conveyed by sound alone. For example, if a t
 
 ## Interactions
 
+### User control
+
+[Giving users control][usercontrol] over user interfaces is a foundational principle of user experience design. It is also the basis of several WCAG 2.1 AA requirements, like ensuring [interfaces operate in predictable ways][wcagpredictable].
+
 ### Links
 
-Links should appear clickable and focusable. And, when possible, links and buttons should look different from one another to give users cues as to their purpose.
+#### Appearance
 
-If a link opens in a new window, this will have to be indicated both visually and non-visually. Text is preferred, but an icon (with text alternative for assistive tech users) can be used to announce that a new window will open.
+Links should appear clickable and focusable. And, when possible, [links][linkfoundations] and [buttons][rhbutton] should look different from one another to give users cues as to their purpose.
+
+#### Opening links in new windows
+
+Avoid opening links in new windows or tabs, as this [takes control away](#user-control) from the user. There are only a few exceptions where it may be acceptable to open links in new windows or tabs:
+
+- A link might interrupt an ongoing process (e.g., filling out a form) where navigating away would lose the user's progress.
+- A link provides help or assistance that could would take the user away from a step in the current experience, like search results.
+- A link leads to a file or document that isn't a web page or web application, like a PDF.
+
+In the first two cases above, such experience interruptions may be better handled through tooltips, popovers, or modals/dialogs.
+
+If a link must open in a new window, indicate this both visually and non-visually. Text is preferred, but an icon (with text alternative for assistive tech users) can be used to announce that a new window will open.
 
 ### Target size
 
@@ -164,7 +180,7 @@ If keyboard focus appears to be trapped in a subsection, instructions for exitin
 
 ### Spacing
 
-Line heights for body copy should be at least 1.5× regular single-spacing. And paragraph spacing should be 1.5× of that line height. In other words, if your line height is 1.5, your paragraph spacing should be at least 2.25× (or 1.5×1.5) the original single-spaced height. (W3C rounds to 2.5× in their [paragraph-spacing recommendation](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html).) Such spacing helps people who find it difficult to read when lines are too close together.
+Line heights for body copy should be at least 1.5× regular single-spacing. And paragraph spacing should be 1.5× of that line height. In other words, if your line height is 1.5, your paragraph spacing should be at least 2.25× (or 1.5×1.5) the original single-spaced height. (W3C rounds to 2.5× in their [paragraph-spacing recommendation][paragraphspacing].) Such spacing helps people who find it difficult to read when lines are too close together.
 
 ### Character counts
 
@@ -177,3 +193,14 @@ For left-to-right languages, left-aligned text is the easiest to read and skim. 
 Center-aligned text can be used sparingly, but it should be avoided for paragraphs.
 
 Text should never be justified. Justified text is aligned to the left and right edges of a content area, and spacing between words is adjusted to make this happen. Depending on how the content flows on various screen sizes and whether the user is manipulating the text for improved readability, justified text can create spaces between words that are too large or narrow to be read comfortably.
+
+[coloraccessibility]: /foundations/color/accessibility/
+[colorcontrast]: https://www.tpgi.com/color-contrast-checker/
+[linkfoundations]: /foundations/interactions/links/
+[paragraphspacing]: https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html
+[rhbutton]: /elements/button/
+[usercontrol]: https://www.interaction-design.org/literature/topics/user-control
+[wcag21aa]: https://www.w3.org/WAI/WCAG21/Understanding/
+[wcagcontrast]: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum
+[webaimskipnav]: https://webaim.org/techniques/skipnav/
+[wcagpredictable]: https://www.w3.org/WAI/WCAG22/quickref/#predictable

--- a/docs/accessibility/design.md
+++ b/docs/accessibility/design.md
@@ -196,7 +196,7 @@ Text should never be justified. Justified text is aligned to the left and right 
 
 [coloraccessibility]: /foundations/color/accessibility/
 [colorcontrast]: https://www.tpgi.com/color-contrast-checker/
-[externallinks]: foundations/interactions/links/#external-pages
+[externallinks]: /foundations/interactions/links/#external-pages
 [linkfoundations]: /foundations/interactions/links/
 [paragraphspacing]: https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html
 [rhbutton]: /elements/button/

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -235,9 +235,9 @@ At Red Hat, we prefer to [keep the user in control](/accessibility/design/#user-
 
 ### External pages
 
-Use an external link icon if a link will direct users to another domain. This visual indicator must also be paired with a non-visual indicator. While text is preferred, alternative text may be used for assistive tech users.
+Indicate when links will direct users to another domain. While text indicators are preferred, you may also use external link icons, provided that the icon has a text label (e.g., alt text) for assistive tech.
 
-External links to another domain are [not a reason](/accessibility/design/#opening-links-in-new-windows) to open them in a new window or tab.
+Pointing an external link to another domain is [not a reason](/accessibility/design/#opening-links-in-new-windows) for opening it in a new window or tab.
 
 <rh-alert state="info">
   <h4 slot="header">Helpful tip</h4>

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -229,13 +229,15 @@ Developers can use the following CSS as a starting point for link underlining:
 
 ## Behavior
 
-### Internal pages
+### Opening links in new windows
 
-If a user selects a link within [redhat.com][redhat] or other Red Hat web property, a new tab or window should typically not be opened.
+At Red Hat, we prefer to [keep the user in control](/accessibility/design/#user-control) of their own experience. Therefore, avoid forcing links to open in new windows or tabs, except under [very specific circumstances](/accessibility/design/#opening-links-in-new-windows).
 
 ### External pages
 
-Use an external link icon if a link will direct users to another domain. This does not necessarily mean that the link will or should open in a new tab or window. However, if navigating to a new page in the same tab is very disruptive to the experience or workflow, then consider having the page open in a new tab or window.
+Use an external link icon if a link will direct users to another domain. This visual indicator must also be paired with a non-visual indicator. While text is preferred, alternative text may be used for assistive tech users.
+
+External links to another domain are [not a reason](/accessibility/design/#opening-links-in-new-windows) to open them in a new window or tab.
 
 <rh-alert state="info">
   <h4 slot="header">Helpful tip</h4>


### PR DESCRIPTION
## What I did

1. Expanded the guidance on Interactions in our Accessibility docs, including our [firming up our stance](https://github.com/RedHat-UX/red-hat-design-system/issues/2321) on opening links in new windows
2. Rewording Foundations / Interactions / Links section to match our stance, and cross-linked.
3. Added a link to our stance under our Writing links best practices section in Accessibility


## Testing Instructions

1. Proofread the [User Control](https://deploy-preview-2333--red-hat-design-system.netlify.app/accessibility/design/#user-control) and [Links](https://deploy-preview-2333--red-hat-design-system.netlify.app/accessibility/design/#links-1) sections under Accessibility / Design / Interactions.
2. Proofread [Foundations / Interactions / Links / Behavior](https://deploy-preview-2333--red-hat-design-system.netlify.app/foundations/interactions/links/#behavior) section
3. Proofread [Accessibility / Content / Writing microcopy / Links](https://deploy-preview-2333--red-hat-design-system.netlify.app/accessibility/content/#best-practices-for-links) section


Closes https://github.com/RedHat-UX/red-hat-design-system/issues/2321
