### PR TITLE
fix(cta): change default, primary, and secondary CTA's font weight to 700

### DIFF
--- a/.changeset/sour-areas-cheat.md
+++ b/.changeset/sour-areas-cheat.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-cta>`: Made the text in primary, secondary, and default CTAs bolder
+`<rh-cta>`: made the text in primary, secondary, and default CTAs bolder

--- a/.changeset/sour-areas-cheat.md
+++ b/.changeset/sour-areas-cheat.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-cta>`: Made the text in primary, secondary, and default CTAs bolder

--- a/elements/rh-cta/rh-cta-lightdom-shim.css
+++ b/elements/rh-cta/rh-cta-lightdom-shim.css
@@ -4,7 +4,7 @@ rh-cta:not(:defined) {
   color: var(--rh-cta-color);
   font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
   font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-  font-weight: 600; /* WARNING: not a token value */
+  font-weight: var(--rh-font-weight-heading-bold, 700);
   line-height: var(--rh-line-height-body-text, 1.5);
   background-color: var(--rh-cta-background-color);
   border-color: var(--rh-cta-border-color, transparent);

--- a/elements/rh-cta/rh-cta.css
+++ b/elements/rh-cta/rh-cta.css
@@ -50,7 +50,7 @@ a:after,
 
   /** Container text size */
   font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-  font-weight: 600; /* WARNING: not a token value */
+  font-weight: var(--rh-font-weight-heading-bold, 700);
 
   /** Container line height */
   line-height: var(--rh-line-height-body-text, 1.5);

--- a/elements/rh-cta/rh-cta.css
+++ b/elements/rh-cta/rh-cta.css
@@ -50,6 +50,8 @@ a:after,
 
   /** Container text size */
   font-size: var(--rh-font-size-body-text-lg, 1.125rem);
+
+  /** Container font weight */
   font-weight: var(--rh-font-weight-heading-bold, 700);
 
   /** Container line height */


### PR DESCRIPTION
## What I did

1. Change default, primary, and secondary's font weight to 700 in both CSS files for `rh-cta`


## Testing Instructions

1.

## Notes to Reviewers
