### PR TITLE
docs: improve `<code>` element rendering on dark color schemes

### DIFF
--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -247,7 +247,9 @@
 
   :where(code:not([class^='language-'])) {
     padding-inline: var(--rh-space-xs);
-    background: oklch(from var(--rh-color-surface) calc(l - 0.05) c h);
+    background:
+      light-dark(oklch(from var(--rh-color-surface) calc(l - 0.05) c h),
+        oklch(from var(--rh-color-surface) calc(l + 0.1) c h));
     border-radius: var(--rh-border-radius-default);
     font-size: var(--rh-font-size-code-md);
     font-weight: var(--rh-font-weight-code-regular);


### PR DESCRIPTION
## What I did

1. Added a recognizable background color to `<code>` elements that exist on dark color schemes.

![Screenshot comparing what code elements look like on a dark color scheme with and without the new background color](https://github.com/user-attachments/assets/5ff33bcf-8b90-4a90-b9b4-2b308e336400)

## Testing Instructions

1. Visit the DP.
2. Turn on the dark color scheme.
3. Go to any page with `<code>` tags.
    * [Theming > Developers](https://deploy-preview-2402--red-hat-design-system.netlify.app/theming/developers/)
    * Any Elements > Code page, eg [Dialog](https://deploy-preview-2402--red-hat-design-system.netlify.app/elements/dialog/code/#rh-dialog-apis)
    * Any [Tokens](https://deploy-preview-2402--red-hat-design-system.netlify.app/tokens/color/) page.

## Notes to Reviewers

Closes #2393. 