### PR TITLE
Fix/card/flex container parent support

### DIFF
--- a/.changeset/dark-poets-type.md
+++ b/.changeset/dark-poets-type.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-card>`: corrected layout when contained in a flex parent
+  

--- a/elements/rh-card/rh-card.css
+++ b/elements/rh-card/rh-card.css
@@ -2,6 +2,7 @@
   display: block;
   container-name: card;
   container-type: inline-size;
+  width: 100%;
   height: max-content;
 }
 


### PR DESCRIPTION
## What I did

1.  Corrected layout when a card is in a flex parent by applying `width: 100%` to the `:host`.

Closes #2044

## Testing Instructions

1.

## Notes to Reviewers

We need to verify this won't break the current implementations.  There is a possibility it might therefore making this a possible breaking change.