### PR TITLE
fix(navigation-primary): correct active states

### DIFF
--- a/.changeset/modern-humans-nail.md
+++ b/.changeset/modern-humans-nail.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-primary>`: corrected `:active` state for hamburger and secondary slotted items
+  

--- a/elements/rh-navigation-primary/rh-navigation-primary-item.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary-item.css
@@ -255,7 +255,7 @@
             }
           }
 
-          &:is(:focus-visible, :hover:focus-visible, :active) {
+          &:is(:focus-visible, :hover:focus-visible) {
             outline:
               var(--rh-border-width-md, 2px)
               solid

--- a/elements/rh-navigation-primary/rh-navigation-primary.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary.css
@@ -147,7 +147,7 @@
         }
       }
 
-      &:is(:focus-visible, :hover:focus-visible, :active) {
+      &:is(:focus-visible, :hover:focus-visible) {
         outline:
           var(--rh-border-width-md, 2px)
           solid


### PR DESCRIPTION
## What I did

1. Corrected `:active` state for hamburger menu and secondary slotted nav items


## Testing Instructions

1. [View Deploy preview](https://deploy-preview-2394--red-hat-design-system.netlify.app/elements/navigation-primary/demo/) on `:active` you should no longer get a outline ring like you do on `:focus`

## Notes to Reviewers
