### PR TITLE
fix(audio-player): play icon misalignment webkit

### DIFF
--- a/.changeset/shaky-things-melt.md
+++ b/.changeset/shaky-things-melt.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-audio-player>`: fix play button icon misalignment in webkit

--- a/elements/rh-audio-player/rh-audio-player.css
+++ b/elements/rh-audio-player/rh-audio-player.css
@@ -433,6 +433,8 @@ rh-menu > button:focus {
 #play,
 #full-play {
   display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
   background-color:
     light-dark(var(--rh-color-surface-darkest, #151515),


### PR DESCRIPTION
## What I did

1. align the play icon in webkit


## Testing Instructions

1. Please see attached issue
2. https://deploy-preview-2373--red-hat-design-system.netlify.app/elements/audio-player/demo/
3. Before: <img width="949" alt="Screenshot 2025-05-14 at 10 51 53" src="https://github.com/user-attachments/assets/78505c9e-8154-42a6-a40a-7f7f7f1551c4" />
4. After: <img width="910" alt="Screenshot 2025-05-14 at 13 28 47" src="https://github.com/user-attachments/assets/2135ea8d-5c9b-47b0-96cf-1be42b228dea" />
## Notes to Reviewers

Closes #2372 