### PR TITLE
fix(dialog): scrollbar state after closing

### DIFF
--- a/.changeset/seven-dragons-jam.md
+++ b/.changeset/seven-dragons-jam.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-dialog>`: add event listener to native dialog close event to enable scrollbar on cancelling the dialog.
+  

--- a/.changeset/seven-dragons-jam.md
+++ b/.changeset/seven-dragons-jam.md
@@ -2,5 +2,5 @@
 "@rhds/elements": patch
 ---
 
-`<rh-dialog>`: add event listener to native dialog close event to enable scrollbar on cancelling the dialog.
+`<rh-dialog>`: The dialog element will now reset scrollbar when closed, even if it was not in focus at the time of closure.
   

--- a/elements/rh-dialog/demo/form.html
+++ b/elements/rh-dialog/demo/form.html
@@ -1,0 +1,62 @@
+<rh-dialog id="dialog-element"  trigger="trigger">
+    <form id="form-element"> 
+        <p>
+          <label>
+            Favorite RHDS Token Value:
+            <select id="selectElement">
+              <option value="default">Choose…</option>
+              <option>--rh-color-brand-red</option>
+              <option>--rh-color-red-50</option>
+              <option>--rh-color-status-note</option>
+            </select>
+          </label>
+        </p>
+        <div>
+            <button id="cancellationButton" value="cancel" formmethod="dialog">Cancel</button>
+            <button type="submit" id="confirmation-button" value="default">Submit</button>
+          </div>
+        </form>
+        </rh-dialog>
+<rh-button id="trigger">Open Dialog</rh-button>
+<output></output>
+
+
+<script type="module">
+    import '@rhds/elements/rh-button/rh-button.js';
+    import '@rhds/elements/rh-dialog/rh-dialog.js';
+  
+    const rhdsDialogElement = document.getElementById('dialog-element');
+    const form = document.getElementById('form-element');
+    
+    const confirmationButton = document.getElementById('confirmation-button');
+    const cancellationButton = document.getElementById('cancellationButton');
+    const selectElement = document.getElementById("selectElement");
+    
+    const eventOutput = document.querySelector('output');
+
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+    });
+
+    const events = [];
+    const onDialogEvent = event => {
+      events.push(event.type);
+      if (event.type !== 'open') {
+        eventOutput.value =
+          rhdsDialogElement.returnValue === "default"
+          ? "No return value."
+          : `ReturnValue: ${rhdsDialogElement.returnValue}.`;
+      }
+    };
+    confirmationButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        rhdsDialogElement.close(selectElement.value);
+    });
+    cancellationButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        rhdsDialogElement.cancel('cancelled');
+    });
+    rhdsDialogElement.addEventListener('close', onDialogEvent);
+    rhdsDialogElement.addEventListener('open', onDialogEvent);
+    rhdsDialogElement.addEventListener('cancel', onDialogEvent);
+  </script>

--- a/elements/rh-dialog/rh-dialog.ts
+++ b/elements/rh-dialog/rh-dialog.ts
@@ -124,6 +124,7 @@ export class RhDialog extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.#triggerElement?.removeEventListener('click', this.onTriggerClick);
+    this.dialog?.removeEventListener('cancel', this.#onNativeDialogCancel);
   }
 
   render() {
@@ -190,6 +191,10 @@ export class RhDialog extends LitElement {
       // Get the first heading in the dialog if it exists
       this.#headings[0].id = this.#headerId;
     }
+
+    if (this.dialog) {
+      this.dialog?.addEventListener('cancel', this.#onNativeDialogCancel.bind(this));
+    }
   }
 
   @observes('open')
@@ -251,6 +256,11 @@ export class RhDialog extends LitElement {
         this.cancel();
       }
     }
+  }
+
+  #onNativeDialogCancel(event: Event) {
+    event.preventDefault();
+    this.cancel();
   }
 
   #onKeyDown(event: KeyboardEvent) {

--- a/elements/rh-dialog/rh-dialog.ts
+++ b/elements/rh-dialog/rh-dialog.ts
@@ -124,13 +124,6 @@ export class RhDialog extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.#triggerElement?.removeEventListener('click', this.onTriggerClick);
-    this.dialog?.removeEventListener('cancel', this.#onNativeDialogCancel);
-  }
-
-  firstUpdated(): void {
-    if (this.dialog) {
-      this.dialog.addEventListener('close', this.#onNativeDialogCancel.bind(this));
-    }
   }
 
   render() {
@@ -147,7 +140,8 @@ export class RhDialog extends LitElement {
           <dialog id="dialog"
                   part="dialog"
                   aria-labelledby=${ifDefined(this.accessibleLabel ? undefined : headerId)}
-                  aria-label=${ifDefined(this.accessibleLabel ? this.accessibleLabel : (!headerId ? triggerLabel : undefined))}>
+                  aria-label=${ifDefined(this.accessibleLabel ? this.accessibleLabel : (!headerId ? triggerLabel : undefined))}
+                  @cancel=${this.#onNativeDialogCancel}>
             <rh-button variant="close"
                        id="close-button"
                        part="close-button"
@@ -261,7 +255,9 @@ export class RhDialog extends LitElement {
   }
 
   #onNativeDialogCancel(event: Event) {
-    event.preventDefault();
+    console.log('native dialog close or cancel');
+    console.log('event:')
+    console.log(event);
     this.cancel();
   }
 
@@ -280,9 +276,9 @@ export class RhDialog extends LitElement {
     }
   }
 
-  private async cancel() {
+  private async cancel(returnValue?: string) {
     this.#cancelling = true;
-    this.close();
+    this.close(returnValue);
     this.open = false;
     await this.updateComplete;
     this.#cancelling = false;
@@ -334,6 +330,8 @@ export class RhDialog extends LitElement {
   close(returnValue?: string) {
     if (typeof returnValue === 'string') {
       this.returnValue = returnValue;
+    } else {
+      this.returnValue = '';
     }
 
     this.dialog?.close();

--- a/elements/rh-dialog/rh-dialog.ts
+++ b/elements/rh-dialog/rh-dialog.ts
@@ -128,7 +128,7 @@ export class RhDialog extends LitElement {
   }
 
   firstUpdated(): void {
-    if (this.dialog){
+    if (this.dialog) {
       this.dialog.addEventListener('close', this.#onNativeDialogCancel.bind(this));
     }
   }

--- a/elements/rh-dialog/rh-dialog.ts
+++ b/elements/rh-dialog/rh-dialog.ts
@@ -127,6 +127,12 @@ export class RhDialog extends LitElement {
     this.dialog?.removeEventListener('cancel', this.#onNativeDialogCancel);
   }
 
+  firstUpdated(): void {
+    if (this.dialog){
+      this.dialog.addEventListener('close', this.#onNativeDialogCancel.bind(this));
+    }
+  }
+
   render() {
     const headerId = (this.#header || this.#headings.length) ? this.#headerId : undefined;
     const triggerLabel = this.#triggerElement ? this.#triggerElement.innerText : undefined;
@@ -190,10 +196,6 @@ export class RhDialog extends LitElement {
     } else if (this.#headings.length > 0) {
       // Get the first heading in the dialog if it exists
       this.#headings[0].id = this.#headerId;
-    }
-
-    if (this.dialog) {
-      this.dialog?.addEventListener('cancel', this.#onNativeDialogCancel.bind(this));
     }
   }
 

--- a/elements/rh-dialog/rh-dialog.ts
+++ b/elements/rh-dialog/rh-dialog.ts
@@ -254,10 +254,7 @@ export class RhDialog extends LitElement {
     }
   }
 
-  #onNativeDialogCancel(event: Event) {
-    console.log('native dialog close or cancel');
-    console.log('event:')
-    console.log(event);
+  #onNativeDialogCancel() {
     this.cancel();
   }
 
@@ -276,7 +273,7 @@ export class RhDialog extends LitElement {
     }
   }
 
-  private async cancel(returnValue?: string) {
+  async cancel(returnValue?: string) {
     this.#cancelling = true;
     this.close(returnValue);
     this.open = false;

--- a/elements/rh-dialog/test/rh-dialog.spec.ts
+++ b/elements/rh-dialog/test/rh-dialog.spec.ts
@@ -110,4 +110,126 @@ describe('<rh-dialog>', function() {
       });
     });
   });
+
+  describe('<rh-dialog> with a form', function() {
+    let element: RhDialog;
+    let triggerButton: RhButton;
+    let formElement: HTMLFormElement;
+    let selectElement: HTMLSelectElement;
+    let confirmationButton: HTMLButtonElement;
+    let cancellationButton: HTMLButtonElement;
+
+    async function openDialog() {
+      triggerButton.click();
+      await element.updateComplete;
+      await nextFrame();
+      expect(element.open, 'Dialog should be open after trigger click').to.be.true;
+    }
+  
+    beforeEach(async function() {
+      const fixture = await createFixture(html`
+        <div>
+          <rh-dialog id="dialog-element-form" trigger="trigger-form">
+            <form id="form-element">
+              <p>
+                <label>
+                  Favorite RHDS Token Value:
+                  <select id="selectElement">
+                    <option value="default">Choose…</option>
+                    <option value="--rh-color-brand-red">--rh-color-brand-red</option>
+                    <option value="--rh-color-red-50">--rh-color-red-50</option>
+                    <option value="--rh-color-status-note">--rh-color-status-note</option>
+                  </select>
+                </label>
+              </p>
+              <div>
+                <button id="cancellationButton" value="cancel">Cancel</button>
+                <button type="submit" id="confirmation-button" value="default">Submit</button>
+              </div>
+            </form>
+          </rh-dialog>
+          <rh-button id="trigger-form">Open Dialog</rh-button>
+        </div>
+      `);
+      element = fixture.querySelector<RhDialog>('#dialog-element-form')!;
+      triggerButton = fixture.querySelector<RhButton>('#trigger-form')!;
+      formElement = fixture.querySelector<HTMLFormElement>('#form-element')!;
+      selectElement = fixture.querySelector<HTMLSelectElement>('#selectElement')!;
+      confirmationButton = fixture.querySelector<HTMLButtonElement>('#confirmation-button')!;
+      cancellationButton = fixture.querySelector<HTMLButtonElement>('#cancellationButton')!;
+  
+      formElement.addEventListener('submit', e => e.preventDefault());
+  
+      confirmationButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        if (element.open) {
+          element.close(selectElement.value);
+        }
+      });
+  
+      cancellationButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        if (element.open) {
+          element.cancel('cancelled');
+        }
+      });
+    });
+  
+    it('should set returnValue correctly when submitting with a selected option', async function() {
+      await openDialog();
+      selectElement.value = '--rh-color-brand-red';
+
+      await confirmationButton.click();
+      await element.updateComplete;
+      await nextFrame();
+
+      expect(element.open, `Dialog should be closed after submit with selection`).to.be.false;
+      expect(element.returnValue, `returnValue after submit with selection`).to.equal(selectElement.value);
+    });
+  
+    it('should set returnValue correctly when submitting with default option', async function() {
+      await openDialog();
+      selectElement.value = 'default';
+
+      await confirmationButton.click();
+      await element.updateComplete;
+      await nextFrame();
+
+      expect(element.open, `Dialog should be closed after submit with default`).to.be.false;
+      expect(element.returnValue, `returnValue after submit with default`).to.equal(selectElement.value);
+    });
+  
+    it('should set returnValue correctly when the forms "Cancel" button is clicked', async function() {
+      await openDialog();
+
+      await cancellationButton.click();
+      await element.updateComplete;
+      await nextFrame();
+
+      expect(element.open, `Dialog should be closed after form cancel button`).to.be.false;
+      expect(element.returnValue, `returnValue after form cancel button`).to.equal('cancelled');
+    });
+  
+    it('should set empty returnValue when closed via ESC key', async function() {
+      await openDialog();
+
+      await press('Escape')();
+      await element.updateComplete;
+      await nextFrame();
+
+      expect(element.open, `Dialog should be closed after ESC key`).to.be.false;
+      expect(element.returnValue, `returnValue after ESC key`).to.equal('');
+    });
+  
+    it('should set empty returnValue when closed by clicking outside', async function() {
+      await openDialog();
+
+      await clickElementAtOffset(document.body, [10, 10]);;
+      await element.updateComplete;
+      await nextFrame();
+
+      expect(element.open, `Dialog should be closed after clicking outside`).to.be.false;
+      expect(element.returnValue, `returnValue after clicking outside`).to.equal('');
+    });
+  });
 });

--- a/elements/rh-dialog/test/rh-dialog.spec.ts
+++ b/elements/rh-dialog/test/rh-dialog.spec.ts
@@ -125,7 +125,7 @@ describe('<rh-dialog>', function() {
       await nextFrame();
       expect(element.open, 'Dialog should be open after trigger click').to.be.true;
     }
-  
+
     beforeEach(async function() {
       const fixture = await createFixture(html`
         <div>
@@ -157,24 +157,24 @@ describe('<rh-dialog>', function() {
       selectElement = fixture.querySelector<HTMLSelectElement>('#selectElement')!;
       confirmationButton = fixture.querySelector<HTMLButtonElement>('#confirmation-button')!;
       cancellationButton = fixture.querySelector<HTMLButtonElement>('#cancellationButton')!;
-  
+
       formElement.addEventListener('submit', e => e.preventDefault());
-  
-      confirmationButton.addEventListener("click", (event) => {
+
+      confirmationButton.addEventListener('click', event => {
         event.preventDefault();
         if (element.open) {
           element.close(selectElement.value);
         }
       });
-  
-      cancellationButton.addEventListener("click", (event) => {
+
+      cancellationButton.addEventListener('click', event => {
         event.preventDefault();
         if (element.open) {
           element.cancel('cancelled');
         }
       });
     });
-  
+
     it('should set returnValue correctly when submitting with a selected option', async function() {
       await openDialog();
       selectElement.value = '--rh-color-brand-red';
@@ -186,7 +186,7 @@ describe('<rh-dialog>', function() {
       expect(element.open, `Dialog should be closed after submit with selection`).to.be.false;
       expect(element.returnValue, `returnValue after submit with selection`).to.equal(selectElement.value);
     });
-  
+
     it('should set returnValue correctly when submitting with default option', async function() {
       await openDialog();
       selectElement.value = 'default';
@@ -198,7 +198,7 @@ describe('<rh-dialog>', function() {
       expect(element.open, `Dialog should be closed after submit with default`).to.be.false;
       expect(element.returnValue, `returnValue after submit with default`).to.equal(selectElement.value);
     });
-  
+
     it('should set returnValue correctly when the forms "Cancel" button is clicked', async function() {
       await openDialog();
 
@@ -209,7 +209,7 @@ describe('<rh-dialog>', function() {
       expect(element.open, `Dialog should be closed after form cancel button`).to.be.false;
       expect(element.returnValue, `returnValue after form cancel button`).to.equal('cancelled');
     });
-  
+
     it('should set empty returnValue when closed via ESC key', async function() {
       await openDialog();
 
@@ -220,11 +220,11 @@ describe('<rh-dialog>', function() {
       expect(element.open, `Dialog should be closed after ESC key`).to.be.false;
       expect(element.returnValue, `returnValue after ESC key`).to.equal('');
     });
-  
+
     it('should set empty returnValue when closed by clicking outside', async function() {
       await openDialog();
 
-      await clickElementAtOffset(document.body, [10, 10]);;
+      await clickElementAtOffset(document.body, [10, 10]); ;
       await element.updateComplete;
       await nextFrame();
 


### PR DESCRIPTION
Adding an event listener to the native dialog element to handle if the dialog is cancelled outside of the context of the  element

## What I did

1.  I added an event listener to the dialog in the `firstUpdated()` function that calls a function called `#onNativeDialogCancel` when the dialog element sends a cancel event.
2. The native dialog cancel prevents the default behavior and instead calls out components `cancel` method directly.


## Testing Instructions

1.  Open the demo site
2. Go to the `Lots of Content` page
3. Open the dialog
4. Tab out of the dialog
5. Click the address bar
6. Tap the `ESC` key twice
7. The scrollbar should be enabled.

## Notes to Reviewers
