### PR TITLE
fix(tooltip): contrasting color-scheme

### DIFF
--- a/.changeset/stale-pans-throw.md
+++ b/.changeset/stale-pans-throw.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-tooltip>`: correctly renders tooltip content using contrasting color scheme

--- a/elements/rh-tooltip/rh-tooltip.css
+++ b/elements/rh-tooltip/rh-tooltip.css
@@ -55,12 +55,15 @@
   /* WARNING: properties containing `__`are deprecated and will be removed */
   color:
     light-dark(var(--rh-tooltip-content-color,
-      var(--rh-tooltip__content--Color, var(--rh-color-text-primary-on-dark, #ffffff))),
-      var(--rh-tooltip-content-color, var(--rh-color-text-primary-on-light, #151515)));
+      var(--rh-tooltip__content--Color, var(--rh-color-text-primary-on-light, #151515))),
+      var(--rh-tooltip-content-color, var(--rh-color-text-primary-on-dark, #ffffff)));
   background-color:
     light-dark(var(--rh-tooltip-content-background-color,
-      var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-darkest, #151515))),
-      var(--rh-tooltip-content-background-color, var(--rh-color-surface-lightest, #ffffff)));
+      var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-lightest, #ffffff))),
+      var(--rh-tooltip-content-background-color, var(--rh-color-surface-darkest, #151515)));
+
+  &.dark { color-scheme: dark; }
+  &.light { color-scheme: light; }
 }
 
 .initialized #tooltip {
@@ -76,9 +79,9 @@
   will-change: left top right bottom;
   background-color:
     light-dark(var(--rh-tooltip-content-background-color,
-      var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-darkest, #151515))),
+      var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-lightest, #ffffff))),
       var(--rh-tooltip-content-background-color,
-      var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-lightest, #ffffff))));
+      var(--rh-tooltip__content--BackgroundColor, var(--rh-color-surface-darkest, #151515))));
 }
 
 .open #tooltip {

--- a/elements/rh-tooltip/rh-tooltip.ts
+++ b/elements/rh-tooltip/rh-tooltip.ts
@@ -91,6 +91,7 @@ export class RhTooltip extends LitElement {
   });
 
   #initialized = false;
+  #style?: CSSStyleDeclaration;
 
   get #content() {
     if (!this.#float.open || isServer) {
@@ -113,6 +114,10 @@ export class RhTooltip extends LitElement {
   override render() {
     const { alignment, anchor, open, styles } = this.#float;
 
+    const scheme = this.#style?.colorScheme ?? 'light';
+    const dark = !!scheme.match(/^light( (dark|only))?/);
+    const light = !!scheme.match(/^dark( only)?/);
+
     return html`
       <div id="container"
            style="${styleMap(styles)}"
@@ -123,7 +128,7 @@ export class RhTooltip extends LitElement {
         <div id="invoker">
           <slot id="invoker-slot"></slot>
         </div>
-        <div id="tooltip" role="status">
+        <div id="tooltip" role="status" class="${classMap({ dark, light })}">
           <slot id="content" name="content">${this.content}</slot>
         </div>
       </div>
@@ -132,6 +137,7 @@ export class RhTooltip extends LitElement {
 
   /** Show the tooltip */
   async show() {
+    this.#style ??= getComputedStyle(this);
     await this.updateComplete;
     const placement = this.position;
     const offset =


### PR DESCRIPTION
## What I did

1. compute the contrasting "color-scheme" value for tooltips when they open

## Testing Instructions

1. pick a page with tooltips, maybe in a demo or a code block, preferably with themable content like `<code>`
2. toggle color schemes back and forth
3. open the tooltip and observe that the themable content is legible

## Notes to Reviewers
This came up when working on knobs #2379.

This all happens in the `open()` method, so it should be client-side only and not cause ssr mismatches.

also NB that we neglected to delete the deprecated properties when releasing cubone, so we should prioritize that for the next breaking change, whenever that might be
