### PR TITLE
fix(navigation-primary): item menu padding

### DIFF
--- a/elements/rh-navigation-primary/rh-navigation-primary-item-menu.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary-item-menu.css
@@ -5,18 +5,16 @@
 #container {
   color: var(--rh-color-text-primary);
   background-color: var(--rh-color-surface);
-  padding:
+  padding-inline: var(--rh-space-lg, 16px);
+  padding-block:
     var(--rh-space-lg, 16px)
-    var(--rh-space-lg, 16px)
-    var(--rh-navigation-primary-item-menu-padding-block-end, var(--rh-space-2xl, 32px))
-    var(--rh-space-lg, 16px);
+    var(--rh-navigation-primary-item-menu-padding-block-end, var(--rh-space-2xl, 32px));
 
   @container (min-width: 768px) {
-    padding:
-      var(--rh-space-lg, 16px)
-      var(--rh-space-lg, 16px)
-      var(--rh-navigation-primary-item-menu-padding-block-end, var(--rh-space-2xl, 32px))
-      var(--rh-space-lg, 16px);
+    padding-inline: var(--rh-space-2xl, 32px);
+    padding-block:
+      var(--rh-space-2xl, 32px)
+      var(--rh-navigation-primary-item-menu-padding-block-end, var(--rh-space-3xl, 48px));
   }
 
   &:not(.compact) {

--- a/elements/rh-navigation-primary/rh-navigation-primary-item-menu.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary-item-menu.css
@@ -5,13 +5,24 @@
 #container {
   color: var(--rh-color-text-primary);
   background-color: var(--rh-color-surface);
-  padding: var(--rh-space-2xl, 32px) var(--rh-space-xl, 24px);
+  padding:
+    var(--rh-space-lg, 16px)
+    var(--rh-space-lg, 16px)
+    var(--rh-navigation-primary-item-menu-padding-block-end, var(--rh-space-2xl, 32px))
+    var(--rh-space-lg, 16px);
+
+  @container (min-width: 768px) {
+    padding:
+      var(--rh-space-lg, 16px)
+      var(--rh-space-lg, 16px)
+      var(--rh-navigation-primary-item-menu-padding-block-end, var(--rh-space-2xl, 32px))
+      var(--rh-space-lg, 16px);
+  }
 
   &:not(.compact) {
     @container (min-width: 1200px) {
       margin: 0 auto;
       max-width: 1440px;
-      padding: var(--rh-space-3xl, 48px) var(--rh-space-2xl, 32px);
     }
   }
 }


### PR DESCRIPTION
## What I did

1. To support the [Account dropdown from design](https://www.figma.com/design/Ob5kpQip4qdSFJ7gTXSP2r/Unified-Navigation?node-id=4153-58012&m=dev), we need the ability to remove the padding from the `rh-navigation-primary-item-menu` container.
2. Added `--rh-navigation-primary-item-menu-padding-block-end`


## Testing Instructions

1. View deploy preview demo
2. Add a new CSS rule  `rh-navigation-primary-item { --rh-navigation-primary-item-menu-padding-block-end: 0; }` 
3. The item dropdown menu should have zero bottom padding.

## Notes to Reviewers

I think this is likely a `minor` change due to the addition of the new functionality, but because we are releasing nav in a controlled way right now and know our consumers, maybe we can squeeze this as a patch-level concern. Thoughts?  Will add changeset when we resolve this question.
