### PR TITLE
docs: add permalinks to element API docs sections

### DIFF
--- a/docs/_includes/layouts/pages/element.11ty.ts
+++ b/docs/_includes/layouts/pages/element.11ty.ts
@@ -368,7 +368,7 @@ export default class ElementsPage extends Renderer<Context> {
 
       ${await this.renderTemplate(manifest.getDescription(tagName) ?? '', 'md')}
 
-      <rh-accordion box>
+      <div class="element-apis">
         ${await this.#renderSlots(tagName, ctx)}
         ${await this.#renderAttributes(tagName, ctx)}
         ${await this.#renderMethods(tagName, ctx)}
@@ -376,12 +376,12 @@ export default class ElementsPage extends Renderer<Context> {
         ${await this.#renderCssParts(tagName, ctx)}
         ${await this.#renderCssCustomProperties(tagName, ctx)}
         ${await this.#renderDesignTokens(tagName, ctx)}
-      </rh-accordion>
+      </div>
     `;;
   }
 
   async #renderSlots(tagName: string, ctx: Context) {
-    const level = ctx.level ?? 2;
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const allSlots = ctx.doc.docsPage.manifest.getSlots(tagName) ?? [];
     const slots = allSlots.filter(x => !x.deprecated);
     const deprecated = allSlots.filter(x => x.deprecated);
@@ -389,15 +389,17 @@ export default class ElementsPage extends Renderer<Context> {
     const deprecatedSlotCount = deprecated.length;
 
     return html`
-      <rh-accordion-header id="${tagName}-slots" ${!count ? '' : 'expanded'}>Slots
-        <rh-badge>${count}</rh-badge>
-        ${deprecatedSlotCount > 0 ? html`<rh-badge state="moderate">${deprecatedSlotCount}</rh-badge>` : ``}
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="slots">
+        <section class="slots" aria-labelledby="${tagName}-slots">
+          <uxdot-copy-permalink class="h${sublevel}">
+            <h${sublevel} id="${tagName}-slots">
+              <a href="#${tagName}-slots">Slots <rh-badge>${count}</rh-badge>
+                ${deprecatedSlotCount > 0 ? html` <rh-badge state="moderate">${deprecatedSlotCount}</rh-badge>` : ``}
+              </a>
+            </h${sublevel}>
+          </uxdot-copy-permalink>
           ${!slots.length ? html`
           <em>None</em>` : html`
-          <rh-table>
+          <rh-table compact>
             <table>
               <thead>
                 <tr>
@@ -418,14 +420,14 @@ export default class ElementsPage extends Renderer<Context> {
                   </uxdot-copy-permalink></td>
                   <td>${await this.#innerMD(slot.summary)}</td>
                   <td>
-                   ${slot.name === '' ? await this.#innerMD(`${slot.description} <br><span style="font-size: var(--rh-font-size-body-text-md);"><strong>Note: </strong>[default] <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/slot#attributes">unnamed slots</a> do not have a slot="name" attribute.</span>`) : await this.#innerMD(slot.description)}
+                   ${slot.name === '' ? await this.#innerMD(`${slot.description} <br><span class="api-note"><strong>Note: </strong>[default] <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/slot#attributes">unnamed slots</a> do not have a slot="name" attribute.</span>`) : await this.#innerMD(slot.description)}
                   </td>
                 </tr>`))).join('')}
               </tbody>
             </table>
           </rh-table>`}${!deprecated.length ? '' : /* NB: we need to use our own stuff. don't replace with details */ html`
           <rh-disclosure summary="Deprecated Slots">
-            <rh-table>
+            <rh-table compact>
               <table>
                 <thead>
                   <tr>
@@ -447,12 +449,11 @@ export default class ElementsPage extends Renderer<Context> {
               </table>
             </rh-table>
           </rh-disclosure>`}
-        </section>
-      </rh-accordion-panel>`;
+        </section>`;
   }
 
   async #renderAttributes(tagName: string, ctx: Context) {
-    const level = ctx.level ?? 2;
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const _attrs = (ctx.doc.docsPage.manifest.getAttributes(tagName) ?? []);
     const deprecated = _attrs.filter(x => x.deprecated);
     const attributes = _attrs.filter(x => !x.deprecated);
@@ -460,14 +461,17 @@ export default class ElementsPage extends Renderer<Context> {
     const deprecatedAttrCount = deprecated.length;
 
     return html`
-      <rh-accordion-header id="${tagName}-attributes" ${!count ? '' : 'expanded'}>Attributes
-        <rh-badge>${count}</rh-badge>
-        ${deprecatedAttrCount > 0 ? html`<rh-badge state="moderate">${deprecatedAttrCount}</rh-badge>` : ``}
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="attributes">${!attributes.length ? html`
-          <em>None</em>` : html`
-          <rh-table>
+      <section class="attributes" aria-labelledby="${tagName}-attributes">
+        <uxdot-copy-permalink class="h${sublevel}">
+          <h${sublevel} id="${tagName}-attributes">
+            <a href="#${tagName}-attributes">Attributes <rh-badge>${count}</rh-badge>
+              ${deprecatedAttrCount > 0 ? html` <rh-badge state="moderate">${deprecatedAttrCount}</rh-badge>` : ``}
+            </a>
+          </h${sublevel}>
+        </uxdot-copy-permalink>
+        ${!attributes.length ? html`
+          <p><em>None</em></p>` : html`
+          <rh-table compact>
             <table>
               <thead>
                 <tr>
@@ -500,7 +504,7 @@ export default class ElementsPage extends Renderer<Context> {
           </rh-table>`}
           ${!deprecated.length ? '' : /* NB: we need to use our own stuff. don't replace with details */ html`
           <rh-disclosure summary="Deprecated Attributes">
-            <rh-table>
+            <rh-table compact>
               <table>
                 <thead>
                   <tr>
@@ -524,13 +528,11 @@ export default class ElementsPage extends Renderer<Context> {
               </table>
             </rh-table>
           </rh-disclosure>`}
-        </section>
-      </rh-accordion-panel>
-    `;
+        </section>`;
   }
 
   async #renderMethods(tagName: string, ctx: Context) {
-    const level = ctx.level ?? 2;
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const allMethods = ctx.doc.docsPage.manifest.getMethods(tagName) ?? [];
     const deprecated = allMethods.filter(x => x.deprecated);
     const methods = allMethods.filter(x => !x.deprecated);
@@ -539,15 +541,17 @@ export default class ElementsPage extends Renderer<Context> {
 
     // TODO: inline code highlighting for type and default: render the markdown to html and extract the `<code>` from the `<pre>`
     return html`
-      <rh-accordion-header id="${tagName}-methods" ${!count ? '' : 'expanded'}>Methods
-        <rh-badge>${count}</rh-badge>
-        ${deprecatedMethodsCount > 0 ? html`<rh-badge state="moderate">${deprecatedMethodsCount}</rh-badge>` : ``}
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="methods">
+        <section class="methods" aria-labelledby="${tagName}-methods">
+          <uxdot-copy-permalink class="h${sublevel}">
+            <h${sublevel} id="${tagName}-methods">
+              <a href="#${tagName}-methods">Methods <rh-badge>${count}</rh-badge>
+                ${deprecatedMethodsCount > 0 ? html` <rh-badge state="moderate">${deprecatedMethodsCount}</rh-badge>` : ``}
+              </a>
+            </h${sublevel}>
+          </uxdot-copy-permalink>
           ${!methods.length ? html`
-          <em>None</em>` : html`
-          <rh-table>
+          <p><em>None</em></p>` : html`
+          <rh-table compact>
             <table>
               <thead>
                 <tr>
@@ -573,7 +577,7 @@ export default class ElementsPage extends Renderer<Context> {
             </table>
           </rh-table>`}${!deprecated.length ? '' : /* NB: we need to use our own stuff. don't replace with details */ html`
           <rh-disclosure summary="Deprecated Methods">
-            <rh-table>
+            <rh-table compact>
               <table>
                 <thead>
                   <tr>
@@ -594,12 +598,11 @@ export default class ElementsPage extends Renderer<Context> {
             </rh-table>
           </rh-disclosure>`}
         </section>
-      </rh-accordion-panel>
     `;
   }
 
   async #renderEvents(tagName: string, ctx: Context) {
-    const level = ctx.level ?? 2;
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const _events = ctx.doc.docsPage.manifest.getEvents(tagName) ?? [];
     const deprecated = _events.filter(x => x.deprecated);
     const events = _events.filter(x => !x.deprecated);
@@ -607,15 +610,17 @@ export default class ElementsPage extends Renderer<Context> {
     const deprecatedEventsCount = deprecated.length;
 
     return html`
-      <rh-accordion-header id="${tagName}-events" ${!count ? '' : 'expanded'}>Events
-        <rh-badge>${count}</rh-badge>
-        ${deprecatedEventsCount > 0 ? html`<rh-badge state="moderate">${deprecatedEventsCount}</rh-badge>` : ``}
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="events">
+      <section class="events" aria-labelledby="${tagName}-events">
+        <uxdot-copy-permalink class="h${sublevel}">
+            <h${sublevel} id="${tagName}-events">
+              <a href="#${tagName}-events">Events <rh-badge>${count}</rh-badge>
+                ${deprecatedEventsCount > 0 ? html` <rh-badge state="moderate">${deprecatedEventsCount}</rh-badge>` : ``}
+              </a>
+            </h${sublevel}>
+          </uxdot-copy-permalink>
           ${!events.length ? html`
-          <em>None</em>` : html`
-          <rh-table>
+          <p><em>None</em></p>` : html`
+          <rh-table compact>
             <table>
               <thead>
                 <tr>
@@ -641,7 +646,7 @@ export default class ElementsPage extends Renderer<Context> {
             </table>
           </rh-table>`}${!deprecated.length ? '' : /* NB: we need to use our own stuff. don't replace with details */ html`
           <rh-disclosure summary="Deprecated Events">
-            <rh-table>
+            <rh-table compact>
               <table>
                 <thead>
                   <tr>
@@ -662,12 +667,11 @@ export default class ElementsPage extends Renderer<Context> {
             </rh-table>
           </rh-disclosure>`}
         </section>
-      </rh-accordion-panel>
     `;
   }
 
   async #renderCssParts(tagName: string, ctx: Context) {
-    const level = ctx.level ?? 2;
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const allParts = ctx.doc.docsPage.manifest.getCssParts(tagName) ?? [];
     const parts = allParts.filter(x => !x.deprecated);
     const deprecated = allParts.filter(x => x.deprecated);
@@ -675,15 +679,17 @@ export default class ElementsPage extends Renderer<Context> {
     const deprecatedCssPartsCount = deprecated.length;
 
     return html`
-      <rh-accordion-header id="${tagName}-css-parts" ${!count ? '' : 'expanded'}>CSS Shadow Parts
-        <rh-badge>${count}</rh-badge>
-        ${deprecatedCssPartsCount > 0 ? html`<rh-badge state="moderate">${deprecatedCssPartsCount}</rh-badge>` : ``}
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="css-shadow-parts">
+    <section class="css-shadow-parts" aria-labelledby="${tagName}-css-parts">
+        <uxdot-copy-permalink class="h${sublevel}">
+            <h${sublevel} id="${tagName}-css-parts">
+              <a href="#${tagName}-css-parts">CSS Shadow Parts <rh-badge>${count}</rh-badge>
+                ${deprecatedCssPartsCount > 0 ? html` <rh-badge state="moderate">${deprecatedCssPartsCount}</rh-badge>` : ``}
+              </a>
+            </h${sublevel}>
+          </uxdot-copy-permalink>
           ${!parts.length ? html`
-          <em>None</em>` : html`
-          <rh-table>
+          <p><em>None</em></p>` : html`
+          <rh-table compact>
             <table>
               <thead>
                 <tr>
@@ -711,7 +717,7 @@ export default class ElementsPage extends Renderer<Context> {
             </table>
           </rh-table>`}${!deprecated.length ? '' : /* NB: we need to use our own stuff. don't replace with details */ html`
           <rh-disclosure summary="Deprecated CSS Shadow Parts">
-            <rh-table>
+            <rh-table compact>
               <table>
                 <thead>
                   <tr>
@@ -734,12 +740,11 @@ export default class ElementsPage extends Renderer<Context> {
             </rh-table>
           </rh-disclosure>`}
         </section>
-      </rh-accordion-panel>
     `;
   }
 
   async #renderCssCustomProperties(tagName: string, ctx: Context) {
-    const level = ctx.level ?? 2;
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const allCssProperties = (ctx.doc.docsPage.manifest.getCssCustomProperties(tagName) ?? [])
         .filter(x => !tokens.has(x.name));
     const cssProperties = allCssProperties.filter(x => !x.deprecated);
@@ -748,15 +753,17 @@ export default class ElementsPage extends Renderer<Context> {
     const deprecatedCssPropertiesCount = deprecated.length;
 
     return html`
-      <rh-accordion-header id="${tagName}-css-properties" ${!count ? '' : 'expanded'}>CSS Custom Properties
-        <rh-badge>${count}</rh-badge>
-        ${deprecatedCssPropertiesCount > 0 ? html`<rh-badge state="moderate">${deprecatedCssPropertiesCount}</rh-badge>` : ``}
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="css-custom-properties">
+      <section class="css-custom-properties" aria-labelledby="${tagName}-css-properties">
+        <uxdot-copy-permalink class="h${sublevel}">
+            <h${sublevel} id="${tagName}-css-properties">
+              <a href="#${tagName}-css-properties">CSS Custom Properties <rh-badge>${count}</rh-badge>
+                ${deprecatedCssPropertiesCount > 0 ? html` <rh-badge state="moderate">${deprecatedCssPropertiesCount}</rh-badge>` : ``}
+              </a>
+            </h${sublevel}>
+          </uxdot-copy-permalink>
           ${!cssProperties.length ? html`
-          <em>None</em>` : html`
-          <rh-table>
+          <p><em>None</em></p>` : html`
+          <rh-table compact>
             <table class=css-custom-properties>
               <thead>
                 <tr>
@@ -777,7 +784,7 @@ export default class ElementsPage extends Renderer<Context> {
             </table>
           </rh-table>`}${!deprecated.length ? '' : /* NB: we need to use our own stuff. don't replace with details */ html`
           <rh-disclosure summary="Deprecated CSS Custom Properties">
-            <rh-table>
+            <rh-table compact>
               <table>
                 <thead>
                   <tr>
@@ -799,23 +806,24 @@ export default class ElementsPage extends Renderer<Context> {
             </rh-table>
           </rh-disclosure>`}
         </section>
-      </rh-accordion-panel>
     `;
   }
 
   async #renderDesignTokens(tagName: string, ctx: Context) {
+    const sublevel = (ctx.level) ? ctx.level + 1 : 3;
     const designTokens = (ctx.doc.docsPage.manifest.getCssCustomProperties(tagName) ?? [])
         .filter(x => tokens.has(x.name));
     const count = designTokens.length;
     return html`
-      <rh-accordion-header id="${tagName}-design-tokens" ${!count ? '' : 'expanded'}>Design Tokens
-        <rh-badge>${count}</rh-badge>
-      </rh-accordion-header>
-      <rh-accordion-panel>
-        <section class="design-tokens">
+      <section class="design-tokens" aria-labelledby="${tagName}-design-tokens">
+        <uxdot-copy-permalink class="h${sublevel}">
+            <h${sublevel} id="${tagName}-design-tokens">
+              <a href="#${tagName}-design-tokens">Design Tokens <rh-badge>${count}</rh-badge></a>
+            </h${sublevel}>
+          </uxdot-copy-permalink>
           ${!designTokens.length ? html`
-          <em>None</em>` : html`
-          <rh-table>
+          <p><em>None</em></p>` : html`
+          <rh-table compact>
             <table>
               <thead>
                 <tr>
@@ -838,7 +846,6 @@ export default class ElementsPage extends Renderer<Context> {
             </table>
           </rh-table>`}
         </section>
-      </rh-accordion-panel>
     `;
   }
 

--- a/docs/styles/pages/code.css
+++ b/docs/styles/pages/code.css
@@ -1,35 +1,48 @@
 /**
- * Elements > Code > Accordion Panel & Table customizations
+ * Elements > Code > API sections & Table customizations
  * Only loaded on the {Element} > Code pages
  **/
-rh-accordion {
-  rh-accordion-panel[expanded] {
-    &::part(container) {
-      background-color: light-dark(var(--rh-color-surface-lighter), var(--rh-color-surface-darker));
-    }
+.element-apis {
+  h3 {
+    font-size: var(--rh-font-size-heading-xs, 1.25rem);
 
-    rh-table {
-      margin: 0;
+    a {
+      display: flex;
+      gap: var(--rh-space-sm);
 
-      tbody tr:last-child {
-        border-block-end: 0 !important;
-      }
-
-      th {
-        font-size: var(--rh-font-size-body-text-sm);
-      }
-
-      :is(pre, code) {
-        white-space: break-spaces;
-      }
-
-      :is(th, td) p {
-        margin-block: 0;
+      rh-badge {
+        display: inline-flex;
+        align-self: center;
       }
     }
   }
 
-  details summary {
-    font-weight: var(--rh-font-weight-heading-medium, 500);
+  rh-table[compact] {
+    --rh-space-xl: 16px;
+    --rh-space-lg: 8px;
+
+    th,
+    td,
+    td :is(p, code) {
+      font-size: var(--rh-font-size-body-text-sm);
+    }
+
+    td {
+      vertical-align: top;
+    }
+
+    :is(pre) {
+      margin-block-start: 0;
+      padding-block: 0;
+      padding-inline-start: 0;
+    }
+
+    :is(pre, code) {
+      white-space: break-spaces;
+    }
+
+    :is(th, td) p {
+      margin-block: 0;
+    }
   }
 }


### PR DESCRIPTION
## What I did

1. Removed element API accordions and replaced with basic sections and headings
2. Added permalinks to each API section heading
3. Improved UI styling of API tables by decreasing padding and font-size


## Testing Instructions

1. Checkout an element's Code / API docs