### PR TITLE
docs: add summary column for tokens in element pages

### DIFF
--- a/docs/_includes/layouts/pages/element.11ty.ts
+++ b/docs/_includes/layouts/pages/element.11ty.ts
@@ -781,18 +781,20 @@ export default class ElementsPage extends Renderer<Context> {
               <thead>
                 <tr>
                   <th>Token</th>
+                  <th>Summary</th>
                   <th>Copy</th>
                 </tr>
               </thead>
-              <tbody>${designTokens.map(token => html`
+              <tbody>${(await Promise.all(designTokens.map(async token => html`
                 <tr>
                   <td>
                     <a href="${getTokenHref(token)}">
                       <code>${token.name}</code>
                     </a>
                   </td>
+                  <td>${await this.#innerMD(token.summary ?? '')}</td>
                   ${copyCell(token)}
-                </tr>`).join('')}
+                </tr>`))).join('')}
               </tbody>
             </table>
           </rh-table>`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@patternfly/icons": "^1.0.3",
         "@patternfly/pfe-tools": "^5.0.4",
         "@playwright/test": "^1.54.1",
-        "@pwrs/cem": "^0.4.6",
+        "@pwrs/cem": "^0.6.4",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@stylistic/eslint-plugin-js": "^2.13.0",
         "@stylistic/stylelint-config": "^2.0.0",
@@ -3493,9 +3493,9 @@
       }
     },
     "node_modules/@pwrs/cem": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem/-/cem-0.4.6.tgz",
-      "integrity": "sha512-F/TPG4y1qOcuzudJh2Yws/2P7lPxOr+DEI2U3TONB/Rh/Ai7/nxKv8YBItGDhe9mMc8GHIwYfysd3roOYXRF+g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem/-/cem-0.6.4.tgz",
+      "integrity": "sha512-g1QIqWSRqycG2szMcSnzxQiuEkKruGhiH++Qc95LAxeLZa2hd4oEBAdr+xoceeklTh6+Ynt38/6uuznFoFYqrw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -3505,18 +3505,18 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@pwrs/cem-darwin-arm64": "0.4.6",
-        "@pwrs/cem-darwin-x64": "0.4.6",
-        "@pwrs/cem-linux-arm64": "0.4.6",
-        "@pwrs/cem-linux-x64": "0.4.6",
-        "@pwrs/cem-win32-arm64": "0.4.6",
-        "@pwrs/cem-win32-x64": "0.4.6"
+        "@pwrs/cem-darwin-arm64": "0.6.4",
+        "@pwrs/cem-darwin-x64": "0.6.4",
+        "@pwrs/cem-linux-arm64": "0.6.4",
+        "@pwrs/cem-linux-x64": "0.6.4",
+        "@pwrs/cem-win32-arm64": "0.6.4",
+        "@pwrs/cem-win32-x64": "0.6.4"
       }
     },
     "node_modules/@pwrs/cem-darwin-arm64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-arm64/-/cem-darwin-arm64-0.4.6.tgz",
-      "integrity": "sha512-tH0i6iSIXsTU1auihdkDDN183bwWYJ98JTBxlPtLSKUrKjWkHs9TRBCTeRp3U6t39YUTpsx2/8jdkSukaj52Yg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-arm64/-/cem-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-OXLlq+mXQTsw2ZL1P2jkw4vo5NYpfCPmEj70Xt398RoG9IwqxemzQp95l7a16LXmbH462/AImSK9IEcNGN9Xyg==",
       "cpu": [
         "arm64"
       ],
@@ -3531,9 +3531,9 @@
       }
     },
     "node_modules/@pwrs/cem-darwin-x64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-x64/-/cem-darwin-x64-0.4.6.tgz",
-      "integrity": "sha512-BLWV0+NQDPOx8eY4Y4MHJtysHbCIQ/faGpcV+tJ1H4lPm9mPsdowNAi0IKKgHJOQ4UXIkAPApCf9aSg0Tee9hg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-x64/-/cem-darwin-x64-0.6.4.tgz",
+      "integrity": "sha512-0P6l0d8T/+CFGHiFZpkzpb4oZrhaDlWAPaL3/Sl5T5qnudyKOsboX17+JET43uRBqibv9yggq1CniPphepkWyQ==",
       "cpu": [
         "x64"
       ],
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/@pwrs/cem-linux-arm64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-arm64/-/cem-linux-arm64-0.4.6.tgz",
-      "integrity": "sha512-DIoUEdTd/O/FkL0wqapM3hlCphBTNstmj9PH34VaKrkdEaSI53mBsKc8y4Vmf2iQl/CJ6yP8d7eQdjDCFIIC6g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-arm64/-/cem-linux-arm64-0.6.4.tgz",
+      "integrity": "sha512-whgleAJAbb6N8GTYcF6eF79bty6AePX38xFn8yS3ctkydTPk7eglBmgbRoDFBYx3NHba/cYVl+P9B0B2gJldqg==",
       "cpu": [
         "arm64"
       ],
@@ -3565,9 +3565,9 @@
       }
     },
     "node_modules/@pwrs/cem-linux-x64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-x64/-/cem-linux-x64-0.4.6.tgz",
-      "integrity": "sha512-gugDOocxqI5tcooK7ES6HyMQhLEMEqUMElNPKPpq81sJcKEUuaYqNWYMrL5Y3szkOXX4LSab+VdOFxGzRf4r0A==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-x64/-/cem-linux-x64-0.6.4.tgz",
+      "integrity": "sha512-riMadWtFdjFiEttxONEnEWOV+hASSyLl4iduzYiCp96vVQVKOwO99xgbcDXa4OkjuG2TOEwPaJLqjsuuOsyAcw==",
       "cpu": [
         "x64"
       ],
@@ -3582,9 +3582,9 @@
       }
     },
     "node_modules/@pwrs/cem-win32-arm64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-arm64/-/cem-win32-arm64-0.4.6.tgz",
-      "integrity": "sha512-KxSRshplHCGoMWflFTSawF7ZbiCaXYYzpCJ7ZYq0+mR/ZhzCRFh8gBQBKK2U5BzEBBkEAH7XceTUuQ4yhBxtZg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-arm64/-/cem-win32-arm64-0.6.4.tgz",
+      "integrity": "sha512-L8gr7IaVfMR43CQvChIJOMYg4QoHxn1gtU1lYD46EXza3TG2SpmPG4UxgHetPwFeFY7TxreQas4n/3GiyCpTVQ==",
       "cpu": [
         "arm64"
       ],
@@ -3599,9 +3599,9 @@
       }
     },
     "node_modules/@pwrs/cem-win32-x64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-x64/-/cem-win32-x64-0.4.6.tgz",
-      "integrity": "sha512-v2mOzt8ZQ9cqiS9CMFIzYczhq4VX+dv4B7c3Dyz7VRnpNO0C0v690mykoe31ogn7clF6FbX9sJt1evUFNGfZ2Q==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-x64/-/cem-win32-x64-0.6.4.tgz",
+      "integrity": "sha512-G8JHh1GETDuD9vwb6wkVBEHxvV5Og/LGJMXIEM6hw/2a/OAkrAr5gmAIlo1KHE/0tYvBKNtgGCc7qlJXixjXng==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@patternfly/icons": "^1.0.3",
     "@patternfly/pfe-tools": "^5.0.4",
     "@playwright/test": "^1.54.1",
-    "@pwrs/cem": "^0.4.6",
+    "@pwrs/cem": "^0.6.4",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@stylistic/eslint-plugin-js": "^2.13.0",
     "@stylistic/stylelint-config": "^2.0.0",


### PR DESCRIPTION
## What I did

1. add a summary column (typically used to describe the token's use in the particular element) to the element code page
2. update cem, to fix parsing of jsdoc


## Testing Instructions

1. view the code page for any element with comprehensive markdown in jsdoc and summary comments for token usage (#2548)

## Notes to Reviewers
