### PR TITLE
chore(cem): update to v0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@patternfly/icons": "^1.0.3",
         "@patternfly/pfe-tools": "^5.0.4",
         "@playwright/test": "^1.54.1",
-        "@pwrs/cem": "^0.3.0",
+        "@pwrs/cem": "^0.4.6",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@stylistic/eslint-plugin-js": "^2.13.0",
         "@stylistic/stylelint-config": "^2.0.0",
@@ -3493,9 +3493,9 @@
       }
     },
     "node_modules/@pwrs/cem": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem/-/cem-0.3.0.tgz",
-      "integrity": "sha512-g3A2TlI86vxuJuh/FGjOJGoMCk23/kt4Qgd3lrf+3ccTdUdu2OOw7efzPEcGI3CZdAlB6v8JQi+S5prAgAyv3g==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem/-/cem-0.4.6.tgz",
+      "integrity": "sha512-F/TPG4y1qOcuzudJh2Yws/2P7lPxOr+DEI2U3TONB/Rh/Ai7/nxKv8YBItGDhe9mMc8GHIwYfysd3roOYXRF+g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -3505,18 +3505,18 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@pwrs/cem-darwin-arm64": "0.3.0",
-        "@pwrs/cem-darwin-x64": "0.3.0",
-        "@pwrs/cem-linux-arm64": "0.3.0",
-        "@pwrs/cem-linux-x64": "0.3.0",
-        "@pwrs/cem-win32-arm64": "0.3.0",
-        "@pwrs/cem-win32-x64": "0.3.0"
+        "@pwrs/cem-darwin-arm64": "0.4.6",
+        "@pwrs/cem-darwin-x64": "0.4.6",
+        "@pwrs/cem-linux-arm64": "0.4.6",
+        "@pwrs/cem-linux-x64": "0.4.6",
+        "@pwrs/cem-win32-arm64": "0.4.6",
+        "@pwrs/cem-win32-x64": "0.4.6"
       }
     },
     "node_modules/@pwrs/cem-darwin-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-arm64/-/cem-darwin-arm64-0.3.0.tgz",
-      "integrity": "sha512-EufvApZSQygjjtx/GCrnkXAtLLKtm7fy7RUQIrx9xLzxSfg+ivsMGJZm9WdKTGHzvrb2QraElZnN6OPYQmnM+g==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-arm64/-/cem-darwin-arm64-0.4.6.tgz",
+      "integrity": "sha512-tH0i6iSIXsTU1auihdkDDN183bwWYJ98JTBxlPtLSKUrKjWkHs9TRBCTeRp3U6t39YUTpsx2/8jdkSukaj52Yg==",
       "cpu": [
         "arm64"
       ],
@@ -3531,9 +3531,9 @@
       }
     },
     "node_modules/@pwrs/cem-darwin-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-x64/-/cem-darwin-x64-0.3.0.tgz",
-      "integrity": "sha512-fNeJC3bvhvYQ/t/JrVHFbkoeyUNj2Kq9Gl/mZ7I8NVZGsgLE8/x3csxe1kFysKTXlWsgmy/oq7KCERjABmXZHA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-x64/-/cem-darwin-x64-0.4.6.tgz",
+      "integrity": "sha512-BLWV0+NQDPOx8eY4Y4MHJtysHbCIQ/faGpcV+tJ1H4lPm9mPsdowNAi0IKKgHJOQ4UXIkAPApCf9aSg0Tee9hg==",
       "cpu": [
         "x64"
       ],
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/@pwrs/cem-linux-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-arm64/-/cem-linux-arm64-0.3.0.tgz",
-      "integrity": "sha512-ayGKg4hzjBukMoaD+BAh+JxiqclmRnPRFbdGamvaj8BG2QsW4AXelKPr/rWspn+c1kvBNy+rvbxV8gz9v3I18Q==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-arm64/-/cem-linux-arm64-0.4.6.tgz",
+      "integrity": "sha512-DIoUEdTd/O/FkL0wqapM3hlCphBTNstmj9PH34VaKrkdEaSI53mBsKc8y4Vmf2iQl/CJ6yP8d7eQdjDCFIIC6g==",
       "cpu": [
         "arm64"
       ],
@@ -3565,9 +3565,9 @@
       }
     },
     "node_modules/@pwrs/cem-linux-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-x64/-/cem-linux-x64-0.3.0.tgz",
-      "integrity": "sha512-TdRvLwfrmnKD77j2Ltak7a/1/HQ/rjIraLqaAQ6yGs80eaddhI77FSdN4451oafGRU0HtzVGWfELRByoR1SM/A==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-x64/-/cem-linux-x64-0.4.6.tgz",
+      "integrity": "sha512-gugDOocxqI5tcooK7ES6HyMQhLEMEqUMElNPKPpq81sJcKEUuaYqNWYMrL5Y3szkOXX4LSab+VdOFxGzRf4r0A==",
       "cpu": [
         "x64"
       ],
@@ -3582,9 +3582,9 @@
       }
     },
     "node_modules/@pwrs/cem-win32-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-arm64/-/cem-win32-arm64-0.3.0.tgz",
-      "integrity": "sha512-hCY6FiaHM4kn9v+ab39+DUcmGRy9D3Lm0DxMU3JPY+fybJWxY9KDCy4H/Gm/YBmsmXFIDQeyjCG2ZUp/NT3APA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-arm64/-/cem-win32-arm64-0.4.6.tgz",
+      "integrity": "sha512-KxSRshplHCGoMWflFTSawF7ZbiCaXYYzpCJ7ZYq0+mR/ZhzCRFh8gBQBKK2U5BzEBBkEAH7XceTUuQ4yhBxtZg==",
       "cpu": [
         "arm64"
       ],
@@ -3599,9 +3599,9 @@
       }
     },
     "node_modules/@pwrs/cem-win32-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-x64/-/cem-win32-x64-0.3.0.tgz",
-      "integrity": "sha512-95aBtvCqfgb0VsJ5dX3DQsHruCAx4CF/YWQ8gp92DxwqmUh6byfRRmu/+A3dATTVkMTz/uV+qO/EzoBfQS0zBw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-x64/-/cem-win32-x64-0.4.6.tgz",
+      "integrity": "sha512-v2mOzt8ZQ9cqiS9CMFIzYczhq4VX+dv4B7c3Dyz7VRnpNO0C0v690mykoe31ogn7clF6FbX9sJt1evUFNGfZ2Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@patternfly/icons": "^1.0.3",
     "@patternfly/pfe-tools": "^5.0.4",
     "@playwright/test": "^1.54.1",
-    "@pwrs/cem": "^0.3.0",
+    "@pwrs/cem": "^0.4.6",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@stylistic/eslint-plugin-js": "^2.13.0",
     "@stylistic/stylelint-config": "^2.0.0",


### PR DESCRIPTION
## What I did

1. Updated CEM from v0.3.0 to v0.4.6.


## Testing Instructions

1. Pull down the branch, `git clean -fdx && npm ci && npm run serve`.
2. Compare the custom element manifest (.json in root after `serve`) does not have any regressions compared to main. 
3. Check docs, make sure there are no regressions, especially on the Code and Tokens pages.

