### PR TITLE
fix(navigation primary): compact state await updateComplete

### DIFF
--- a/.changeset/forty-colts-read.md
+++ b/.changeset/forty-colts-read.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-primary>`: corrected state race condition on menu load'
+  

--- a/elements/rh-navigation-primary/rh-navigation-primary.ts
+++ b/elements/rh-navigation-primary/rh-navigation-primary.ts
@@ -410,11 +410,17 @@ export class RhNavigationPrimary extends LitElement {
   }
 
   async #openHamburger() {
+    if (!this._hamburger) {
+      await this.updateComplete;
+    }
     this._hamburger.open = true;
     await this.updateComplete;
   }
 
   async #closeHamburger() {
+    if (!this._hamburger) {
+      await this.updateComplete;
+    }
     this._hamburger.open = false;
     await this.updateComplete;
   }


### PR DESCRIPTION
## What I did

1. Added a check for `updateComplete` if the hamburger menu was unavailable.


## Testing Instructions

1. This is hard to test on the DP as it gets masked by DSD.    The best way I've found to confirm the change is by overriding the JS file on the [Code Pen ](https://codepen.io/zeroedin/pen/raavPGV)where the issue does occur with the change in this branch to confirm the issue is no longer present.

## Notes to Reviewers
