### PR TITLE
docs(pagination): fix typo in guidelines

### DIFF
--- a/.changeset/ten-garlics-grin.md
+++ b/.changeset/ten-garlics-grin.md
@@ -1,6 +1,0 @@
----
-"@rhds/elements": patch
----
-
-`<rh-pagination>`: fix typo in guidelines doc
-  


### PR DESCRIPTION
## What I did

1. Fixed a typo in the pagination guidelines documentation where "Disabled butons" was corrected to "Disabled buttons"

## Testing Instructions

1. View the rendered documentation to verify the heading now reads "Disabled buttons"
2. No functional changes - documentation only

## Notes to Reviewers

This is a simple typo fix in the documentation. No code changes or testing required beyond reviewing the corrected text.
