### PR TITLE
fix(pagination): total pages

### DIFF
--- a/.changeset/small-clocks-visit.md
+++ b/.changeset/small-clocks-visit.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-pagination>`: hide total pages counter until the correct number is calculated


### PR DESCRIPTION
## What I did

1. compute the total pages and set state client side
2. hide the total until then

## Testing Instructions

1. view any pagination demo both in the DP and the dev server

## Notes to Reviewers
This is a nice way to avoid SSR mismatch errors:
- use private `@state` for the *actual rendered value*
- provide some default value in the class field initializer
- compute that value client side once the DOM is available
- set the private `@state` field, thus triggering an update

This avoids the mismatch-on-first render problem by making the default value the first-rendered value in all scenarios. This works well in pagination, because it makes little sense to say "page 1 of 0", and thus we can confidently hide the "of 0" part until client side is ready