### PR TITLE
perf(code-block): avoid loading prism when prerendered

### DIFF
--- a/.changeset/cruel-walls-carry.md
+++ b/.changeset/cruel-walls-carry.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-code-block>`: improve performance of pre-rendered code blocks.

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -237,7 +237,7 @@ export class RhCodeBlock extends LitElement {
     if (!isServer && getComputedStyle(this).getPropertyValue('--_styles-applied') !== 'true') {
       const root = this.getRootNode();
       if (root instanceof Document || root instanceof ShadowRoot) {
-        const { preRenderedLightDomStyles: { styleSheet } } = await import('./prism.js');
+        const { preRenderedLightDomStyles: { styleSheet } } = await import('./prism.css.js');
         root.adoptedStyleSheets = [...root.adoptedStyleSheets, styleSheet!];
       }
     }


### PR DESCRIPTION
## What I did

1. load the prerendered styles from a module which doesn't also load prism


## Testing Instructions

1. check out some prerendered codeblocks in the dp, make sure they work.
2. Find a page that *only* has prerendered code blocks - reload with network panel open, ensure prism-esm.js is not loaded
3. find a page with both preloaded and client code blocks, they should work

## Notes to Reviewers
This should help with code block perf on large docs pages
cc @kylebuch8 