### PR TITLE
fix(pagination): change inactive stepper icon color

### DIFF
--- a/.changeset/orange-bats-serve.md
+++ b/.changeset/orange-bats-serve.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-pagination>`: add a customizable token for disabled stepper icon color

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -49,9 +49,16 @@
   --rh-pagination-stepper-color:
     light-dark(var(--rh-color-gray-50, #707070),
       var(--rh-color-text-secondary-on-dark, #c7c7c7));
-  --rh-pagination-background-focused:
-    light-dark(var(--rh-color-gray-30, #c7c7c7),
-      var(--rh-color-gray-50, #707070));
+
+  /**
+   * Remove this re-declaration when the status-disabled variable is defined in tokens
+   * and deprecate `--rh-pagination-background-focused`.
+  */
+  --rh-color-icon-status-disabled:
+    light-dark(var(--rh-color-gray-50, #707070),
+      var(--rh-color-gray-60, #4d4d4d));
+  /* stylelint-disable-next-line rhds/no-unknown-token-name */
+  --rh-pagination-background-focused: var(--rh-color-icon-status-disabled);
 }
 
 @container pagination (min-width: 768px) {
@@ -175,7 +182,7 @@ svg {
   pointer-events: none;
 
   /** Sets the disabled stepper color. */
-  color: var(--rh-pagination-background-focused, var(--rh-color-gray-30, #c7c7c7));
+  color: var(--rh-pagination-background-focused);
   background-color:
     light-dark(var(--rh-color-surface-lighter, #f2f2f2),
       var(--rh-color-surface-darker, #1f1f1f));

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -55,7 +55,7 @@
    * and deprecate `--rh-pagination-background-focused`.
   */
   --rh-color-icon-status-disabled:
-    light-dark(var(--rh-color-gray-50, #707070),
+    light-dark(var(--rh-color-gray-40, #a3a3a3),
       var(--rh-color-gray-60, #4d4d4d));
   /* stylelint-disable-next-line rhds/no-unknown-token-name */
   --rh-pagination-background-focused: var(--rh-color-icon-status-disabled);

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -183,9 +183,7 @@ svg {
 
   /** Sets the disabled stepper color. */
   color: var(--rh-pagination-background-focused);
-  background-color:
-    light-dark(var(--rh-color-surface-lighter, #f2f2f2),
-      var(--rh-color-surface-darker, #1f1f1f));
+  background-color: var(--_stepper-bg-color);
 }
 
 @container pagination (min-width: 768px) {


### PR DESCRIPTION
## What I did

1. This PR defines `--rh-color-icon-status-disabled` in `rh-pagination.css` and uses it for the disabled stepper (left and right arrow) icons.
2. Closes #2516. 

## Testing Instructions

1. View the [Color Context demo](https://deploy-preview-2596--red-hat-design-system.netlify.app/elements/pagination/demo/color-context/) in the DP.
2. Verify the disabled stepper icon color looks correct in both light and dark color schemes. 

## Notes to Reviewers

According to @coreyvickery's [comment](https://github.com/RedHat-UX/red-hat-design-system/pull/2593#issuecomment-3238070197), this changes the light disabled stepper icon color to `gray-50`.

This seems like a much more _contrasty_ disabled state for light color schemes. Ensure this change is intended.