### PR TITLE
docs(accordion): removing extraneous > from accessibility page

### DIFF
--- a/elements/rh-accordion/docs/40-accessibility.md
+++ b/elements/rh-accordion/docs/40-accessibility.md
@@ -36,7 +36,7 @@ Each panel is selectable instead of only title text or the chevrons.
   <img alt="Accordion showing touch target size examples for large and small sizes"
        src="../accordion-touch-targets.png"
        width="872"
-       height="536">>
+       height="536">
 </uxdot-example>
 
 {% include 'partials/accessibility/ariaguide.md' %}


### PR DESCRIPTION
## What I did

1. Removed extraneous `>` from below the Touch Targets graphic on the accessibility page

## Testing Instructions

1. Go to the live version of the Touch Targets section on Accordion's Accessibility page
2. See extraneous `>` below graphic
3. Compare to the DP's version
