### PR TITLE
docs: add ::selection at page layer to investigate text selection issue

### DIFF
--- a/.changeset/olive-geese-pump.md
+++ b/.changeset/olive-geese-pump.md
@@ -1,7 +1,0 @@
----
-"@rhds/elements": patch
----
-
-Added `::selection` styles to the base layer in `docs/styles/styles.css` to ensure consistent text selection color across pages.  
-Improved visibility and accessibility of selected text for users.
-


### PR DESCRIPTION
This PR fix to issue #2218 
### What I did
Added the `::selection` styles at the `base` layer (`docs/styles/styles.css`) as suggested,  
so that text selection colors are applied at the page layer (outside the shadow DOM).  

### What I expected
The selection color should appear when selecting text on the documentation page.

### What actually happens
After adding the styles, there is no visible change — the page seems not to load the `::selection` styles at all.

### Request
Could you please take a look and let me know if I'm missing something?  
I followed the suggestion to define the colors in the base layer,  
but it seems the styles are not being applied to the page.
@bennypowers  @zeroedin  @marionnegp 

