### PR TITLE
fix(accordion): guard SSR-unsafe DOM operations

### DIFF
--- a/.changeset/accordion-ssr-guard.md
+++ b/.changeset/accordion-ssr-guard.md
@@ -1,0 +1,4 @@
+---
+"@rhds/elements": patch
+---
+`<rh-accordion>`: fixed server-side rendering compatibility

--- a/elements/rh-accordion/rh-accordion.ts
+++ b/elements/rh-accordion/rh-accordion.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, type TemplateResult } from 'lit';
+import { LitElement, html, isServer, type TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
@@ -147,8 +147,10 @@ export class RhAccordion extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('change', this.#onChange as EventListener);
-    this.#mo.observe(this, { childList: true });
-    this.updateAccessibility();
+    if (!isServer) {
+      this.updateAccessibility();
+      this.#mo.observe(this, { childList: true });
+    }
   }
 
   override render(): TemplateResult {


### PR DESCRIPTION
## Summary
- Guard `updateAccessibility()` and `MutationObserver.observe()` behind `isServer` in `connectedCallback`, matching the pattern already used in other elements (accordion-header, code-block, tabs, navigation-secondary).

Supersedes the accordion portion of #2131.

## Test plan
- [ ] SSR build completes without errors
- [ ] Accordion expands/collapses normally in the browser
- [ ] Accordion headers have correct `aria-controls`/`aria-labelledby` after hydration