### PR TITLE
docs(release-notes): add v3.0.4 notes

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -60,7 +60,7 @@ or anything else, please submit a [GitHub issue][issues].
 
 | Change        | Type        | Notes        |
 | ------------- | ----------- | ------------ |
-| `<rh-audio-player>`: responsive design | {{p()}} | fix layout issue between 576px and 768px breakpoints |
+| `<rh-audio-player>`: responsive design | {{p()}} | Fix layout issue between 576px and 768px breakpoints |
 | `<rh-navigation-primary>`: reactivity | {{p()}} | Improved component reactivity |
 | Server side rendering: improve support | {{p()}} | Improved SSR for elements whose layout depends on their content |
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -54,6 +54,20 @@ or anything else, please submit a [GitHub issue][issues].
 
 <section aria-labelledby="version-3.0.0">
 
+### Patches from version 3.0.4
+
+<rh-table>
+
+| Change        | Type        | Notes        |
+| ------------- | ----------- | ------------ |
+| `<rh-audio-player>`: responsive design | {{p()}} | fix layout issue between 576px and 768px breakpoints |
+| `<rh-navigation-primary>`: reactivity | {{p()}} | Improved component reactivity |
+| Server side rendering: improve support | {{p()}} | Improved SSR for elements whose layout depends on their content |
+
+</rh-table>
+
+<rh-cta href="https://github.com/RedHat-UX/red-hat-design-system/releases/tag/v3.0.4">View all version 3.0.4 release notes</rh-cta>
+
 ### Patches from version 3.0.2
 
 <rh-table>


### PR DESCRIPTION
## What I did

1. Added v3.0.4 to the Release Notes page.

## Testing Instructions

1. View [the DP](https://deploy-preview-2458--red-hat-design-system.netlify.app/release-notes/).
2. Check that it matches what's listed on [Github](https://github.com/RedHat-UX/red-hat-design-system/releases/tag/v3.0.4).

## Notes to reviewers

Please review and approve https://github.com/RedHat-UX/red-hat-design-system/pull/2434 before approving this PR.