### PR TITLE
fix(code-block): fix failing build

### DIFF
--- a/.changeset/shy-coins-fall.md
+++ b/.changeset/shy-coins-fall.md
@@ -1,6 +1,0 @@
----
-"@rhds/elements": patch
----
-
-`<rh-code-block>`: fix syntax error breaking build
-  


### PR DESCRIPTION
## What I did

1. Fixed failing build (`npm run dev` erroring out due to syntax error in code block).

## Testing Instructions

1. Pull down this PR.
2. `git clean -fdx && fnm use && npm ci && npm run dev`
3. Make sure `npm run dev` and `npm run serve` works
4. Make sure the prose in the changeset works.

## Notes to Reviewers

This looks to be something that happened in [a merge](https://github.com/RedHat-UX/red-hat-design-system/commit/e67496027a3e268422a2991bc05ef1d70bf73efe#diff-daf3317eaebfc8841826cc635321b0c2d2f7502b86c418ea468106b258c96464L337).