### PR TITLE
fix(code-block): autoload tooltip for fabs

### DIFF
--- a/.changeset/thin-baboons-do.md
+++ b/.changeset/thin-baboons-do.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-code-block>`: automatically load tooltip when action buttons are added

--- a/elements/rh-code-block/demo/actions.html
+++ b/elements/rh-code-block/demo/actions.html
@@ -23,7 +23,6 @@
 <script type="module">
   import '@rhds/elements/rh-button/rh-button.js';
   import '@rhds/elements/rh-code-block/rh-code-block.js';
-  import '@rhds/elements/rh-tooltip/rh-tooltip.js';
 </script>
 
 <style>

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -221,6 +221,9 @@ export class RhCodeBlock extends LitElement {
     if (changed.has('wrap')) {
       this.#wrapChanged();
     }
+    if (this.actions.length && !isServer) {
+      import('@rhds/elements/rh-tooltip/rh-tooltip.js');
+    }
   }
 
   async #onSlotChange() {


### PR DESCRIPTION
Closes #2121

## What I did

1. lazy load tooltip client side when actions are used


## Testing Instructions

1. load the actions demo, tooltips should work

## Notes to Reviewers
