### PR TITLE
docs(release-notes): add a few missing patches

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -78,6 +78,7 @@ Released August 6, 2025
 | `<rh-footer>`: corrected height style | {{p()}} | Corrected height style when JavaScript is not available |
 | `<rh-footer>`: removed console warnings | {{p()}} | Removed console warnings in `<rh-footer>`. |
 | `<rh-footer>`: removed "Inc" from copyright | {{p()}} | Removed "Inc" from copyright in `<rh-footer>`. |
+| `<rh-navigation-primary>`: keyboard accessibility | {{p()}} | Improved keyboard accessibility of the dropdown toggle. |
 | `<rh-tabs>`: corrected background styles | {{p()}} | Corrected background styles inherited from parent color-scheme and host color-palette. |
 | `<rh-tabs>`: corrected vertical layout styles | {{p()}} |  |
 | `<rh-tabs>`: corrected duplicate focus ring | {{p()}} | Fixed duplicate focus ring with keyboard navigation. |


### PR DESCRIPTION
## What I did

1. Added a few missing patches to the release notes highlights


## Testing Instructions

1. Check wording and accuracy on the 3.1 release notes
2. Compare to [GitHub's release notes](https://github.com/RedHat-UX/red-hat-design-system/releases/tag/v3.1.0)

## Added these
<img width="970" height="264" alt="image" src="https://github.com/user-attachments/assets/6d345e34-111c-4ce6-8f7d-ca4253d93ab1" />

[See diff](https://github.com/RedHat-UX/red-hat-design-system/pull/2553/files)