### PR TITLE
fix(audio-player): close button (chrome)

### DIFF
--- a/.changeset/short-squids-obey.md
+++ b/.changeset/short-squids-obey.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-audio-player>`: fix transcript close button on chrome

--- a/elements/rh-audio-player/rh-audio-player.css
+++ b/elements/rh-audio-player/rh-audio-player.css
@@ -357,8 +357,7 @@ input[type='range'] {
   display: none;
 }
 
-.expanded #close-tooltip,
-:not(.expanded) #menu-tooltip {
+.expanded #close-tooltip {
   display: inline-block;
 }
 


### PR DESCRIPTION
## What I did

1. ensure menu button is hidden when transcript is open (chrome)

## Testing Instructions

1. view transcript demo in all three browsers
2. click menu
3. click transcript
4. observe that close button is well positioned and menu button is not visible

## Notes to Reviewers

Closes #2362 