### PR TITLE
fix(docs): correct WCAG target size link

### DIFF
--- a/docs/_includes/partials/accessibility/2.5.5-AAA.md
+++ b/docs/_includes/partials/accessibility/2.5.5-AAA.md
@@ -1,1 +1,1 @@
-- [SC 2.5.5 Target size](https://www.w3.org/WAI/WCAG22/Understanding/target-size) (Level AAA)
+- [SC 2.5.5 Target size](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced) (Level AAA)


### PR DESCRIPTION
## What I did

- Fixed broken WCAG link in accessibility docs
- Updated SC 2.5.5 target size



## Testing Instructions

- Open accessibility docs page
- Click "SC 2.5.5 target size" link
- Verify it redirects to:
  https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced

## Notes to Reviewers

- This is a small documentation fix
- Only the link URL was updated, no other changes are done

Closes #2912