### PR TITLE
docs: adding nesting guidance for vertical nav demos

### DIFF
--- a/elements/rh-navigation-vertical/demo/nested.md
+++ b/elements/rh-navigation-vertical/demo/nested.md
@@ -1,0 +1,1 @@
+When nesting `<rh-navigation-vertical-list>` elements, it's advised limit nesting to 5 levels or less.


### PR DESCRIPTION
## What I did

1. Added guidance on nesting levels for `<rh-navigation-vertical>` demos


## Testing Instructions

1. Check out the [guidance under the nesting demo](https://deploy-preview-2783--red-hat-design-system.netlify.app/elements/navigation-vertical/demos/#demo-nested).
2. Verify accuracy and grammar.
