### PR TITLE
docs: fix bout typo on rh-icon guidelines

### DIFF
--- a/elements/rh-icon/docs/20-guidelines.md
+++ b/elements/rh-icon/docs/20-guidelines.md
@@ -13,7 +13,7 @@ Standard icons are pictograms that represent general technology concepts in mark
        height="48">
 </uxdot-example>
 
-<rh-cta href="https://www.redhat.com/en/about/brand/standards/icons/standard-icons">Learn more bout standard icons</rh-cta>
+<rh-cta href="https://www.redhat.com/en/about/brand/standards/icons/standard-icons">Learn more about standard icons</rh-cta>
 
 ### UI Icons
 


### PR DESCRIPTION
## What I did

1. Fixed typo on [RH Icon's Guidelines](https://ux.redhat.com/elements/icon/guidelines/#standard-(default)-icons) (`bout` —> `about`)

<img width="344" height="59" alt="image" src="https://github.com/user-attachments/assets/39dffc50-9ae9-4ff6-8192-1ec771eb238a" />


## Testing Instructions

1. Check DP for corrected spelling

