### PR TITLE
feat(rh-scheme-toggle): add scheme changed event

### DIFF
--- a/.changeset/hip-geckos-stare.md
+++ b/.changeset/hip-geckos-stare.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-scheme-toggle>`: add the `scheme-changed` event that fires whenever a user changes the color scheme.

--- a/elements/rh-scheme-toggle/demo/events.html
+++ b/elements/rh-scheme-toggle/demo/events.html
@@ -1,5 +1,6 @@
-<meta itemprop="description" content="Demonstrates the scheme-changed event fired when a user changes the color scheme.">
-
+---
+description: "Demonstrates the scheme-changed event fired when a user changes the color scheme."
+---
 <rh-scheme-toggle id="scheme-toggle"></rh-scheme-toggle>
 
 <p class="container">

--- a/elements/rh-scheme-toggle/demo/events.html
+++ b/elements/rh-scheme-toggle/demo/events.html
@@ -1,27 +1,30 @@
 ---
 description: "Demonstrates the scheme-changed event fired when a user changes the color scheme."
 ---
-<rh-scheme-toggle id="scheme-toggle"></rh-scheme-toggle>
+<form id="scheme-toggle-events">
+  <rh-scheme-toggle id="scheme-toggle"></rh-scheme-toggle>
 
-<p class="container">
-  A <code>scheme-changed</code> event fires whenever the color scheme changes.
-</p>
+  <p class="container">
+    A <code>scheme-changed</code> event fires whenever the color scheme changes.
+  </p>
 
-<fieldset class="container">
-  <legend>Events Fired</legend>
-  <output name="events">No events yet</output>
-</fieldset>
+  <fieldset class="container">
+    <legend>Events Fired</legend>
+    <output name="events">No events yet</output>
+  </fieldset>
+</form>
 
 <script type="module">
   import '@rhds/elements/rh-scheme-toggle/rh-scheme-toggle.js';
 
-  const toggle = document.querySelector('#scheme-toggle');
-  const output = document.querySelector('output[name="events"]');
+  const toggle = document.getElementById('scheme-toggle');
+  const form = document.getElementById('scheme-toggle-events');
   const events = [];
+  form.addEventListener('submit', e => e.preventDefault());
 
   toggle.addEventListener('scheme-changed', event => {
     events.push(event.scheme);
-    output.textContent = events.join(', ');
+    form.elements.events.value = events.join(', ');
   });
 </script>
 

--- a/elements/rh-scheme-toggle/demo/events.html
+++ b/elements/rh-scheme-toggle/demo/events.html
@@ -1,0 +1,45 @@
+<meta itemprop="description" content="Demonstrates the scheme-changed event fired when a user changes the color scheme.">
+
+<rh-scheme-toggle id="scheme-toggle"></rh-scheme-toggle>
+
+<p class="container">
+  A <code>scheme-changed</code> event fires whenever the color scheme changes.
+</p>
+
+<fieldset class="container">
+  <legend>Events Fired</legend>
+  <output name="events">No events yet</output>
+</fieldset>
+
+<script type="module">
+  import '@rhds/elements/rh-scheme-toggle/rh-scheme-toggle.js';
+
+  const toggle = document.querySelector('#scheme-toggle');
+  const output = document.querySelector('output[name="events"]');
+  const events = [];
+
+  toggle.addEventListener('scheme-changed', event => {
+    events.push(event.scheme);
+    output.textContent = events.join(', ');
+  });
+</script>
+
+<style>
+  body {
+    color-scheme: light dark;
+    background-color: light-dark(var(--rh-color-surface-lightest, #ffffff),
+        var(--rh-color-surface-darkest, #151515));
+    color: light-dark(var(--rh-color-text-primary-default-on-light, #151515),
+        var(--rh-color-text-primary-default-on-dark, #ffffff));
+  }
+
+  rh-scheme-toggle {
+    padding: var(--rh-space-md, 8px);
+  }
+
+  .container {
+    margin-inline: 20px;
+    margin-block-end: var(--rh-space-md, 8px);
+    font-family: var(--rh-font-family-body-text);
+  }
+</style>

--- a/elements/rh-scheme-toggle/demo/index.html
+++ b/elements/rh-scheme-toggle/demo/index.html
@@ -1,4 +1,6 @@
-<meta itemprop="description" content="Default scheme toggle with light, dark, and system options.">
+---
+description: "Default scheme toggle with light, dark, and system options."
+---
 <rh-scheme-toggle></rh-scheme-toggle>
 
 <script type="module">

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.ts
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.ts
@@ -17,6 +17,19 @@ declare global {
 type Scheme = 'light' | 'dark' | 'light dark';
 
 /**
+ * Fired when the active color scheme changes, whether by user interaction
+ * or programmatic update. Does not fire on initial load from localStorage.
+ * Listeners can read `event.scheme` to get the new value.
+ */
+export class SchemeChangedEvent extends Event {
+  constructor(
+    public scheme: Scheme,
+  ) {
+    super('scheme-changed', { bubbles: true, composed: true });
+  }
+}
+
+/**
  * A scheme toggle provides users with the ability to switch between
  * light, dark, and system default color schemes. It should be placed
  * in a visible location for easy access. For WCAG compliance, screen
@@ -26,11 +39,16 @@ type Scheme = 'light' | 'dark' | 'light dark';
  *
  * @summary Switches between light, dark, and system default color schemes.
  *
+ * @fires {SchemeChangedEvent} scheme-changed - Fired when the color scheme changes
+ *
  * @alias Scheme toggle
  */
 @customElement('rh-scheme-toggle')
 export class RhSchemeToggle extends LitElement {
   static styles = [styles];
+
+  /** Guards against dispatching scheme-changed on initial boot. */
+  #initialized = false;
 
   /** Whether the light radio button is currently checked. */
   #isLight = false;
@@ -76,7 +94,25 @@ export class RhSchemeToggle extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.#schemeCheck();
+    // Defer until after the first Lit update cycle so @observes('scheme')
+    // doesn't dispatch scheme-changed for the initial localStorage value.
+    this.updateComplete.then(() => {
+      this.#initialized = true;
+    });
+  }
+
+  /**
+   * Syncs the radio checked-state flags before each render so the
+   * template always reflects the current `scheme` value.
+   */
+  protected override willUpdate(): void {
+    if (!isServer) {
+      this.#isLight = this.scheme === 'light';
+      this.#isDark = this.scheme === 'dark';
+      this.#isSystem = (this.scheme?.includes('light')
+        && this.scheme?.includes('dark'))
+        || (this.scheme === undefined);
+    }
   }
 
   render() {
@@ -89,7 +125,7 @@ export class RhSchemeToggle extends LitElement {
             <input type="radio"
                    name="scheme"
                    value="light"
-                   ?checked="${this.#isLight}">
+                   .checked="${this.#isLight}">
             <rh-icon set="ui" icon="light-mode"></rh-icon>
           </label>
           <label title="${this.darkText}">
@@ -97,7 +133,7 @@ export class RhSchemeToggle extends LitElement {
             <input type="radio"
                    name="scheme"
                    value="dark"
-                   ?checked="${this.#isDark}">
+                   .checked="${this.#isDark}">
             <rh-icon set="ui" icon="dark-mode"></rh-icon>
           </label>
           <label title="${this.systemText}">
@@ -105,7 +141,7 @@ export class RhSchemeToggle extends LitElement {
             <input type="radio"
                    name="scheme"
                    value="light dark"
-                   ?checked="${this.#isSystem}">
+                   .checked="${this.#isSystem}">
             <rh-icon set="ui" icon="auto-light-dark-mode"></rh-icon>
           </label>
         </div>
@@ -113,27 +149,13 @@ export class RhSchemeToggle extends LitElement {
     `;
   }
 
-  /** Handles radio button changes and updates the selected scheme. */
+  /**
+   * Handles radio button changes and updates the selected scheme.
+   * @param e - The change event from the radio input.
+   */
   #onChange(e: Event) {
     if (e.target instanceof HTMLInputElement) {
       this.scheme = e.target.value as Scheme;
-    }
-    this.#schemeCheck();
-  }
-
-  /**
-   * Synchronizes the private checked-state flags with the current
-   * `scheme` value and requests a re-render. Treats `undefined` as
-   * equivalent to the system default (`'light dark'`).
-   */
-  #schemeCheck() {
-    if (!isServer) {
-      this.#isLight = this.scheme === 'light';
-      this.#isDark = this.scheme === 'dark';
-      this.#isSystem = (this.scheme?.includes('light')
-        && this.scheme?.includes('dark'))
-        || (this.scheme === undefined);
-      this.requestUpdate();
     }
   }
 
@@ -144,12 +166,15 @@ export class RhSchemeToggle extends LitElement {
    */
   @observes('scheme')
   private schemeChanged() {
-    if (!isServer) {
-      if (this.scheme) {
-        document.body.style.setProperty('color-scheme', this.scheme);
-        if (!isServer) {
-          localStorage.rhdsColorScheme = this.scheme;
-        }
+    if (isServer) {
+      return;
+    }
+
+    if (this.scheme) {
+      document.body.style.setProperty('color-scheme', this.scheme);
+      localStorage.rhdsColorScheme = this.scheme;
+      if (this.#initialized) {
+        this.dispatchEvent(new SchemeChangedEvent(this.scheme));
       }
     }
   }

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.ts
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.ts
@@ -18,8 +18,12 @@ type Scheme = 'light' | 'dark' | 'light dark';
 
 /**
  * Fired when the active color scheme changes, whether by user interaction
- * or programmatic update. Does not fire on initial load from localStorage.
- * Listeners can read `event.scheme` to get the new value.
+ * or programmatic update. This event allows consumers to coordinate UI
+ * updates or analytics when the scheme changes. Listeners should read
+ * `event.scheme` for the new value. Consumers must not rely on this
+ * event firing during initial load from localStorage.
+ *
+ * @summary Fires when the color scheme changes for coordination and analytics.
  */
 export class SchemeChangedEvent extends Event {
   constructor(
@@ -39,7 +43,9 @@ export class SchemeChangedEvent extends Event {
  *
  * @summary Switches between light, dark, and system default color schemes.
  *
- * @fires {SchemeChangedEvent} scheme-changed - Fired when the color scheme changes
+ * @fires {SchemeChangedEvent} scheme-changed - Fired when the color scheme
+ *        changes. Has no `detail` payload; read the new value from
+ *        `event.scheme` (`'light'`, `'dark'`, or `'light dark'`).
  *
  * @alias Scheme toggle
  */

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.ts
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.ts
@@ -106,13 +106,15 @@ export class RhSchemeToggle extends LitElement {
    * template always reflects the current `scheme` value.
    */
   protected override willUpdate(): void {
-    if (!isServer) {
-      this.#isLight = this.scheme === 'light';
-      this.#isDark = this.scheme === 'dark';
-      this.#isSystem = (this.scheme?.includes('light')
-        && this.scheme?.includes('dark'))
-        || (this.scheme === undefined);
+    if (isServer) {
+      return;
     }
+
+    this.#isLight = this.scheme === 'light';
+    this.#isDark = this.scheme === 'dark';
+    this.#isSystem = (this.scheme?.includes('light')
+      && this.scheme?.includes('dark'))
+      || (this.scheme === undefined);
   }
 
   render() {

--- a/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
+++ b/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
@@ -148,11 +148,13 @@ describe('<rh-scheme-toggle>', function() {
 
   describe('scheme-changed event', function() {
     let element: RhSchemeToggle;
+    const events: SchemeChangedEvent[] = [];
 
     beforeEach(async function() {
+      events.length = 0;
       localStorage.removeItem('rhdsColorScheme');
       element = await createFixture<RhSchemeToggle>(
-        html`<rh-scheme-toggle></rh-scheme-toggle>`
+        html`<rh-scheme-toggle @scheme-changed="${(e: SchemeChangedEvent) => events.push(e)}"></rh-scheme-toggle>`
       );
       await element.updateComplete;
     });
@@ -163,9 +165,6 @@ describe('<rh-scheme-toggle>', function() {
     });
 
     it('fires on user interaction via radio', async function() {
-      const events: SchemeChangedEvent[] = [];
-      element.addEventListener('scheme-changed', e => events.push(e as SchemeChangedEvent));
-
       selectScheme(element, 'dark');
       await element.updateComplete;
 
@@ -174,9 +173,6 @@ describe('<rh-scheme-toggle>', function() {
     });
 
     it('fires on programmatic property change', async function() {
-      const events: SchemeChangedEvent[] = [];
-      element.addEventListener('scheme-changed', e => events.push(e as SchemeChangedEvent));
-
       element.scheme = 'dark';
       await element.updateComplete;
 
@@ -185,42 +181,27 @@ describe('<rh-scheme-toggle>', function() {
     });
 
     it('does not fire on initial load from localStorage', async function() {
-      const events: SchemeChangedEvent[] = [];
+      const initEvents: SchemeChangedEvent[] = [];
       localStorage.setItem('rhdsColorScheme', 'dark');
 
-      // Listen on document BEFORE fixture — composed event would reach here
-      const handler = (e: Event) => events.push(e as SchemeChangedEvent);
-      document.addEventListener('scheme-changed', handler);
-
       const el = await createFixture<RhSchemeToggle>(
-        html`<rh-scheme-toggle></rh-scheme-toggle>`
+        html`<rh-scheme-toggle @scheme-changed="${(e: SchemeChangedEvent) => initEvents.push(e)}"></rh-scheme-toggle>`
       );
       await el.updateComplete;
 
-      document.removeEventListener('scheme-changed', handler);
-      expect(events).to.have.length(0);
+      expect(initEvents).to.have.length(0);
     });
 
     it('has bubbles and composed set to true', async function() {
-      let event: SchemeChangedEvent | undefined;
-      element.addEventListener('scheme-changed', e => {
-        event = e as SchemeChangedEvent;
-      });
-
       element.scheme = 'light';
       await element.updateComplete;
 
-      expect(event).to.exist;
-      expect(event!.bubbles).to.be.true;
-      expect(event!.composed).to.be.true;
+      expect(events[0]).to.exist;
+      expect(events[0].bubbles).to.be.true;
+      expect(events[0].composed).to.be.true;
     });
 
     it('carries the correct scheme for each value', async function() {
-      const schemes: string[] = [];
-      element.addEventListener('scheme-changed', e => {
-        schemes.push((e as SchemeChangedEvent).scheme);
-      });
-
       element.scheme = 'dark';
       await element.updateComplete;
       element.scheme = 'light dark';
@@ -228,7 +209,7 @@ describe('<rh-scheme-toggle>', function() {
       element.scheme = 'light';
       await element.updateComplete;
 
-      expect(schemes).to.deep.equal(['dark', 'light dark', 'light']);
+      expect(events.map(e => e.scheme)).to.deep.equal(['dark', 'light dark', 'light']);
     });
   });
 

--- a/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
+++ b/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
@@ -1,6 +1,6 @@
-import { expect, html, nextFrame } from '@open-wc/testing';
+import { expect, html } from '@open-wc/testing';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
-import { RhSchemeToggle } from '@rhds/elements/rh-scheme-toggle/rh-scheme-toggle.js';
+import { RhSchemeToggle, SchemeChangedEvent } from '@rhds/elements/rh-scheme-toggle/rh-scheme-toggle.js';
 import { a11ySnapshot } from '@patternfly/pfe-tools/test/a11y-snapshot.js';
 import { sendKeys } from '@web/test-runner-commands';
 
@@ -8,6 +8,20 @@ function press(key: string) {
   return async function() {
     await sendKeys({ press: key });
   };
+}
+
+/**
+ * Simulates a user selecting a radio option by checking the matching
+ * input and dispatching a native `change` event on the fieldset.
+ * @param element - the rh-scheme-toggle instance
+ * @param value - the option value to select (e.g. 'light', 'dark', 'light dark')
+ */
+function selectScheme(element: RhSchemeToggle, value: string) {
+  const radio = element.shadowRoot!.querySelector<HTMLInputElement>(
+    `input[type="radio"][value="${value}"]`
+  )!;
+  radio.checked = true;
+  radio.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
 describe('<rh-scheme-toggle>', function() {
@@ -129,6 +143,145 @@ describe('<rh-scheme-toggle>', function() {
           });
         });
       });
+    });
+  });
+
+  describe('scheme-changed event', function() {
+    let element: RhSchemeToggle;
+
+    beforeEach(async function() {
+      localStorage.removeItem('rhdsColorScheme');
+      element = await createFixture<RhSchemeToggle>(
+        html`<rh-scheme-toggle></rh-scheme-toggle>`
+      );
+      await element.updateComplete;
+    });
+
+    afterEach(function() {
+      localStorage.removeItem('rhdsColorScheme');
+      document.body.style.removeProperty('color-scheme');
+    });
+
+    it('fires on user interaction via radio', async function() {
+      const events: SchemeChangedEvent[] = [];
+      element.addEventListener('scheme-changed', e => events.push(e as SchemeChangedEvent));
+
+      selectScheme(element, 'dark');
+      await element.updateComplete;
+
+      expect(events).to.have.length(1);
+      expect(events[0].scheme).to.equal('dark');
+    });
+
+    it('fires on programmatic property change', async function() {
+      const events: SchemeChangedEvent[] = [];
+      element.addEventListener('scheme-changed', e => events.push(e as SchemeChangedEvent));
+
+      element.scheme = 'dark';
+      await element.updateComplete;
+
+      expect(events).to.have.length(1);
+      expect(events[0].scheme).to.equal('dark');
+    });
+
+    it('does not fire on initial load from localStorage', async function() {
+      const events: SchemeChangedEvent[] = [];
+      localStorage.setItem('rhdsColorScheme', 'dark');
+
+      const el = await createFixture<RhSchemeToggle>(
+        html`<rh-scheme-toggle></rh-scheme-toggle>`
+      );
+      el.addEventListener('scheme-changed', e => events.push(e as SchemeChangedEvent));
+      await el.updateComplete;
+
+      expect(events).to.have.length(0);
+    });
+
+    it('has bubbles and composed set to true', async function() {
+      let event: SchemeChangedEvent | undefined;
+      element.addEventListener('scheme-changed', e => {
+        event = e as SchemeChangedEvent;
+      });
+
+      element.scheme = 'light';
+      await element.updateComplete;
+
+      expect(event).to.exist;
+      expect(event!.bubbles).to.be.true;
+      expect(event!.composed).to.be.true;
+    });
+
+    it('carries the correct scheme for each value', async function() {
+      const schemes: string[] = [];
+      element.addEventListener('scheme-changed', e => {
+        schemes.push((e as SchemeChangedEvent).scheme);
+      });
+
+      element.scheme = 'dark';
+      await element.updateComplete;
+      element.scheme = 'light dark';
+      await element.updateComplete;
+      element.scheme = 'light';
+      await element.updateComplete;
+
+      expect(schemes).to.deep.equal(['dark', 'light dark', 'light']);
+    });
+  });
+
+  describe('radio checked state after programmatic scheme change', function() {
+    let element: RhSchemeToggle;
+
+    /** Returns the checked radio's value, or null if none checked. */
+    function checkedValue(): string | null {
+      const radio = element.shadowRoot!.querySelector<HTMLInputElement>(
+        'input[type="radio"]:checked'
+      );
+      return radio?.value ?? null;
+    }
+
+    beforeEach(async function() {
+      localStorage.removeItem('rhdsColorScheme');
+      element = await createFixture<RhSchemeToggle>(
+        html`<rh-scheme-toggle></rh-scheme-toggle>`
+      );
+      await element.updateComplete;
+    });
+
+    afterEach(function() {
+      localStorage.removeItem('rhdsColorScheme');
+      document.body.style.removeProperty('color-scheme');
+    });
+
+    it('checks the light radio after setting scheme to "light"', async function() {
+      element.scheme = 'light';
+      await element.updateComplete;
+      expect(checkedValue()).to.equal('light');
+    });
+
+    it('checks the dark radio after setting scheme to "dark"', async function() {
+      element.scheme = 'dark';
+      await element.updateComplete;
+      expect(checkedValue()).to.equal('dark');
+    });
+
+    it('checks the system radio after setting scheme to "light dark"', async function() {
+      element.scheme = 'light dark';
+      await element.updateComplete;
+      expect(checkedValue()).to.equal('light dark');
+    });
+
+    it('updates checked radio across sequential changes', async function() {
+      element.scheme = 'dark';
+      await element.updateComplete;
+      expect(checkedValue()).to.equal('dark');
+
+      element.scheme = 'light';
+      await element.updateComplete;
+      expect(checkedValue()).to.equal('light');
+
+      element.scheme = 'light dark';
+      await element.updateComplete;
+      expect(checkedValue()).to.equal('light dark');
     });
   });
 });

--- a/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
+++ b/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
@@ -10,20 +10,6 @@ function press(key: string) {
   };
 }
 
-/**
- * Simulates a user selecting a radio option by checking the matching
- * input and dispatching a native `change` event on the fieldset.
- * @param element - the rh-scheme-toggle instance
- * @param value - the option value to select (e.g. 'light', 'dark', 'light dark')
- */
-function selectScheme(element: RhSchemeToggle, value: string) {
-  const radio = element.shadowRoot!.querySelector<HTMLInputElement>(
-    `input[type="radio"][value="${value}"]`
-  )!;
-  radio.checked = true;
-  radio.dispatchEvent(new Event('change', { bubbles: true }));
-}
-
 describe('<rh-scheme-toggle>', function() {
   describe('simply instantiating', function() {
     let element: RhSchemeToggle;
@@ -33,6 +19,11 @@ describe('<rh-scheme-toggle>', function() {
         html`<rh-scheme-toggle></rh-scheme-toggle>`
       );
       await element.updateComplete;
+    });
+
+    afterEach(function() {
+      localStorage.removeItem('rhdsColorScheme');
+      document.body.style.removeProperty('color-scheme');
     });
 
     it('imperatively instantiates', function() {
@@ -52,6 +43,7 @@ describe('<rh-scheme-toggle>', function() {
       await expect(element).to.be.accessible();
     });
   });
+
   describe('keyboard navigation', function() {
     let element: RhSchemeToggle;
 
@@ -62,10 +54,15 @@ describe('<rh-scheme-toggle>', function() {
     });
     beforeEach(async () => await element.updateComplete);
 
+    afterEach(function() {
+      localStorage.removeItem('rhdsColorScheme');
+      document.body.style.removeProperty('color-scheme');
+    });
+
     describe('Tab', function() {
       beforeEach(press('Tab'));
 
-      it('should focus and check the System radio input', async function() {
+      it('focuses and checks System', async function() {
         const snapshot = await a11ySnapshot();
         expect(snapshot).to.have.axQuery({ name: 'System', focused: true, checked: true });
       });
@@ -73,77 +70,53 @@ describe('<rh-scheme-toggle>', function() {
       describe('Right Arrow', function() {
         beforeEach(press('ArrowRight'));
 
-        it('should focus and check the light mode radio input', async function() {
+        it('focuses and checks Light', async function() {
           const snapshot = await a11ySnapshot();
           expect(snapshot).to.have.axQuery({ name: 'Light', focused: true, checked: true });
         });
+
+        describe('Right Arrow again ', function() {
+          beforeEach(press('ArrowRight'));
+
+          it('focuses and checks Dark', async function() {
+            const snapshot = await a11ySnapshot();
+            expect(snapshot).to.have.axQuery({ name: 'Dark', focused: true, checked: true });
+          });
+        });
       });
 
-      describe('Right Arrow again ', function() {
-        beforeEach(press('ArrowRight'));
+      describe('Left Arrow', function() {
+        beforeEach(press('ArrowLeft'));
 
-        it('should focus and check the dark mode radio input', async function() {
+        it('focuses and checks Dark', async function() {
           const snapshot = await a11ySnapshot();
           expect(snapshot).to.have.axQuery({ name: 'Dark', focused: true, checked: true });
         });
       });
     });
+  });
 
-    describe('local storage', function() {
-      describe('with empty localStorage', function() {
-        beforeEach(function() {
-          localStorage.clear();
-        });
+  describe('localStorage', function() {
+    let element: RhSchemeToggle;
 
-        describe('with stored scheme set to `light dark`', function() {
-          beforeEach(async function() {
-            localStorage.setItem('rhdsColorScheme', 'light dark');
-          });
-
-          describe('adding basic toggle element', function() {
-            let element: RhSchemeToggle;
-            beforeEach(async function() {
-              element = await createFixture<RhSchemeToggle>(html`<rh-scheme-toggle></rh-scheme-toggle>`);
-            });
-            it('uses the stored scheme', async function() {
-              expect(element.scheme).to.equal('light dark');
-            });
-          });
-        });
-
-        describe('with stored scheme set to `light`', function() {
-          beforeEach(async function() {
-            localStorage.setItem('rhdsColorScheme', 'light');
-          });
-
-          describe('adding basic toggle element', function() {
-            let element: RhSchemeToggle;
-            beforeEach(async function() {
-              element = await createFixture<RhSchemeToggle>(html`<rh-scheme-toggle></rh-scheme-toggle>`);
-            });
-            it('uses the stored scheme', async function() {
-              expect(element.scheme).to.equal('light');
-            });
-          });
-        });
-      });
-
-      describe('with stored scheme set to `dark`', function() {
-        beforeEach(async function() {
-          localStorage.setItem('rhdsColorScheme', 'dark');
-        });
-
-        describe('adding basic toggle element', function() {
-          let element: RhSchemeToggle;
-          beforeEach(async function() {
-            element = await createFixture<RhSchemeToggle>(html`<rh-scheme-toggle></rh-scheme-toggle>`);
-          });
-          it('uses the stored scheme', async function() {
-            expect(element.scheme).to.equal('dark');
-          });
-        });
-      });
+    afterEach(function() {
+      localStorage.removeItem('rhdsColorScheme');
+      document.body.style.removeProperty('color-scheme');
     });
+
+    for (const scheme of ['light dark', 'light', 'dark'] as const) {
+      describe(`with stored scheme "${scheme}"`, function() {
+        beforeEach(async function() {
+          localStorage.setItem('rhdsColorScheme', scheme);
+          element = await createFixture<RhSchemeToggle>(
+            html`<rh-scheme-toggle></rh-scheme-toggle>`
+          );
+        });
+        it('uses the stored scheme', function() {
+          expect(element.scheme).to.equal(scheme);
+        });
+      });
+    }
   });
 
   describe('scheme-changed event', function() {
@@ -165,7 +138,8 @@ describe('<rh-scheme-toggle>', function() {
     });
 
     it('fires on user interaction via radio', async function() {
-      selectScheme(element, 'dark');
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ press: 'ArrowLeft' });
       await element.updateComplete;
 
       expect(events).to.have.length(1);
@@ -213,16 +187,8 @@ describe('<rh-scheme-toggle>', function() {
     });
   });
 
-  describe('radio checked state after programmatic scheme change', function() {
+  describe('programmatic scheme change', function() {
     let element: RhSchemeToggle;
-
-    /** Returns the checked radio's value, or null if none checked. */
-    function checkedValue(): string | null {
-      const radio = element.shadowRoot!.querySelector<HTMLInputElement>(
-        'input[type="radio"]:checked'
-      );
-      return radio?.value ?? null;
-    }
 
     beforeEach(async function() {
       localStorage.removeItem('rhdsColorScheme');
@@ -237,36 +203,25 @@ describe('<rh-scheme-toggle>', function() {
       document.body.style.removeProperty('color-scheme');
     });
 
-    it('checks the light radio after setting scheme to "light"', async function() {
+    it('checks the Light radio after setting scheme to "light"', async function() {
       element.scheme = 'light';
       await element.updateComplete;
-      expect(checkedValue()).to.equal('light');
+      const snapshot = await a11ySnapshot();
+      expect(snapshot).to.have.axQuery({ name: 'Light', checked: true });
     });
 
-    it('checks the dark radio after setting scheme to "dark"', async function() {
+    it('checks the Dark radio after setting scheme to "dark"', async function() {
       element.scheme = 'dark';
       await element.updateComplete;
-      expect(checkedValue()).to.equal('dark');
+      const snapshot = await a11ySnapshot();
+      expect(snapshot).to.have.axQuery({ name: 'Dark', checked: true });
     });
 
-    it('checks the system radio after setting scheme to "light dark"', async function() {
+    it('checks the System radio after setting scheme to "light dark"', async function() {
       element.scheme = 'light dark';
       await element.updateComplete;
-      expect(checkedValue()).to.equal('light dark');
-    });
-
-    it('updates checked radio across sequential changes', async function() {
-      element.scheme = 'dark';
-      await element.updateComplete;
-      expect(checkedValue()).to.equal('dark');
-
-      element.scheme = 'light';
-      await element.updateComplete;
-      expect(checkedValue()).to.equal('light');
-
-      element.scheme = 'light dark';
-      await element.updateComplete;
-      expect(checkedValue()).to.equal('light dark');
+      const snapshot = await a11ySnapshot();
+      expect(snapshot).to.have.axQuery({ name: 'System', checked: true });
     });
   });
 });

--- a/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
+++ b/elements/rh-scheme-toggle/test/rh-scheme-toggle.spec.ts
@@ -188,12 +188,16 @@ describe('<rh-scheme-toggle>', function() {
       const events: SchemeChangedEvent[] = [];
       localStorage.setItem('rhdsColorScheme', 'dark');
 
+      // Listen on document BEFORE fixture — composed event would reach here
+      const handler = (e: Event) => events.push(e as SchemeChangedEvent);
+      document.addEventListener('scheme-changed', handler);
+
       const el = await createFixture<RhSchemeToggle>(
         html`<rh-scheme-toggle></rh-scheme-toggle>`
       );
-      el.addEventListener('scheme-changed', e => events.push(e as SchemeChangedEvent));
       await el.updateComplete;
 
+      document.removeEventListener('scheme-changed', handler);
       expect(events).to.have.length(0);
     });
 


### PR DESCRIPTION
## What I did

1. Added `scheme-changed` custom event to `<rh-scheme-toggle>`
2. Fixed a bug where programmatic `scheme` property changes did not update the radio button UI
3. Added an events demo and tests

## Testing Instructions

1. Visit the [events demo](http://deploy-preview-2974--red-hat-design-system.netlify.app/elements/scheme-toggle/demo/) on the DP.
2. Click each radio button (light, dark, system).
3. Ensure the "Events Fired" output logs each scheme value.
4. Open the browser console and run the following lines individually:
   ```js
   const el = document.querySelector('#scheme-toggle');
   el.scheme = 'dark';
   el.scheme = 'light dark';
   el.scheme = 'light';
   ```
5. Ensure each radio button highlights correctly after each assignment.
6. Ensure the output shows `dark, light dark, light`.
7. Refresh the page — output should show "No events yet" (event does not fire on initial load from localStorage).
8. Ensure `localStorage.rhdsColorScheme` updates after each change (DevTools > Application > Storage > LocalStorage).
9. Test for accessibility.
   * Ensure the fieldset has an accessible legend
   * Ensure each radio is appropriately labeled
   * Ensure keyboard navigation still works (Tab to focus, arrow keys to switch)
   * Ensure VoiceOver reads the correct radio when light/dark/system is selected (or programatically selected)
10. Ensure changeset is appropriate (do we need another?).

## Notes to Reviewers

### Bug fix: radio buttons not updating on programmatic changes

Two pre-existing issues were found and fixed:

1. **`#schemeCheck()` not called on programmatic changes** — the checked-state flags (`#isLight`, `#isDark`, `#isSystem`) were only synced from `connectedCallback` and user interaction (`#onChange`). Replaced with `willUpdate()` so flags sync before every render.
2. **`?checked` attribute binding vs `.checked` property binding** — Lit's `?checked` toggles the HTML attribute, which only controls initial state for radio buttons. After any DOM interaction, only the `checked` property matters. Changed to `.checked` property bindings.

### Event design

The `scheme-changed` event mirrors the implementation in `<rh-scheme-dropdown>` ([PR #2959](https://github.com/RedHat-UX/red-hat-design-system/pull/2959)).