### PR TITLE
fix(alert): support toastStyles as CSSStyleSheet

### DIFF
--- a/.changeset/quick-items-clean.md
+++ b/.changeset/quick-items-clean.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-alert>`: allow toast function to work when built using native constructible style sheets
+  

--- a/elements/rh-alert/rh-alert.ts
+++ b/elements/rh-alert/rh-alert.ts
@@ -269,9 +269,12 @@ function initToaster() {
   const node = document.createElement('section');
   node.classList.add('rh-alert-toast-group');
   // TODO: possibly allow other roots
+  const styles =
+      toastStyles instanceof CSSStyleSheet ? toastStyles
+    : (toastStyles as unknown as CSSResult).styleSheet!;
   document.adoptedStyleSheets = [
     ...document.adoptedStyleSheets ?? [],
-    (toastStyles as unknown as CSSResult).styleSheet!,
+    styles,
   ];
   document.body.append(node);
   return node;


### PR DESCRIPTION
If css imports are converted to native CSSStyleSheets instead of CSSResults, it would break rh-alert toasts. This change allows rh-alert to work when tools convert css imports to native objects.

## What I did

1. check the type of toastStyles (the imported stylesheet) before adopting it

