### PR TITLE
fix(audio-player): document media slot via class-level JSDoc

### DIFF
--- a/elements/rh-audio-player/rh-audio-player.ts
+++ b/elements/rh-audio-player/rh-audio-player.ts
@@ -42,6 +42,10 @@ import '@rhds/elements/rh-icon/rh-icon.js';
  *
  * @alias audio-player
  *
+ * @slot media - Must contain an `<audio>` block element with source children.
+ *               The audio element is visually hidden but remains accessible
+ *               to screen readers for native media controls.
+ *
  * @csspart toolbar - The main controls toolbar container.
  * @csspart panel - The expandable content panel below the toolbar.
  * @csspart about - The about panel slot container.


### PR DESCRIPTION
## Summary
- The `media` slot's inline HTML doc comment was not included in the CEM manifest because a preceding void `<input>` element prevented the tree-sitter parser from associating the comment with the `<slot>`.
- Added a `@slot media` tag to the class-level JSDoc as a workaround, so the slot description now appears in `custom-elements.json` and on the Code page.

Closes #2923

## Test plan
- [x] `cem generate -q` succeeds
- [x] `cem health --component rh-audio-player` shows slots at 15/15
- [x] `media` slot appears in `custom-elements.json` with its description

Generated with [Claude Code](https://claude.com/claude-code)