### PR TITLE
fix(uxdot-sidenav): add `<h2>` to uxdot's main side navigation

### DIFF
--- a/uxdot/uxdot-sidenav.css
+++ b/uxdot/uxdot-sidenav.css
@@ -50,6 +50,18 @@
   padding-block: var(--rh-space-lg, 16px);
 }
 
+.visually-hidden {
+  block-size: 1px;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  inline-size: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+}
+
 [part='overlay'] {
   display: none;
   background-color: rgb(from var(---rh-color-gray-90) / var(--rh-opacity-60));

--- a/uxdot/uxdot-sidenav.ts
+++ b/uxdot/uxdot-sidenav.ts
@@ -62,7 +62,8 @@ export class UxdotSideNav extends LitElement {
             <rh-icon set="ui" icon="close" size="lg"></rh-icon>
           </button>
         </div>
-        <nav part="nav" aria-label="Main menu">
+        <nav part="nav" aria-labelledby="aria__uxdot-nav-header">
+          <h2 id="aria__uxdot-nav-header" class="visually-hidden">Main navigation</h2>
           <slot></slot>
         </nav>
       </div>


### PR DESCRIPTION
## What I did

1. Adds a `<h2>` with `aria-labelledby` to the main navigation on ux.redhat.com.
2. Closes #2579. 

## Testing Instructions

1. Open up the homepage of uxdot on [this PR's DP](https://deploy-preview-2581--red-hat-design-system.netlify.app/).
2. Right click and inspect "Home" in the `<uxdot-sidenav>`.
3. View the new `<h2>` that provides a label for the `<nav>` element in that component's shadowroot.
4. Ensure the ID and the `aria-labelledby` attribute match.
5. Ensure the `<h2>` is visually hidden.
6. Test with various a11y technology (Lumar, axe, screen readers, et all) to make sure these changes don't flag any new warnings or errors).