### PR TITLE
feat(tabs): add icon and icon-set attributes with optional custom slot (fixes #2337)

### DIFF
--- a/elements/rh-tabs/demo/rh-tab-icon.html
+++ b/elements/rh-tabs/demo/rh-tab-icon.html
@@ -1,0 +1,35 @@
+<rh-tabs>
+  <rh-tab slot="tab" icon="users" icon-set="ui" active>
+    Users
+  </rh-tab>
+  <rh-tab-panel>Users</rh-tab-panel>
+
+  <rh-tab slot="tab" icon="container">
+    Containers
+  </rh-tab>
+  <rh-tab-panel>Containers</rh-tab-panel>
+
+  <rh-tab slot="tab" icon="bell">
+    <svg slot="icon" width="16" height="16" viewBox="0 0 24 24">
+      <path d="M3 12h18M12 3v18" stroke="currentColor" />
+    </svg>
+    Slot wins
+  </rh-tab>
+  <rh-tab-panel>Slot wins</rh-tab-panel>
+
+  <rh-tab slot="tab">
+    No Icon
+  </rh-tab>
+  <rh-tab-panel>No icon content</rh-tab-panel>
+</rh-tabs>
+
+<script type="module">
+  import '@rhds/elements/rh-tabs/rh-tabs.js';
+  import '@rhds/elements/rh-icon/rh-icon.js';
+</script>
+
+<style>
+  rh-icon {
+    --rh-icon-size: var(--rh-size-icon-03);
+  }
+</style>


### PR DESCRIPTION
Adds support for `icon` / `icon-set` attributes and optional `slot="icon"` in `rh-tab`.  
Slot content overrides attributes if both are provided.  
Demo page updated to show all scenarios.  
Fixes #2337.

@bennypowers 