### PR TITLE
fix(badge): ssr hydration mismatch

### DIFF
--- a/.changeset/wet-papayas-bow.md
+++ b/.changeset/wet-papayas-bow.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-badge>`: fixed rendering in SSR scenarios

--- a/elements/rh-badge/rh-badge.css
+++ b/elements/rh-badge/rh-badge.css
@@ -35,6 +35,10 @@ slot {
   &.danger { background-color: var(--rh-color-status-danger); }
 }
 
+span:empty {
+  display: none;
+}
+
 slot { display: inline-flex; }
 
 :host([number]) {

--- a/elements/rh-badge/rh-badge.css
+++ b/elements/rh-badge/rh-badge.css
@@ -1,5 +1,5 @@
-span {
-  display: inline-flex;
+span,
+slot {
   align-items: center;
   justify-content: center;
   position: relative;
@@ -33,4 +33,11 @@ span {
   }
 
   &.danger { background-color: var(--rh-color-status-danger); }
+}
+
+slot { display: inline-flex; }
+
+:host([number]) {
+  slot { display: none; }
+  span { display: inline-flex; }
 }

--- a/elements/rh-badge/rh-badge.ts
+++ b/elements/rh-badge/rh-badge.ts
@@ -1,6 +1,7 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, isServer } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
+import { state } from 'lit/decorators/state.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { observes } from '@patternfly/pfe-core/decorators/observes.js';
 
@@ -79,16 +80,12 @@ export class RhBadge extends LitElement {
   }
 
   override render() {
-    const { threshold, number, textContent, state = 'neutral' } = this;
-    const displayText =
-        (threshold && number && (threshold < number)) ? `${threshold.toString()}+`
-      : (number != null) ? number.toString()
-      : textContent ?? '';
-
+    const { state, threshold, number } = this;
+    const isLarge = !!threshold && number != null && (threshold < number);
+    const computedContent = isLarge ? `${threshold}+` : number?.toString() ?? null;
     return html`
-      <span class="${classMap({
-        [state]: true,
-      })}">${displayText}</span>
+      <span class="${classMap({ [state]: true })}">${computedContent}</span>
+      <slot class="${classMap({ [state]: true })}"></slot>
     `;
   }
 }


### PR DESCRIPTION
Closes #2397 

## What I did

1. add a slot to rh-badge
2. hide the slot when there's a number attribute
3. hide the span otherwise


## Testing Instructions

1. see codeblock demos - badges should appear

## Notes to Reviewers

This adds a downstream footgun. previously, if a developer did this:

```html
<rh-badge><span class="big-and-ugly">AHHA</span></rh-badge>
```
Then the badge would render the text "AHHA" without styles. Now, it will render it big & ugly