### PR TITLE
POC: open demos in codepen

### DIFF
--- a/uxdot/uxdot-demo.css
+++ b/uxdot/uxdot-demo.css
@@ -37,6 +37,30 @@ rh-card {
       margin-inline-end: auto;
     }
   }
+
+  rh-tooltip[slot='footer'] {
+    --rh-icon-size: var(--rh-size-icon-02, 24px) !important;
+
+    & a {
+      padding: var(--rh-space-sm, 6px) var(--rh-space-lg, 16px);
+      display: flex;
+      place-items: center;
+
+      &#new-tab {
+        --rh-icon-size: 18px !important;
+
+        margin-block-start: 4px;
+      }
+    }
+
+    & rh-button {
+      & svg {
+        width: 24px;
+        height: 24px;
+        fill: currentcolor;
+      }
+    }
+  }
 }
 
 .code-tabs {

--- a/uxdot/uxdot-demo.ts
+++ b/uxdot/uxdot-demo.ts
@@ -6,6 +6,7 @@ import { property } from 'lit/decorators/property.js';
 import styles from './uxdot-demo.css';
 
 import { LitElement } from 'lit';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 @customElement('uxdot-demo')
 export class UxdotDemo extends LitElement {
@@ -22,6 +23,8 @@ export class UxdotDemo extends LitElement {
   @property({ attribute: 'demo-source-url' }) demoSourceUrl!: string;
 
   @property({ attribute: 'demo-file-path' }) demoFilePath!: string;
+
+  @property({ attribute: 'codepen-data' }) codePenData?: string;
 
   render() {
     return html`
@@ -47,8 +50,33 @@ export class UxdotDemo extends LitElement {
                      icon="refresh"
                      icon-set="ui"
                      @click="${this.#reloadIframe}">Reload</rh-button>
-          <rh-cta slot="footer" href="${this.demoSourceUrl}">View source on GitHub</rh-cta>
-          <rh-cta slot="footer" href="${this.demoUrl}">View In Own Tab</rh-cta>
+          
+          <rh-tooltip slot="footer">
+            <a href="${this.demoSourceUrl}" aria-label="View source on Github">
+              <rh-icon set="social" icon="github"></rh-icon>
+            </a>
+            <span slot="content">View source on Github</span>
+          </rh-tooltip>
+
+          <rh-tooltip slot="footer">
+            <form action="https://codepen.io/pen/define" method="post">
+              <input type="hidden" name="data" value="${ifDefined(this.codePenData)}">
+              <rh-button variant="link" aria-label="View In Codepen" type="submit">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                  <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+                  <path d="M502.3 159.7l-234-156c-8-4.9-16.5-5-24.6 0l-234 156C3.7 163.7 0 170.8 0 178v156c0 7.1 3.7 14.3 9.7 18.3l234 156c8 4.9 16.5 5 24.6 0l234-156c6-4 9.7-11.1 9.7-18.3V178c0-7.1-3.7-14.3-9.7-18.3zM278 63.1l172.3 114.9-76.9 51.4L278 165.7V63.1zm-44 0v102.6l-95.4 63.7-76.9-51.4L234 63.1zM44 219.1l55.1 36.9L44 292.8v-73.7zm190 229.7L61.7 334l76.9-51.4L234 346.3v102.6zm22-140.9l-77.7-52 77.7-52 77.7 52-77.7 52zm22 140.9V346.3l95.4-63.7 76.9 51.4L278 448.8zm190-156l-55.1-36.9L468 219.1v73.7z"/>
+                </svg>
+              </rh-button>
+            </form>
+            <span slot="content">Open in Codepen</span>
+          </rh-tooltip>
+          
+          <rh-tooltip slot="footer">
+            <a id="new-tab" href="${this.demoUrl}" aria-label="View in new tab">
+              <rh-icon set="ui" icon="external-link"></rh-icon>
+            </a>
+            <span slot="content">View in new tab</span>
+          </rh-tooltip>
         </rh-card>
       </div>
     `;


### PR DESCRIPTION
## Proof of Concept: Do Not Merge

## What I did

1. Explored a proof of concept for creating Codepens from demo code.


## Testing Instructions

1.  Visit an element demo page, click open in codepen button on a demo, you should create a new Codepen with a working version of that demo.

## Notes to Reviewers

There is some hacky stuff here, namely dealing with lightdom CSS, where the method needs to be abstracted more to deal with any `<link rel>` stylesheets that could be present.   Also, we are reliant on a 3rd party CDN, meaning on release day likely, none of the demos would work. That's not great. I'd love to see our CDN be whitelisted for Codepen so we can rely on our infrastructure for these demos; that way, the code base will always be the same.

That said, I'm not convinced yet that the approach in this PR is the implementation we want. I want to look deeper into Codepen's APIs to see if there are other ways of doing this. 

This POC will explore the concept and maybe consider ways to improve it.  If you have an idea, jump in :) 
