### PR TITLE
Fix/navigation primary/remove imperatively set state

### DIFF
--- a/.changeset/crazy-webs-wear.md
+++ b/.changeset/crazy-webs-wear.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-primary>`: improved component reactivity
+  

--- a/elements/rh-navigation-primary/rh-navigation-primary.ts
+++ b/elements/rh-navigation-primary/rh-navigation-primary.ts
@@ -85,6 +85,9 @@ export class RhNavigationPrimary extends LitElement {
   @state()
   private _overlayOpen = false;
 
+  @state()
+  private _hamburgerOpen = false;
+
   @query('#hamburger')
   private _hamburger!: HTMLDetailsElement;
 
@@ -177,7 +180,7 @@ export class RhNavigationPrimary extends LitElement {
               </a>
             </slot>
           </div>
-          <details id="hamburger" @toggle="${this.#hamburgerToggle}">
+          <details id="hamburger" ?open="${this._hamburgerOpen}" @toggle="${this.#hamburgerToggle}">
             <summary>
               <rh-icon icon="menu-bars" set="ui"></rh-icon>
               <div id="summary">${this.mobileToggleLabel}</div>
@@ -266,7 +269,7 @@ export class RhNavigationPrimary extends LitElement {
     } else {
       if (secondaryEventToggle) {
         this.#openSecondaryDropdowns.delete(item);
-        if (this.#openSecondaryDropdowns.size === 0 && (this.compact && !this._hamburger.open)) {
+        if (this.#openSecondaryDropdowns.size === 0 && (this.compact && !this._hamburgerOpen)) {
           this.#closeOverlay();
         }
       } else {
@@ -292,7 +295,7 @@ export class RhNavigationPrimary extends LitElement {
           const [dropdown] = this.#openSecondaryDropdowns;
           dropdown.hide();
           dropdown.shadowRoot?.querySelector('summary')?.focus();
-        } else if (this._hamburger.open) {
+        } else if (this._hamburgerOpen) {
           this.#closeHamburger();
           this._hamburger.querySelector('summary')?.focus();
         }
@@ -377,7 +380,7 @@ export class RhNavigationPrimary extends LitElement {
   }
 
   #onTabKeyup(event: KeyboardEvent) {
-    if (this.compact && this._hamburger.open) {
+    if (this.compact && this._hamburgerOpen) {
       const secondaryDropdowns = this.#secondaryDropdowns();
       const target = event.target as HTMLElement;
       if (event.shiftKey && target === this) {
@@ -413,7 +416,8 @@ export class RhNavigationPrimary extends LitElement {
     if (!this._hamburger) {
       await this.updateComplete;
     }
-    this._hamburger.open = true;
+    this._hamburgerOpen = true;
+    this.requestUpdate();
     await this.updateComplete;
   }
 
@@ -421,7 +425,8 @@ export class RhNavigationPrimary extends LitElement {
     if (!this._hamburger) {
       await this.updateComplete;
     }
-    this._hamburger.open = false;
+    this._hamburgerOpen = false;
+    this.requestUpdate();
     await this.updateComplete;
   }
 

--- a/elements/rh-navigation-primary/test/rh-navigation-primary.spec.ts
+++ b/elements/rh-navigation-primary/test/rh-navigation-primary.spec.ts
@@ -1,10 +1,16 @@
 import { expect, fixture, nextFrame } from '@open-wc/testing';
-import { setViewport } from '@web/test-runner-commands';
+import { setViewport, sendKeys } from '@web/test-runner-commands';
 import { a11ySnapshot } from '@patternfly/pfe-tools/test/a11y-snapshot.js';
 import { html } from 'lit';
 
 import { RhNavigationPrimary } from '@rhds/elements/rh-navigation-primary/rh-navigation-primary.js';
 import { RhNavigationPrimaryItem } from '../rh-navigation-primary-item.js';
+
+function press(key: string) {
+  return async function() {
+    await sendKeys({ press: key });
+  };
+}
 
 const [
   HamburgerItem1Name,
@@ -168,13 +174,9 @@ describe('<rh-navigation-primary>', function() {
 
       describe('interactions', function() {
         describe('toggling hamburger menu', function() {
-          let summary: HTMLElement | null | undefined;
-
-          beforeEach(async function() {
-            const details = element.shadowRoot?.querySelector('#hamburger');
-            summary = details?.querySelector('summary');
-            summary?.click();
-          });
+          beforeEach(press('Tab'));
+          beforeEach(press('Tab'));
+          beforeEach(press('Enter'));
           beforeEach(async () => await element.updateComplete);
 
           describe('toggle open', function() {
@@ -201,10 +203,7 @@ describe('<rh-navigation-primary>', function() {
           });
 
           describe('toggle closed', function() {
-            beforeEach(function() {
-              summary?.click();
-            });
-
+            beforeEach(press('Enter'));
             beforeEach(async () => await element.updateComplete);
 
             it('menu should be closed', async function() {


### PR DESCRIPTION
## What I did

1. Removed imperative setting of the `#hamburger` details open state. Instead, using declarative set state through private property and lit reactivity.
2. Improved tests to use keyboard navigation instead of click emulation

Closes #2408 


## Testing Instructions

1. View deploy preview.

## Notes to Reviewers

- Test responsiveness of the hamburger menu between desktop and compact-sized viewports
