### PR TITLE
fix(tabs): corrected focus selector

### DIFF
--- a/.changeset/loose-years-sip.md
+++ b/.changeset/loose-years-sip.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tabs>`: improved accessibility so only one focus outline is visible at a time when navigating within a tab panel
+  

--- a/elements/rh-tabs/rh-tab-panel.css
+++ b/elements/rh-tabs/rh-tab-panel.css
@@ -11,7 +11,7 @@
 
 :host(:focus-visible) {
   /** Focus ring, design token rh-color-interactive-primary */
-  outline: 1px auto var(--rh-color-interactive-primary-default);
+  outline: var(--rh-border-width-lg, 3px) auto var(--rh-color-interactive-primary-default);
 }
 
 #container {

--- a/elements/rh-tabs/rh-tab-panel.css
+++ b/elements/rh-tabs/rh-tab-panel.css
@@ -7,11 +7,14 @@
 
 :host([hidden]) {
   display: none !important;
+  position: relative;
 }
 
 :host(:focus-visible) {
   /** Focus ring, design token rh-color-interactive-primary */
-  outline: var(--rh-border-width-lg, 3px) auto var(--rh-color-interactive-primary-default);
+  border-radius: var(--rh-border-radius-default, 3px);
+  outline: var(--rh-border-width-lg, 3px) solid var(--rh-color-interactive-primary-default);
+  outline-offset: -3px;
 }
 
 #container {

--- a/elements/rh-tabs/rh-tab-panel.css
+++ b/elements/rh-tabs/rh-tab-panel.css
@@ -9,7 +9,7 @@
   display: none !important;
 }
 
-:host(:is(:focus, :focus-within)) {
+:host(:focus-visible) {
   /** Focus ring, design token rh-color-interactive-primary */
   outline: 1px auto var(--rh-color-interactive-primary-default);
 }

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -453,10 +453,9 @@ rh-icon,
   outline: none;
 
   & #button {
-    &:after {
-      /** Focus outline, adapts to color-palette */
-      outline: var(--rh-border-width-lg, 3px) auto var(--rh-color-interactive-primary-default);
-      outline-offset: -6px;
-    }
+    /** Focus outline, adapts to color-palette */
+    border-radius: var(--rh-border-radius-default, 3px);
+    outline: var(--rh-border-width-lg, 3px) solid var(--rh-color-interactive-primary-default);
+    outline-offset: -7px;
   }
 }

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -453,8 +453,10 @@ rh-icon,
   outline: none;
 
   & #button {
-    /** Focus outline, adapts to color-palette */
-    outline: 1px auto var(--rh-color-interactive-primary-default);
-    outline-offset: -3px;
+    &:after {
+      /** Focus outline, adapts to color-palette */
+      outline: var(--rh-border-width-lg, 3px) auto var(--rh-color-interactive-primary-default);
+      outline-offset: -6px;
+    }
   }
 }

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -449,7 +449,7 @@ rh-icon,
   }
 }
 
-:host(:is(:focus, :focus-within)) {
+:host(:is(:focus-visible)) {
   outline: none;
 
   & #button {


### PR DESCRIPTION
## What I did

1. Improved accessibility so only one focus outline is visible at a time when navigating within a tab panel

Closes #2970 

## Testing Instructions

1. View [Deploy Preview Tabs Demo](https://deploy-preview-2971--red-hat-design-system.netlify.app/elements/tabs/demo/) tab to containers tab activate then tab the "Focusable element" link only 1 focus ring should be shown

## Notes to Reviewers
