### PR TITLE
docs: fix focus indicator demo image

### DIFF
--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -99,7 +99,7 @@ We have designated focus ring colors that align with our brand standards for bot
 
 Note that there may be cases where a focus ring appears against a light background in dark mode and vice versa. For example, an inset focus ring for a text field may appear against a white background, even in dark mode. In these cases, you may need to manually override the default dark scheme ring color (<code>--rh-color-blue-30</code>) with the light scheme color (<code>--rh-color-blue-50</code>).
 
-<img src="./focus-styling-considerations-demo.png" alt="Demo of how inset ring colors should be set based on their background color and not the page theme" style="max-width: 100%;">
+<img src="./focus-styling-considerations-demo.svg" alt="Demo of how inset ring colors should be set based on their background color and not the page theme" style="max-width: 100%;">
 
 
 ## Example CSS


### PR DESCRIPTION
## What I did

1. Fixed a broken image link on the Focus indicator page in the [Styling considerations section](https://ux.redhat.com/foundations/interactions/focus-indicators/#styling-considerations):

<img width="145" height="54" alt="screencap of broken image" src="https://github.com/user-attachments/assets/32078a54-642a-4983-ac1e-c58f3b7efa58" />


## Testing Instructions

1. Go to the [Styling considerations section](https://deploy-preview-2694--red-hat-design-system.netlify.app/foundations/interactions/focus-indicators/#styling-considerations) on the preview page and verify the image is now present:

<img width="1163" height="222" alt="screencap of the image displaying properly" src="https://github.com/user-attachments/assets/642e0d30-6644-43ac-b90c-0b08bb0954d9" />

