### PR TITLE
patch(footer): removed Inc from copyright

### DIFF
--- a/.changeset/nine-facts-tease.md
+++ b/.changeset/nine-facts-tease.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-footer>`: removed Inc from copyright
+  

--- a/elements/rh-footer/demo/footer-universal.html
+++ b/elements/rh-footer/demo/footer-universal.html
@@ -11,7 +11,7 @@
     <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
     <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
   </ul>
-  <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+  <rh-footer-copyright slot="links-secondary">© 2025 Red Hat</rh-footer-copyright>
   <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
   <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
     <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>

--- a/elements/rh-footer/demo/rh-footer.html
+++ b/elements/rh-footer/demo/rh-footer.html
@@ -87,7 +87,7 @@
       <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
       <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+    <rh-footer-copyright slot="links-secondary">© 2025 Red Hat</rh-footer-copyright>
     <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
     <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
       <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>

--- a/elements/rh-footer/demo/slotted-social-links.html
+++ b/elements/rh-footer/demo/slotted-social-links.html
@@ -63,7 +63,7 @@
       <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
       <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+    <rh-footer-copyright slot="links-secondary">© 2025 Red Hat</rh-footer-copyright>
     <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
     <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
       <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>

--- a/elements/rh-footer/rh-footer-copyright.ts
+++ b/elements/rh-footer/rh-footer-copyright.ts
@@ -10,7 +10,7 @@ export class RhFooterCopyright extends LitElement {
   static readonly styles = style;
 
   render() {
-    return html`<slot>&copy; ${currentYear} Red Hat, Inc.</slot>`;
+    return html`<slot>&copy; ${currentYear} Red Hat</slot>`;
   }
 }
 


### PR DESCRIPTION
## What I did

1. Removed `, Inc.` from the `<rh-footer>` default/fallback copyright statement
2. Removed `, Inc.` from the demos


## Testing Instructions

1. Check demos on DP
3. Copyright should only say `© 2025 Red Hat`

## Notes to Reviewers
