### PR TITLE
docs: demo codeblock backticks

### DIFF
--- a/docs/_includes/layouts/pages/element.11ty.ts
+++ b/docs/_includes/layouts/pages/element.11ty.ts
@@ -718,7 +718,7 @@ export default class ElementsPage extends Renderer<Context> {
 
   async #renderDemos(content: string, ctx: Context) {
     const tagName = ctx.tagName as `rh-${string}`;
-    const demos = ElementsPage.demoManifestsForTagNames[tagName] ?? [];
+    const demos: DemoRecord[] = ElementsPage.demoManifestsForTagNames[tagName] ?? [];
     return [
       html`
       <script type="module" data-helmet>
@@ -801,7 +801,7 @@ export default class ElementsPage extends Renderer<Context> {
 
       const blocks = await Promise.all(map.entries().map(([kind, content]) => {
         const tpl = dedent(`
-          \`\`\`\`${kind} uxdotcodeblock {slot=${kind}}
+          \`\`\`${kind} uxdotcodeblock {slot=${kind}}
           ${content.trim()}
           \`\`\`
         `);


### PR DESCRIPTION
Closes #2346 

## What I did

1. remove uncouth backticks from demos page codeblocks. so rude.


## Testing Instructions

1. https://deploy-preview-2374--red-hat-design-system.netlify.app/elements/tag/demos/
2. check out a demo html codeblock, scroll to the bottom