### PR TITLE
docs: fix broken link to false positives

### DIFF
--- a/docs/_includes/partials/accessibility/wcag.md
+++ b/docs/_includes/partials/accessibility/wcag.md
@@ -8,5 +8,5 @@
 
 <rh-alert state="info">
   <h3 slot="header">Automated testing</h3>
-  <p>Some of our elements may receive errors or warnings that are false positives from automated testing tools. If you are experiencing some of these issues, please read our <a href="/accessibility/accessibility-tools/#false-positives-in-automated-tools">update on false positives in automated tools</a>.</p>
+  <p>Some of our elements may receive errors or warnings that are false positives from automated testing tools. If you are experiencing some of these issues, please read our <a href="/accessibility/accessibility-tools/#false-positives-on-custom-elements-in-automated-tools">update on false positives in automated tools</a>.</p>
 </rh-alert>

--- a/docs/accessibility/accessibility-tools.md
+++ b/docs/accessibility/accessibility-tools.md
@@ -71,7 +71,7 @@ Some of our elements may receive errors or warnings that are false positives fro
   </figure>
 </div>
 
-In many cases, these false positives occur because automated tools expect to see an ARIA `role` or `aria-*` attribute explicitly defined on a Custom Element, even though that `role` or attribute is already being applied through the [ElementInternals API](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals).
+In many cases, these false positives occur because automated tools expect to see an ARIA `role` or `aria-*` attribute explicitly defined on a Custom Element, even though that `role` or attribute is already being applied implicitly through the [ElementInternals API](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals).
 
 By using the ElementInternals API, we can assign roles and other accessibility properties directly to a Custom Element, just like a native HTML element. These roles appear correctly in the [accessibility tree](#accessibility-tools-built-into-the-browser-inspector) and are interpreted properly by [screen readers](/accessibility/screen-readers/).
 


### PR DESCRIPTION
## What I did

1. Fixed the broken link from Elements' Accessibility pages to the False Positives header
2. Adding the word "implicitly" to the explanation of False Positives


## Testing Instructions

1. Check that the links work now.
2. Make sure that my adding "implicitly" makes sense (it felt right).
