### PR TITLE
fix(code-block): prerendered callouts

### DIFF
--- a/.changeset/odd-paws-wonder.md
+++ b/.changeset/odd-paws-wonder.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-code-block>`: fixed copy actions for prerendered codeblocks with badge callouts

--- a/elements/rh-code-block/demo/callout-prerendered.html
+++ b/elements/rh-code-block/demo/callout-prerendered.html
@@ -1,0 +1,15 @@
+<rh-code-block highlighting="prerendered" actions="copy wrap">
+  <pre class="language-html"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">&gt;</span></span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nullam eleifend elit sed est egestas, a sollicitudin mauris
+tincidunt. Pellentesque vel dapibus risus. Nullam aliquam</code></pre><rh-badge state="info">1</rh-badge><pre class="language-html"><code class="language-html">
+felis orci, eget cursus mi lacinia quis. Vivamus at felis sem.<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">&gt;</span></span>
+
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>rh-cta</span> <span class="token attr-name">slot</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>footer<span class="token punctuation">"</span></span> <span class="token attr-name">priority</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>primary<span class="token punctuation">"</span></span><span class="token punctuation">&gt;</span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>a</span> <span class="token attr-name">href</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>#<span class="token punctuation">"</span></span><span class="token punctuation">&gt;</span></span>Call to action<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>a</span><span class="token punctuation">&gt;</span></span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rh-cta</span><span class="token punctuation">&gt;</span></span></code></pre>
+</rh-code-block>
+
+<script type="module">
+  import '@rhds/elements/rh-code-block/rh-code-block.js';
+  import '@rhds/elements/rh-badge/rh-badge.js';
+</script>

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -237,7 +237,7 @@ export class RhCodeBlock extends LitElement {
     if (!isServer && getComputedStyle(this).getPropertyValue('--_styles-applied') !== 'true') {
       const root = this.getRootNode();
       if (root instanceof Document || root instanceof ShadowRoot) {
-        const { preRenderedLightDomStyles: { styleSheet } } = await import('./prism.js');
+        const { preRenderedLightDomStyles: { styleSheet } } = await import('./prism.css.js');
         root.adoptedStyleSheets = [...root.adoptedStyleSheets, styleSheet!];
       }
     }
@@ -378,7 +378,11 @@ export class RhCodeBlock extends LitElement {
   async #copy() {
     let content: string;
     if (this.highlighting === 'prerendered') {
-      content = this.querySelector('pre')?.textContent ?? '';
+      content =
+        Array.from(
+          this.querySelectorAll('pre'),
+          x => x?.textContent ?? '',
+        ).join('');
     } else {
       content = Array.from(
         this.querySelectorAll('script'),


### PR DESCRIPTION
## What I did

1. add a demo for code-block illustrating how to add rh-badge callouts for prerendered code
2. fix the private copy method to work with such code blocks

## Testing Instructions

1. use the copy button on [the new demo](https://deploy-preview-2391--red-hat-design-system.netlify.app/elements/code-block/demo/callout-prerendered/), ensure copied result is correct

## Notes to Reviewers
