### PR TITLE
fix(code-block): show more button bug

### DIFF
--- a/.changeset/wise-rings-yell.md
+++ b/.changeset/wise-rings-yell.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+Fix "Show More" button not appearing when line-numbers="hidden"
+  

--- a/elements/rh-code-block/demo/actions-i18n.html
+++ b/elements/rh-code-block/demo/actions-i18n.html
@@ -7,15 +7,6 @@
   display: block;
   background-color: var(--rh-color-surface-lighter, #f2f2f2);
   border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);
-  border-block-start-width: var( --rh-code-block-border-block-start-width, var(--rh-border-width-sm, 1px));
-  font-family: var(--rh-font-family-code, RedHatMono, "Red Hat Mono", "Courier New", Courier, monospace);
-  color: var(--rh-color-text-primary-on-light, #151515);
-  padding: var(--rh-space-xl, 24px);
-  height: calc(100% - 2 * var(--rh-space-xl, 24px));
-  border-radius: var(--rh-border-radius-default, 3px);
-  max-width: 1000px;
-  max-height: 640px;
-  overflow-y: auto;
 }</script>
 </rh-code-block>
 

--- a/elements/rh-code-block/demo/actions-i18n.html
+++ b/elements/rh-code-block/demo/actions-i18n.html
@@ -7,6 +7,15 @@
   display: block;
   background-color: var(--rh-color-surface-lighter, #f2f2f2);
   border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);
+  border-block-start-width: var( --rh-code-block-border-block-start-width, var(--rh-border-width-sm, 1px));
+  font-family: var(--rh-font-family-code, RedHatMono, "Red Hat Mono", "Courier New", Courier, monospace);
+  color: var(--rh-color-text-primary-on-light, #151515);
+  padding: var(--rh-space-xl, 24px);
+  height: calc(100% - 2 * var(--rh-space-xl, 24px));
+  border-radius: var(--rh-border-radius-default, 3px);
+  max-width: 1000px;
+  max-height: 640px;
+  overflow-y: auto;
 }</script>
 </rh-code-block>
 

--- a/elements/rh-code-block/demo/actions.html
+++ b/elements/rh-code-block/demo/actions.html
@@ -2,17 +2,8 @@
 <script type="text/css">#content {
   display: block;
   background-color: var(--rh-color-surface-lighter, #f2f2f2);
-  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);
-  border-block-start-width: var( --rh-code-block-border-block-start-width, var(--rh-border-width-sm, 1px));
-  font-family: var(--rh-font-family-code, RedHatMono, "Red Hat Mono", "Courier New", Courier, monospace);
-  color: var(--rh-color-text-primary-on-light, #151515);
-  padding: var(--rh-space-xl, 24px);
-  height: calc(100% - 2 * var(--rh-space-xl, 24px));
-  border-radius: var(--rh-border-radius-default, 3px);
-  max-width: 1000px;
-  max-height: 640px;
-  overflow-y: auto;
-}</script>
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);}
+</script>
 </rh-code-block>
 
 

--- a/elements/rh-code-block/demo/actions.html
+++ b/elements/rh-code-block/demo/actions.html
@@ -2,8 +2,17 @@
 <script type="text/css">#content {
   display: block;
   background-color: var(--rh-color-surface-lighter, #f2f2f2);
-  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);}
-</script>
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);
+  border-block-start-width: var( --rh-code-block-border-block-start-width, var(--rh-border-width-sm, 1px));
+  font-family: var(--rh-font-family-code, RedHatMono, "Red Hat Mono", "Courier New", Courier, monospace);
+  color: var(--rh-color-text-primary-on-light, #151515);
+  padding: var(--rh-space-xl, 24px);
+  height: calc(100% - 2 * var(--rh-space-xl, 24px));
+  border-radius: var(--rh-border-radius-default, 3px);
+  max-width: 1000px;
+  max-height: 640px;
+  overflow-y: auto;
+}</script>
 </rh-code-block>
 
 

--- a/elements/rh-code-block/demo/hide-line-numbers.html
+++ b/elements/rh-code-block/demo/hide-line-numbers.html
@@ -1,4 +1,3 @@
-
 <rh-code-block line-numbers="hidden">
 <script type="text/html"><!DOCTYPE html>
 <title>Title</title>

--- a/elements/rh-code-block/demo/hide-line-numbers.html
+++ b/elements/rh-code-block/demo/hide-line-numbers.html
@@ -1,3 +1,4 @@
+
 <rh-code-block line-numbers="hidden">
 <script type="text/html"><!DOCTYPE html>
 <title>Title</title>

--- a/elements/rh-code-block/demo/prerendered-prism-highlighting.html
+++ b/elements/rh-code-block/demo/prerendered-prism-highlighting.html
@@ -28,7 +28,7 @@
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>html</span><span class="token punctuation">&gt;</span></span></code></pre>
   </rh-code-block>
 
-  <rh-code-block highlighting="prerendered" actions="copy wrap" >
+  <rh-code-block highlighting="prerendered" actions="copy wrap">
   <span slot="action-label-copy">Copy to Clipboard</span>
   <span slot="action-label-copy" hidden data-code-block-state="active">Copied!</span>
   <span slot="action-label-wrap">Toggle word wrap</span>
@@ -52,7 +52,7 @@
 <span class="token punctuation">}</span></code></pre>
   </rh-code-block>
 
-  <rh-code-block highlighting="prerendered" actions="copy wrap" >
+  <rh-code-block highlighting="prerendered" actions="copy wrap">
   <span slot="action-label-copy">Copy to Clipboard</span>
   <span slot="action-label-copy" hidden data-code-block-state="active">Copied!</span>
   <span slot="action-label-wrap">Toggle word wrap</span>

--- a/elements/rh-code-block/demo/prerendered-prism-highlighting.html
+++ b/elements/rh-code-block/demo/prerendered-prism-highlighting.html
@@ -28,7 +28,7 @@
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>html</span><span class="token punctuation">&gt;</span></span></code></pre>
   </rh-code-block>
 
-  <rh-code-block highlighting="prerendered" actions="copy wrap">
+  <rh-code-block highlighting="prerendered" actions="copy wrap" >
   <span slot="action-label-copy">Copy to Clipboard</span>
   <span slot="action-label-copy" hidden data-code-block-state="active">Copied!</span>
   <span slot="action-label-wrap">Toggle word wrap</span>
@@ -52,7 +52,7 @@
 <span class="token punctuation">}</span></code></pre>
   </rh-code-block>
 
-  <rh-code-block highlighting="prerendered" actions="copy wrap">
+  <rh-code-block highlighting="prerendered" actions="copy wrap" >
   <span slot="action-label-copy">Copy to Clipboard</span>
   <span slot="action-label-copy" hidden data-code-block-state="active">Copied!</span>
   <span slot="action-label-wrap">Toggle word wrap</span>

--- a/elements/rh-code-block/demo/show-more.html
+++ b/elements/rh-code-block/demo/show-more.html
@@ -1,0 +1,19 @@
+<rh-code-block actions="wrap copy" line-numbers="hidden" >
+<script type="text/css">#content {
+    display: block;
+    background-color: var(--rh-color-surface-lighter, #f2f2f2);
+    border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);}
+</script>
+</rh-code-block>
+
+
+<script type="module">
+  import '@rhds/elements/rh-button/rh-button.js';
+  import '@rhds/elements/rh-code-block/rh-code-block.js';
+</script>
+
+<style>
+  rh-code-block {
+    margin-block-end: var(--rh-space-lg, 16px);
+  }
+</style>

--- a/elements/rh-code-block/demo/show-more.html
+++ b/elements/rh-code-block/demo/show-more.html
@@ -1,10 +1,49 @@
 <rh-code-block actions="wrap copy" line-numbers="hidden" >
-<script type="text/css">#content {
-    display: block;
-    background-color: var(--rh-color-surface-lighter, #f2f2f2);
-    border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle-on-light, #c7c7c7);}
+<script type="text/css">check with 1 line
 </script>
 </rh-code-block>
+
+<rh-code-block actions="wrap copy" line-numbers="hidden" >
+<script type="text/css">check with 2 lines
+    check with 2 lines  
+</script>
+</rh-code-block>
+
+<rh-code-block actions="wrap copy" line-numbers="hidden" >
+<script type="text/css">check with 3 lines
+    check with 3 lines
+    check with 3 lines  
+</script>
+</rh-code-block>
+
+<rh-code-block actions="wrap copy" line-numbers="hidden" >
+<script type="text/css">check with 4 lines
+    check with 4 lines
+    check with 4 lines
+    check with 4 lines
+</script>
+</rh-code-block>
+
+<rh-code-block actions="wrap copy" line-numbers="hidden" >
+<script type="text/css">check with 5 lines
+  check with 5 lines
+  check with 5 lines
+  check with 5 lines
+  check with 5 lines
+</script>
+</rh-code-block>
+
+<rh-code-block actions="wrap copy" line-numbers="hidden" >
+<script type="text/css">check with 6 lines
+  check with 6 lines  
+  check with 6 lines
+  check with 6 lines
+  check with 6 lines
+  check with 6 lines
+</script>
+</rh-code-block>
+
+
 
 
 <script type="module">

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -335,13 +335,23 @@ export class RhCodeBlock extends LitElement {
    * Portions copyright prism.js authors (MIT license)
    */
   async #computeLineNumbers() {
-    if ( !this.#isIntersecting) {
+    if (!this.#isIntersecting) {
       return;
     }
     await this.updateComplete;
     const codes =
         this.#prismOutput ? [this.shadowRoot?.getElementById('prism-output')].filter(x => !!x)
       : this.#getSlottedCodeElements();
+
+     if (this.lineNumbers === 'hidden') {
+        this.#lineHeights = codes.flatMap(element =>
+          element.textContent?.split(/\n(?!$)/g).map(() => 1) ?? []
+        );
+        this.requestUpdate();
+        return; 
+      }
+
+
 
     const infos: CodeLineHeightsInfo[] = codes.map(element => {
       const codeElement = this.#prismOutput ? element.querySelector('code') : element;

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -345,7 +345,7 @@ export class RhCodeBlock extends LitElement {
 
      if (this.lineNumbers === 'hidden') {
         this.#lineHeights = codes.flatMap(element =>
-          element.textContent?.split(/\n(?!$)/g).map(() => 1) ?? []
+          element.textContent?.split(/\n(?!$)/g).map(() => '1px' ) ?? []
         );
         this.requestUpdate();
         return; 

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -335,7 +335,7 @@ export class RhCodeBlock extends LitElement {
    * Portions copyright prism.js authors (MIT license)
    */
   async #computeLineNumbers() {
-    if (this.lineNumbers === 'hidden' || !this.#isIntersecting) {
+    if ( !this.#isIntersecting) {
       return;
     }
     await this.updateComplete;


### PR DESCRIPTION
**Resolves**: https://github.com/RedHat-UX/red-hat-design-system/issues/2475

**What I did**

We saw that the problem starts when the attribute line-numbers has the value hidden. Originally, the function that counts the number of lines exited as soon as it saw hidden, which caused the "Show More" button not to appear. The button depends on the function that counts the lines to know whether to show.
Instead of removing this part of the condition, we modified it so that it now returns an array according to the number of lines even when the attribute is hidden. This way, the function still knows the correct number of lines and the button behaves correctly.
We then verified that this change does not interfere with other behaviors.

**Testing Instructions**

Navigate to rh-code-block where the "Show More" button is used.
Click on the "Show More" button.
Verify that additional content/items are displayed correctly.
Click again (if applicable) to ensure collapse works as expected.
Check for any UI glitches or layout issues.

**Notes to Reviewers**

Adjusted the "Show More" logic to correctly handle line-numbers="hidden" without removing the condition.
Please verify that expanding/collapsing content works as expected.