### PR TITLE
fix: web-dev-server serving lightdom.css

### DIFF
--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { pfeDevServerConfig } from '@patternfly/pfe-tools/dev-server/config.js';
-import { glob } from 'node:fs/promises';
-import { readFile } from 'node:fs/promises';
+import { glob, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { makeDemoEnv } from './scripts/environment.js';
 import { parse, serialize } from 'parse5';


### PR DESCRIPTION
## What I did

1. Fixes dev server not serving lightdom.css or lightdom-shim.css files.


## Testing Instructions

1. Check out branch, run `npm run dev`.  Check elements that serve lightdom.css and lightdom-shim.css files.

## Notes to Reviewers
