### PR TITLE
docs: add crosslink to RHDC a11y hub homepage

### DIFF
--- a/docs/accessibility/index.md
+++ b/docs/accessibility/index.md
@@ -21,7 +21,7 @@ order: 1
 
 ### The Red Hat Design System and Accessibility
 
-At Red Hat®, we believe that an [open source approach to accessibility](https://www.redhat.com/en/accessibility) leads to better, more inclusive experiences for all people, including users with disabilities.
+At Red Hat, we believe that an [open source approach to accessibility](https://www.redhat.com/en/accessibility) leads to better, more inclusive experiences for all people, including users with disabilities.
 
 The user experience across Red Hat properties, including our products, services, applications, and digital communications, are all held to a high standard of inclusivity. We strive to make them accessible for as many users and devices as possible.
 


### PR DESCRIPTION
## What I did

1. Added "to accessibility" after "open source approach" in the `Accessibility > Fundamentals` page's intro paragraph.
2. Linked this "open source approach to accessibility" phrase to our accessibility hub homepage at RHDC (https://www.redhat.com/en/accessibility).

## Testing Instructions

1. Verify that the phrase "open source approach to accessibility" occurs in the intro paragraph of the [deploy preview's `Accessibility > Fundamentals` page](https://deploy-preview-2774--red-hat-design-system.netlify.app/accessibility/).
2. Verify that this phrase links to https://www.redhat.com/en/accessibility