### PR TITLE
docs: add new dashed underline style to inline links

### DIFF
--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -39,10 +39,21 @@
 
   a {
     color: var(--rh-color-interactive-primary-default);
-    &:hover { color: var(--rh-color-interactive-primary-hover); }
+    text-decoration: underline dashed 1px;
+    text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+    text-underline-offset: max(5px, 0.28em);
+    transition: ease all 0.3s;
+
+    &:hover {
+      color: var(--rh-color-interactive-primary-hover);
+      text-decoration-color: inherit;
+      text-underline-offset: max(6px, 0.33em);
+    }
 
     &:focus-within {
       color: var(--rh-color-interactive-primary-focus);
+      text-decoration-color: inherit;
+      text-underline-offset: max(6px, 0.33em);
       &:hover { color: var(--rh-color-interactive-primary-focus); }
     }
 

--- a/uxdot/uxdot-feedback.css
+++ b/uxdot/uxdot-feedback.css
@@ -25,6 +25,22 @@ p {
   font-size: var(--rh-font-size-body-text-lg);
 }
 
+a {
+  text-decoration: underline dashed var(--rh-color-gray-50, #707070) 1px;
+  text-underline-offset: max(5px, 0.28em);
+  transition: ease all 0.3s;
+
+  &:hover {
+    text-decoration-color: inherit;
+    text-underline-offset: max(6px, 0.33em);
+  }
+
+  &:focus-within {
+    text-decoration-color: inherit;
+    text-underline-offset: max(6px, 0.33em);
+  }
+}
+
 @container host (min-width: 576px) {
   #container {
     grid-template-columns: 1fr 1fr;

--- a/uxdot/uxdot-feedback.css
+++ b/uxdot/uxdot-feedback.css
@@ -26,7 +26,8 @@ p {
 }
 
 a {
-  text-decoration: underline dashed var(--rh-color-gray-50, #707070) 1px;
+  text-decoration: underline dashed 1px;
+  text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
   text-underline-offset: max(5px, 0.28em);
   transition: ease all 0.3s;
 

--- a/uxdot/uxdot-feedback.ts
+++ b/uxdot/uxdot-feedback.ts
@@ -21,7 +21,7 @@ export class UxdotFeedback extends LitElement {
         <h2>Feedback</h2>
           <p>
             To give feedback about anything on this page,
-            <a href="https://github.com/RedHat-UX/red-hat-design-system/discussions" class="feedback-contact-link">contact us</a>.
+            <a href="https://github.com/RedHat-UX/red-hat-design-system/discussions">contact us</a>.
           </p>
         </div>
       </div>

--- a/uxdot/uxdot-masthead.css
+++ b/uxdot/uxdot-masthead.css
@@ -87,9 +87,20 @@
     gap: var(--rh-space-lg);
     align-items: center;
     color: var(--rh-color-text-primary-on-dark, #ffffff) !important;
+    text-decoration: underline dashed 1px;
+    text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+    text-underline-offset: max(5px, 0.28em);
+    transition: ease all 0.3s;
 
     &:is(:hover, :focus) {
       color: var(--rh-color-icon-subtle-hover, #a3a3a3) !important;
+      text-decoration-color: inherit;
+      text-underline-offset: max(6px, 0.33em);
+    }
+
+    &:focus-within {
+      text-decoration-color: inherit;
+      text-underline-offset: max(6px, 0.33em);
     }
   }
 


### PR DESCRIPTION
## What I did

1. Added the dashed underline for inline links in docs


## Testing Instructions

1.  Make sure that the underline styles for inline links on ux dot match the inline link styles on our Interactions > [Links page](https://ux.redhat.com/foundations/interactions/links/#interaction-states)

## Notes to Reviewers

