### PR TITLE
fix(tabs): update the background color of inactive box variant tabs

### DIFF
--- a/.changeset/famous-gifts-sip.md
+++ b/.changeset/famous-gifts-sip.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tabs>`: updated the background color of inactive box variant tabs

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -84,7 +84,7 @@
   &.box {
     background-color:
       light-dark(var(--rh-color-surface-lighter, #f2f2f2),
-        oklch(from var(--rh-color-surface-dark, #383838) calc(l * 0.82) c h));
+        var(--rh-color-surface-darker, #1f1f1f));
   }
 
   /* When button is vertical format */

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -96,10 +96,13 @@ button {
   --_arrow-color: var(--rh-color-accent-base);
   --_overflow-button-text-color: var(--rh-color-text-secondary);
 
-  /* Non Standard usage of crayon token */
-  --_overflow-button-disabled-text-color:
-    light-dark(var(--rh-color-gray-40, #a3a3a3),
-      var(--rh-color-gray-50, #707070));
+  /* Non Standard usage of rh-color-icon-status-disabled.
+  * Remove this re-declaration when the variable is defined in tokens */
+  --rh-color-icon-status-disabled:
+    light-dark(var(--rh-color-gray-50, #707070),
+      var(--rh-color-gray-60, #4d4d4d));
+  /* stylelint-disable-next-line rhds/no-unknown-token-name */
+  --_overflow-button-disabled-text-color: var(--rh-color-icon-status-disabled);
   --_overflow-button-hover-text-color: var(--rh-color-text-primary);
 
   color: var(--rh-color-text-primary);

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -99,7 +99,7 @@ button {
   /* Non Standard usage of rh-color-icon-status-disabled.
   * Remove this re-declaration when the variable is defined in tokens */
   --rh-color-icon-status-disabled:
-    light-dark(var(--rh-color-gray-50, #707070),
+    light-dark(var(--rh-color-gray-40, #a3a3a3),
       var(--rh-color-gray-60, #4d4d4d));
   /* stylelint-disable-next-line rhds/no-unknown-token-name */
   --_overflow-button-disabled-text-color: var(--rh-color-icon-status-disabled);


### PR DESCRIPTION
## What I did

1. Changes the dark scheme background color of the box variant of inactive `<rh-tab>` elements.
2.  Closes #2517. 

## Testing Instructions

1. Open the [Box Inset demo](https://deploy-preview-2593--red-hat-design-system.netlify.app/elements/tabs/demo/box-inset/) on the DP.
2. Right click > Inspect Element on an inactive tab.
3. Add `color-palette="darkest"` to the parent `<rh-tabs>` element.
4. Verify the appropriate background color exists for inactive box variant tabs.
5. Verify this change doesn't adversely affect other tab variants.

## Notes to Reviewers

- [x] Need the new token for disabled icons for the overflow situation as described in 2517.