### PR TITLE
feat(breadcrumb): add truncation

### DIFF
--- a/.changeset/lemon-owls-peel.md
+++ b/.changeset/lemon-owls-peel.md
@@ -1,0 +1,18 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-breadcrumb>`: added the `truncate` property to allow users to temporarily hide the middle breadcrumb items:
+
+```html
+<rh-breadcrumb truncate>
+  <ol>
+    <li><a href="#home">Home</a></li>
+    <li><a href="#products">Products</a></li>
+    <li><a href="#open-shift-aws">Red Hat OpenShift on AWS</a></li>
+    <li><a href="#4">4</a></li>
+    <li><a href="#introduction-to-rosa">Introduction to ROSA</a></li>
+    <li><a href="#understanding-rosa" aria-current="page">Chapter 1. Understanding ROSA</a></li>
+  </ol>
+</rh-breadcrumb>
+```

--- a/.changeset/lemon-owls-peel.md
+++ b/.changeset/lemon-owls-peel.md
@@ -2,7 +2,9 @@
 "@rhds/elements": minor
 ---
 
-`<rh-breadcrumb>`: added the `truncate` property to allow users to temporarily hide the middle breadcrumb items:
+`<rh-breadcrumb>`: added the `truncate` attribute.
+
+When present, the middle breadcrumb items are hidden until the user interacts with them:
 
 ```html
 <rh-breadcrumb truncate>

--- a/elements/rh-breadcrumb/demo/truncate.html
+++ b/elements/rh-breadcrumb/demo/truncate.html
@@ -1,0 +1,15 @@
+<rh-breadcrumb truncate>
+  <ol>
+    <li><a href="#home">Home</a></li>
+    <li><a href="#products">Products</a></li>
+    <li><a href="#open-shift-aws">Red Hat OpenShift on AWS</a></li>
+    <li><a href="#4">4</a></li>
+    <li><a href="#introduction-to-rosa">Introduction to ROSA</a></li>
+    <li><a href="#understanding-rosa" aria-current="page">Chapter 1. Understanding ROSA</a></li>
+  </ol>
+</rh-breadcrumb>
+
+<link rel="stylesheet" href="../rh-breadcrumb-lightdom.css">
+<script type="module">
+  import '@rhds/elements/rh-breadcrumb/rh-breadcrumb.js';
+</script>

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -17,123 +17,125 @@ rh-breadcrumb {
   & [hidden] {
     display: none !important;
   }
+
+  & > ol {
+    container-type: inline-size;
+    container-name: breadcrumbs-list;
+    font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+    line-height: var(--rh-line-height-body-text, 1.5);
+    margin-block: 0;
+    padding-inline-start: 0;
+    & > li {
+      display: inline-flex;
+      margin-block-end: var(--rh-space-md, 8px);
+      padding-inline-end: var(--rh-breadcrumb-li-padding-inline-end, var(--rh-space-lg, 16px));
+      vertical-align: bottom;
+      align-items: center;
+      gap: var(--rh-space-lg, 16px);
+
+      &:not(:first-of-type):before {
+        display: inline-block;
+        background-color: var(--rh-color-icon-secondary);
+        mask-image: var(--_breadcrumb-caret-image-default);
+        mask-position: center center;
+        mask-repeat: no-repeat;
+        height: var(--rh-font-size-body-text-sm, 0.875rem);
+        width: var(--rh-font-size-body-text-sm, 0.875rem);
+        content: '';
+      }
+
+      &:first-child {
+        padding-inline-start: 0;
+        & > a {
+          margin-inline-start: 0;
+        }
+      }
+
+      &:last-child {
+        background-image: none;
+      }
+
+      & > a {
+        text-decoration: underline;
+        &:is(:hover, :focus, :active) {
+          color: var(--_breadcrumb-link-color-hover);
+        }
+
+        &:is(:focus, :focus-visible) {
+          border-radius: var(--rh-border-radius-default, 3px);
+          outline: 2px solid var(--_breadcrumb-link-focus-outline-color);
+        }
+
+        &:visited {
+          color: var(--_breadcrumb-link-color-visited);
+        }
+
+        &:visited:hover {
+          color: var(--_breadcrumb-link-color-visited-hover);
+        }
+
+        &[aria-current='page'] {
+          cursor: default;
+          pointer-events: none;
+        }
+      }
+
+      &:last-child,
+      & > a[aria-current='page'] {
+        color: var(--_breadcrumb-link-color-current-page);
+        text-decoration: none;
+      }
+
+    }
+
+    & > li,
+    & > li > a {
+      color: var(--_breadcrumb-link-color);
+    }
+  }
+
+  &[variant='subtle'] > ol > li {
+    &:not(:first-of-type):before {
+      background-color: var(--rh-color-icon-subtle, #707070);
+    }
+
+    &:last-child,
+    & > a[aria-current='page'] {
+      color: var(--_breadcrumb-link-color-current-page-subtle);
+    }
+  }
+
+  & .truncate-btn {
+    background-color: transparent;
+    border: 0;
+    color: var(--_breadcrumb-link-color);
+    cursor: pointer;
+    min-inline-size: var(--rh-length-xl, 24px);
+    padding: 0;
+
+    &:hover,
+    &:focus {
+      color: var(--_breadcrumb-link-color-hover);
+      text-decoration: underline;
+    }
+
+    &:focus {
+      border-radius: var(--rh-border-radius-default, 3px);
+      outline: 2px solid var(--_breadcrumb-link-focus-outline-color);
+    }
+
+    & .visually-hidden {
+      border: 0;
+      clip: rect(0, 0, 0, 0);
+      block-size: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      white-space: nowrap;
+      inline-size: 1px;
+    }
+  }
 }
 
-rh-breadcrumb ol {
-  container-type: inline-size;
-  container-name: breadcrumbs-list;
-  font-size: var(--rh-font-size-body-text-sm, 0.875rem);
-  line-height: var(--rh-line-height-body-text, 1.5);
-  margin-block: 0;
-  padding-inline-start: 0;
-}
 
-rh-breadcrumb > ol > li {
-  display: inline-flex;
-  margin-block-end: var(--rh-space-md, 8px);
-  padding-inline-end: var(--rh-breadcrumb-li-padding-inline-end, var(--rh-space-lg, 16px));
-  vertical-align: bottom;
-  align-items: center;
-  gap: var(--rh-space-lg, 16px);
-}
-
-rh-breadcrumb > ol > li:not(:first-of-type):before {
-  display: inline-block;
-  background-color: var(--rh-color-icon-secondary);
-  mask-image: var(--_breadcrumb-caret-image-default);
-  mask-position: center center;
-  mask-repeat: no-repeat;
-  height: var(--rh-font-size-body-text-sm, 0.875rem);
-  width: var(--rh-font-size-body-text-sm, 0.875rem);
-  content: '';
-}
-
-rh-breadcrumb[variant='subtle'] > ol > li:not(:first-of-type):before {
-  background-color: var(--rh-color-icon-subtle, #707070);
-}
-
-rh-breadcrumb > ol > li:first-child {
-  padding-inline-start: 0;
-}
-
-rh-breadcrumb > ol > li:last-child {
-  background-image: none;
-}
-
-rh-breadcrumb > ol > li,
-rh-breadcrumb > ol > li > a {
-  color: var(--_breadcrumb-link-color);
-}
-
-rh-breadcrumb > ol > li > a {
-  text-decoration: underline;
-}
-
-rh-breadcrumb > ol > li > a:is(:hover, :focus, :active) {
-  color: var(--_breadcrumb-link-color-hover);
-}
-
-rh-breadcrumb > ol > li > a:is(:focus, :focus-visible) {
-  border-radius: var(--rh-border-radius-default, 3px);
-  outline: 2px solid var(--_breadcrumb-link-focus-outline-color);
-}
-
-rh-breadcrumb > ol > li:first-child > a {
-  margin-inline-start: 0;
-}
-
-rh-breadcrumb > ol > li > a:visited {
-  color: var(--_breadcrumb-link-color-visited);
-}
-
-rh-breadcrumb > ol > li > a:visited:hover {
-  color: var(--_breadcrumb-link-color-visited-hover);
-}
-
-rh-breadcrumb > ol > li:last-child,
-rh-breadcrumb > ol > li > a[aria-current='page'] {
-  color: var(--_breadcrumb-link-color-current-page);
-  text-decoration: none;
-}
-
-rh-breadcrumb > ol > li > a[aria-current='page'] {
-  cursor: default;
-  pointer-events: none;
-}
-
-rh-breadcrumb[variant='subtle'] > ol > li:last-child,
-rh-breadcrumb[variant='subtle'] > ol > li > a[aria-current='page'] {
-  color: var(--_breadcrumb-link-color-current-page-subtle);
-}
-
-.rhds-truncate-btn {
-  background-color: transparent;
-  border: 0;
-  color: var(--_breadcrumb-link-color);
-  cursor: pointer;
-  min-inline-size: var(--rh-length-xl, 24px);
-  padding: 0;
-}
-
-.rhds-truncate-btn:hover,
-.rhds-truncate-btn:focus {
-  color: var(--_breadcrumb-link-color-hover);
-  text-decoration: underline;
-}
-
-.rhds-truncate-btn:focus {
-  border-radius: var(--rh-border-radius-default, 3px);
-  outline: 2px solid var(--_breadcrumb-link-focus-outline-color);
-}
-
-.rhds-truncate-visually-hidden {
-  border: 0;
-  clip: rect(0, 0, 0, 0);
-  block-size: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  inline-size: 1px;
-}

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -101,3 +101,39 @@ rh-breadcrumb[variant='subtle'] > ol > li:last-child,
 rh-breadcrumb[variant='subtle'] > ol > li > a[aria-current='page'] {
   color: var(--_breadcrumb-link-color-current-page-subtle);
 }
+
+[hidden] {
+  display: none !important;
+}
+
+.truncate-btn {
+  background-color: transparent;
+  border: 0;
+  color: var(--_breadcrumb-link-color);
+  cursor: pointer;
+  min-inline-size: var(--rh-length-xl, 24px);
+  padding: 0;
+}
+
+.truncate-btn:hover,
+.truncate-btn:focus {
+  color: var(--_breadcrumb-link-color-hover);
+  text-decoration: underline;
+}
+
+.truncate-btn:focus {
+  border-radius: var(--rh-border-radius-default, 3px);
+  outline: 2px solid var(--_breadcrumb-link-focus-outline-color);
+}
+
+.truncate-visually-hidden {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  block-size: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  inline-size: 1px;
+}

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -13,6 +13,10 @@ rh-breadcrumb {
   --_breadcrumb-link-focus-outline-color: var(--rh-color-border-interactive);
 
   display: block;
+
+  & [hidden] {
+    display: none !important;
+  }
 }
 
 rh-breadcrumb ol {
@@ -100,10 +104,6 @@ rh-breadcrumb > ol > li > a[aria-current='page'] {
 rh-breadcrumb[variant='subtle'] > ol > li:last-child,
 rh-breadcrumb[variant='subtle'] > ol > li > a[aria-current='page'] {
   color: var(--_breadcrumb-link-color-current-page-subtle);
-}
-
-[hidden] {
-  display: none !important;
 }
 
 .rhds-truncate-btn {

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -25,6 +25,7 @@ rh-breadcrumb {
     line-height: var(--rh-line-height-body-text, 1.5);
     margin-block: 0;
     padding-inline-start: 0;
+
     & > li {
       display: inline-flex;
       margin-block-end: var(--rh-space-md, 8px);
@@ -46,6 +47,7 @@ rh-breadcrumb {
 
       &:first-child {
         padding-inline-start: 0;
+
         & > a {
           margin-inline-start: 0;
         }
@@ -55,8 +57,10 @@ rh-breadcrumb {
         background-image: none;
       }
 
+      /* stylelint-disable-next-line no-descending-specificity */
       & > a {
         text-decoration: underline;
+
         &:is(:hover, :focus, :active) {
           color: var(--_breadcrumb-link-color-hover);
         }
@@ -85,7 +89,6 @@ rh-breadcrumb {
         color: var(--_breadcrumb-link-color-current-page);
         text-decoration: none;
       }
-
     }
 
     & > li,
@@ -137,5 +140,3 @@ rh-breadcrumb {
     }
   }
 }
-
-

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -39,8 +39,8 @@ rh-breadcrumb {
         mask-image: var(--_breadcrumb-caret-image-default);
         mask-position: center center;
         mask-repeat: no-repeat;
-        height: var(--rh-font-size-body-text-sm, 0.875rem);
-        width: var(--rh-font-size-body-text-sm, 0.875rem);
+        block-size: var(--rh-font-size-body-text-sm, 0.875rem);
+        inline-size: var(--rh-font-size-body-text-sm, 0.875rem);
         content: '';
       }
 

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -112,11 +112,11 @@ rh-breadcrumb {
     cursor: pointer;
     min-inline-size: var(--rh-length-xl, 24px);
     padding: 0;
+    text-decoration: underline;
 
     &:hover,
     &:focus {
       color: var(--_breadcrumb-link-color-hover);
-      text-decoration: underline;
     }
 
     &:focus {

--- a/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
+++ b/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css
@@ -106,7 +106,7 @@ rh-breadcrumb[variant='subtle'] > ol > li > a[aria-current='page'] {
   display: none !important;
 }
 
-.truncate-btn {
+.rhds-truncate-btn {
   background-color: transparent;
   border: 0;
   color: var(--_breadcrumb-link-color);
@@ -115,18 +115,18 @@ rh-breadcrumb[variant='subtle'] > ol > li > a[aria-current='page'] {
   padding: 0;
 }
 
-.truncate-btn:hover,
-.truncate-btn:focus {
+.rhds-truncate-btn:hover,
+.rhds-truncate-btn:focus {
   color: var(--_breadcrumb-link-color-hover);
   text-decoration: underline;
 }
 
-.truncate-btn:focus {
+.rhds-truncate-btn:focus {
   border-radius: var(--rh-border-radius-default, 3px);
   outline: 2px solid var(--_breadcrumb-link-focus-outline-color);
 }
 
-.truncate-visually-hidden {
+.rhds-truncate-visually-hidden {
   border: 0;
   clip: rect(0, 0, 0, 0);
   block-size: 1px;

--- a/elements/rh-breadcrumb/rh-breadcrumb.ts
+++ b/elements/rh-breadcrumb/rh-breadcrumb.ts
@@ -73,8 +73,8 @@ export class RhBreadcrumb extends LitElement {
     return html`
       <nav 
         aria-label="${label}"
-        @click="${this.truncate && this.#handleTruncationClick}"
-        @keyup="${this.truncate && this.#onKeyUp}"
+        @click="${this.truncate ? this.#handleTruncationClick : undefined}"
+        @keyup="${this.truncate ? this.#onKeyUp : undefined}"
         id="container"
         part="container">
         <slot></slot>
@@ -110,6 +110,10 @@ export class RhBreadcrumb extends LitElement {
   }
 
   #handleTruncationClick(event: Event): void {
+    if (isServer) {
+      return;
+    }
+
     const target = event.target as HTMLButtonElement;
     if (!target.closest('.truncate-btn')) {
       return;

--- a/elements/rh-breadcrumb/rh-breadcrumb.ts
+++ b/elements/rh-breadcrumb/rh-breadcrumb.ts
@@ -7,10 +7,10 @@ import { themable } from '@rhds/elements/lib/themable.js';
 import styles from './rh-breadcrumb.css';
 
 const truncationBtn = html`
-  <li class="truncate-btn-container">
-    <button type="button" class="truncate-btn" aria-expanded="false" title="Show middle breadcrumb items">
+  <li class="rhds-truncate-btn-container">
+    <button type="button" class="rhds-truncate-btn" aria-expanded="false" title="Show middle breadcrumb items">
       <span aria-hidden="true">&#8230;</span>
-      <span class="truncate-visually-hidden">
+      <span class="rhds-truncate-visually-hidden">
         Show middle breadcrumb items
       </span>
     </button>
@@ -115,7 +115,7 @@ export class RhBreadcrumb extends LitElement {
     }
 
     const target = event.target as HTMLButtonElement;
-    if (!target.closest('.truncate-btn')) {
+    if (!target.closest('.rhds-truncate-btn')) {
       return;
     }
 
@@ -127,7 +127,7 @@ export class RhBreadcrumb extends LitElement {
       item.removeAttribute('hidden');
     }
 
-    target.closest('.truncate-btn-container')?.remove();
+    target.closest('.rhds-truncate-btn-container')?.remove();
   }
 
   // appease linter

--- a/elements/rh-breadcrumb/rh-breadcrumb.ts
+++ b/elements/rh-breadcrumb/rh-breadcrumb.ts
@@ -18,7 +18,8 @@ function isTruncateButtonDescendant(target: EventTarget | null): target is HTMLE
 const truncationBtn = html`
   <button class="${truncateBtnClass}"
           aria-expanded="false"
-          title="Show middle breadcrumb items">
+          title="Show middle breadcrumb items"
+          type="button">
     <span aria-hidden="true">&#8230;</span>
     <span class="visually-hidden">
       Show middle breadcrumb items

--- a/elements/rh-breadcrumb/rh-breadcrumb.ts
+++ b/elements/rh-breadcrumb/rh-breadcrumb.ts
@@ -83,13 +83,14 @@ export class RhBreadcrumb extends LitElement {
   }
 
   firstUpdated(): void {
-    if (isServer) {
-      return;
-    }
     this.#updateLightDOM();
   }
 
   #updateLightDOM(): void {
+    if (isServer || !this.truncate) {
+      return;
+    }
+
     this.#list = this.querySelector('ol');
     if (!this.#list) {
       return;

--- a/elements/rh-breadcrumb/rh-breadcrumb.ts
+++ b/elements/rh-breadcrumb/rh-breadcrumb.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, isServer } from 'lit';
+import { LitElement, html, isServer, render } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
@@ -7,14 +7,12 @@ import { themable } from '@rhds/elements/lib/themable.js';
 import styles from './rh-breadcrumb.css';
 
 const truncationBtn = html`
-  <li class="rhds-truncate-btn-container">
-    <button type="button" class="rhds-truncate-btn" aria-expanded="false" title="Show middle breadcrumb items">
-      <span aria-hidden="true">&#8230;</span>
-      <span class="rhds-truncate-visually-hidden">
-        Show middle breadcrumb items
-      </span>
-    </button>
-  </li>`;
+  <button type="button" class="rhds-truncate-btn" aria-expanded="false" title="Show middle breadcrumb items">
+    <span aria-hidden="true">&#8230;</span>
+    <span class="rhds-truncate-visually-hidden">
+      Show middle breadcrumb items
+    </span>
+  </button>`;
 
 /**
  * A breadcrumb navigation is a secondary navigation element consisting of a list
@@ -67,6 +65,7 @@ export class RhBreadcrumb extends LitElement {
 
   #list: HTMLOListElement | null = null;
   #listItems: NodeListOf<HTMLLIElement> | null | undefined = null;
+  #truncateBtnContainerClass = 'rhds-truncate-btn-container';
 
   render() {
     const label = this.accessibleLabel ? this.accessibleLabel : 'Breadcrumb';
@@ -105,8 +104,10 @@ export class RhBreadcrumb extends LitElement {
       item.setAttribute('hidden', 'true');
     }
 
-    const [truncationBtnString] = truncationBtn.strings;
-    middleItems[0].insertAdjacentHTML('beforebegin', truncationBtnString);
+    const container = document.createElement('li');
+    container.className = this.#truncateBtnContainerClass;
+    render(truncationBtn, container);
+    middleItems[0].before(container);
   }
 
   #handleTruncationClick(event: Event): void {
@@ -127,7 +128,7 @@ export class RhBreadcrumb extends LitElement {
       item.removeAttribute('hidden');
     }
 
-    target.closest('.rhds-truncate-btn-container')?.remove();
+    target.closest(`.${this.#truncateBtnContainerClass}`)?.remove();
   }
 
   // appease linter

--- a/elements/rh-breadcrumb/rh-breadcrumb.ts
+++ b/elements/rh-breadcrumb/rh-breadcrumb.ts
@@ -1,10 +1,20 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, isServer } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
 import { themable } from '@rhds/elements/lib/themable.js';
 
 import styles from './rh-breadcrumb.css';
+
+const truncationBtn = html`
+  <li class="truncate-btn-container">
+    <button type="button" class="truncate-btn" aria-expanded="false" title="Show middle breadcrumb items">
+      <span aria-hidden="true">&#8230;</span>
+      <span class="truncate-visually-hidden">
+        Show middle breadcrumb items
+      </span>
+    </button>
+  </li>`;
 
 /**
  * A breadcrumb navigation is a secondary navigation element consisting of a list
@@ -38,6 +48,7 @@ import styles from './rh-breadcrumb.css';
 @customElement('rh-breadcrumb')
 @themable
 export class RhBreadcrumb extends LitElement {
+  static readonly styles = [styles];
   /**
    * Customize the default `aria-label` on the `<nav>` container.
    * Defaults to "Breadcrumb" if no attribute/property is set.
@@ -49,15 +60,74 @@ export class RhBreadcrumb extends LitElement {
    */
   @property({ reflect: true }) variant?: 'subtle';
 
-  static readonly styles = [styles];
+  /**
+ * Breadcrumbs over four items will be truncated and include a button to expand the middle breadcrumb items
+ */
+  @property({ reflect: true, type: Boolean }) truncate? = false;
+
+  #list: HTMLOListElement | null = null;
+  #listItems: NodeListOf<HTMLLIElement> | null | undefined = null;
 
   render() {
     const label = this.accessibleLabel ? this.accessibleLabel : 'Breadcrumb';
     return html`
-      <nav aria-label="${label}" part="container" id="container">
+      <nav 
+        aria-label="${label}"
+        @click="${this.truncate && this.#handleTruncationClick}"
+        @keyup="${this.truncate && this.#onKeyUp}"
+        id="container"
+        part="container">
         <slot></slot>
       </nav>
     `;
+  }
+
+  firstUpdated(): void {
+    if (isServer) {
+      return;
+    }
+    this.#updateLightDOM();
+  }
+
+  #updateLightDOM(): void {
+    this.#list = this.querySelector('ol');
+    if (!this.#list) {
+      return;
+    }
+
+    if (this.#list.children.length < 5) {
+      return;
+    }
+
+    const middleItems = this.#list.querySelectorAll('li:nth-child(n+2):nth-last-child(n+3)');
+    for (const item of middleItems) {
+      item.setAttribute('hidden', 'true');
+    }
+
+    const [truncationBtnString] = truncationBtn.strings;
+    middleItems[0].insertAdjacentHTML('beforebegin', truncationBtnString);
+  }
+
+  #handleTruncationClick(event: Event): void {
+    const target = event.target as HTMLButtonElement;
+    if (!target.closest('.truncate-btn')) {
+      return;
+    }
+
+    this.#listItems = this.#list?.querySelectorAll('li');
+    if (!this.#listItems) {
+      return;
+    }
+    for (const item of this.#listItems) {
+      item.removeAttribute('hidden');
+    }
+
+    target.closest('.truncate-btn-container')?.remove();
+  }
+
+  // appease linter
+  #onKeyUp() {
+    return;
   }
 }
 

--- a/elements/rh-breadcrumb/test/rh-breadcrumb.spec.ts
+++ b/elements/rh-breadcrumb/test/rh-breadcrumb.spec.ts
@@ -43,9 +43,9 @@ describe('<rh-breadcrumb>', function() {
 
     it('should have nav element with aria-label "Breadcrumb"', async function() {
       const { shadowRoot } = element;
-      const navElement = shadowRoot.querySelector('nav');
+      const navElement = shadowRoot?.querySelector('nav');
       expect(navElement).to.exist;
-      expect(navElement.getAttribute('aria-label')).to.equal('Breadcrumb');
+      expect(navElement?.getAttribute('aria-label')).to.equal('Breadcrumb');
     });
 
     it('should contain an ordered list, list items, and anchor tags', function() {
@@ -58,7 +58,7 @@ describe('<rh-breadcrumb>', function() {
       listItemElements.forEach(function(li) {
         const anchorElement = li.querySelector('a');
         expect(anchorElement).to.exist;
-        expect(anchorElement.getAttribute('href')).to.not.be.empty;
+        expect(anchorElement?.getAttribute('href')).to.not.be.empty;
       });
     });
 
@@ -76,7 +76,7 @@ describe('<rh-breadcrumb>', function() {
 
       it('should underline the first link when focused', function() {
         const firstBreadcrumb = element.querySelector('a');
-        const computedStyle = getComputedStyle(firstBreadcrumb);
+        const computedStyle = getComputedStyle(firstBreadcrumb as Element);
         expect(computedStyle.textDecorationLine).to.equal('underline');
       });
     });
@@ -103,9 +103,11 @@ describe('<rh-breadcrumb>', function() {
 
     it('should output the custom accessible label', async function() {
       const { shadowRoot } = element;
-      const navElement = shadowRoot.querySelector('nav');
+      const navElement = shadowRoot?.querySelector('nav');
       expect(navElement).to.exist;
-      expect(navElement.getAttribute('aria-label')).to.equal(customAccessibleLabel);
+      expect(navElement?.getAttribute('aria-label')).to.equal(customAccessibleLabel);
+    });
+  });
 
   describe('when truncate is enabled', function() {
     let element: RhBreadcrumb;

--- a/elements/rh-breadcrumb/test/rh-breadcrumb.spec.ts
+++ b/elements/rh-breadcrumb/test/rh-breadcrumb.spec.ts
@@ -24,12 +24,12 @@ describe('<rh-breadcrumb>', function() {
       element = await createFixture<RhBreadcrumb>(html`
         <rh-breadcrumb>
           <ol>
-            <li><a href="#">Home</a></li>
-            <li><a href="#">Products</a></li>
-            <li><a href="#">Red Hat OpenShift on AWS</a></li>
-            <li><a href="#">4</a></li>
-            <li><a href="#">Introduction to ROSA</a></li>
-            <li><a href="#" aria-current="page">Chapter 1. Understanding ROSA</a></li>
+            <li><a href="#">One</a></li>
+            <li><a href="#">Two</a></li>
+            <li><a href="#">Three</a></li>
+            <li><a href="#">Four</a></li>
+            <li><a href="#">Five</a></li>
+            <li><a href="#" aria-current="page">Six</a></li>
           </ol>
         </rh-breadcrumb>
       `);
@@ -89,12 +89,12 @@ describe('<rh-breadcrumb>', function() {
       element = await createFixture<RhBreadcrumb>(html`
         <rh-breadcrumb accessible-label="${customAccessibleLabel}">
           <ol>
-            <li><a href="#">Home</a></li>
-            <li><a href="#">Products</a></li>
-            <li><a href="#">Red Hat OpenShift on AWS</a></li>
-            <li><a href="#">4</a></li>
-            <li><a href="#">Introduction to ROSA</a></li>
-            <li><a href="#" aria-current="page">Chapter 1. Understanding ROSA</a></li>
+            <li><a href="#">One</a></li>
+            <li><a href="#">Two</a></li>
+            <li><a href="#">Three</a></li>
+            <li><a href="#">Four</a></li>
+            <li><a href="#">Five</a></li>
+            <li><a href="#" aria-current="page">Six</a></li>
           </ol>
         </rh-breadcrumb>
       `);


### PR DESCRIPTION
## What I did

1. Added a prop, `truncate`, to allow middle breadcrumb items to be temporarily replaced by a button.
2. Users can click the button to 1) show the middle breadcrumb buttons and 2) remove the button from the DOM.

### How truncation works

1. Requires the `truncate` boolean property
2. Only truncates when there are more than four breadcrumb items
3. Starts truncation at the second list item
4. Ends truncation at the third to last list item

## Testing Instructions

1. View the [DP demo](https://deploy-preview-2357--red-hat-design-system.netlify.app/elements/breadcrumb/demo/truncate/).
1. Ensure I am taking the right approach in the code.

## Notes to Reviewers

Based off of [this Figma](https://www.figma.com/proto/FSkPCjWTWK63QfSnX8rChZ/rh-breadcrumb?page-id=1%3A3&type=design&node-id=1-218&viewport=122%2C139%2C1&t=AmmdkOlWBdRh2fWu-1&scaling=min-zoom).

We can optionally add other properties to tell where to start and end truncation. The figma hints at this.

The Figma shows no truncation at LG and XL viewports. Ideally this could be handled by a Container Size Controller; although, last I looked, there was no JS API for container queries. Perhaps this could be handled by our ScreenSizeController. 

## To do's

- [x] Remove errant commits from this PR
- [x] Fix tests
- [x] Add new tests for `truncate` functionality

Closes #2262.