### PR TITLE
docs(code): fix duplicate rendering of `30-code.md` content

### DIFF
--- a/docs/_includes/layouts/pages/element.11ty.ts
+++ b/docs/_includes/layouts/pages/element.11ty.ts
@@ -278,7 +278,6 @@ export default class ElementsPage extends Renderer<Context> {
       await this.#renderLightdom(ctx),
       this.#header('Usage'),
       await this.#getMainDemoContent(tagName),
-      doc.fileExists && await this.renderFile(doc.filePath, ctx),
       await this.#renderCodeDocs.call(this,
                                       doc.docsPage.tagName,
                                       { ...ctx, level: (ctx.level ?? 1) + 1 }),


### PR DESCRIPTION
## What I did

1. If you look at any Code page on uxdot that has custom content coming from a `30-code.md` file (eg: [Spinner](https://ux.redhat.com/elements/spinner/code/)), you'll notice that content is duplicated on the page.
2. This PR fixes that.


## Testing Instructions

1. View the existing duplicated content on uxdot element Code pages like rh-icon, rh-alert, rh-table, rh-spinner, rh-code-block, rh-pagination, rh-navigation-secondary and maybe others.
2. View the Code page for those elements in [this DP](https://deploy-preview-2485--red-hat-design-system.netlify.app/elements/spinner/code/) and verify the content is not duplicated.
3. Verify that instructions for lightdom and lightdom shim CSS still work on these elements and for other elements that don't have custom content in `30-code.md`.