### PR TITLE
docs: `since` and `new` status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: scripts/version.sh
           publish: npx changeset publish
           commit: "chore: prepare release"
           title: "chore: prepare release"

--- a/docs/_includes/partials/component/header.njk
+++ b/docs/_includes/partials/component/header.njk
@@ -2,44 +2,61 @@
 {%- set headingId = (heading if heading else title) | lower | slug -%}
 {%- set manifest = doc and doc.docsPage and doc.docsPage.manifest -%}
 {%- if manifest == doc and doc.docsPage -%}
-  {% set manifest = null %}
+{% set manifest = null %}
 {% endif -%}
 {%- set prettyName -%}{{ (doc.alias or doc.slug or element.slug or '') | deslugify | capitalize }}{% endset %}
 {%- set tabs = doc.tabs -%}
 {%- if not tabs and subnav.collection -%}
-  {% set tabs = collections[subnav.collection] | sort(attribute = "data.subnav.order") %}
+{% set tabs = collections[subnav.collection] | sort(attribute = "data.subnav.order") %}
 {%- endif -%}
 {%- set demos = manifest and manifest.getDemos(doc.docsPage.tagName) -%}
+{%- set latestVersion = "v" + packageinfo.version -%}
 
-<script type="module" data-helmet>
-  import '@uxdot/elements/uxdot-header.js';
-</script>
+<script type="module"
+        data-helmet>
+          import '@uxdot/elements/uxdot-header.js';
+        </script>
 
 {% if tabs %}
-<script type="module" data-helmet>
-  import '@rhds/elements/rh-subnav/rh-subnav.js';
-</script>
+<script type="module"
+        data-helmet>
+          import '@rhds/elements/rh-subnav/rh-subnav.js';
+        </script>
 {% endif %}
 
 <uxdot-header {% if tabs %}has-subnav{% endif %}>
   {#- TODO: cheap hack here to fix data spaghetti from demos page -#}
-  <h1 id="{{ headingId }}" class="page-title">
+  <h1 id="{{ headingId }}"
+      class="page-title">
     {{ prettyName or heading or title }}
     {% if doc.planned %}
-    <rh-tag icon="notification-fill" color="gray">Planned</rh-tag>
+    <rh-tag icon="notification-fill"
+            color="gray">Planned</rh-tag>
+    {% endif %}
+    {% if doc.elementData and doc.elementData.since %}
+    <rh-tag color="gray"
+            variant="outline"
+            {%- if doc.elementData.since == latestVersion %}
+            icon="new"
+            icon-set="ui"
+            {%- endif %}
+            href="https://github.com/RedHat-UX/red-hat-design-system/releases/tag/{{ doc.elementData.since }}">
+      Since {{ doc.elementData.since }}
+    </rh-tag>
     {% endif %}
   </h1>
 
   {% if tabs %}
-  <rh-subnav slot="subnav" accessible-label="{{ heading }}">
-  {% for tab in tabs %}
+  <rh-subnav slot="subnav"
+             accessible-label="{{ heading }}">
+    {% for tab in tabs %}
     {%- set pageUrl = (doc and doc.permalink | replace('index.html', '')) or page.url -%}
     {%- set title = tab.pageTitle or tab.data.title -%}
     {%- set active = tab.url == pageUrl -%}
     <rh-navigation-link href="{{ tab.url }}"
-       {{- ' current-page' if active -}}
-       {{- ' hidden' if hidden -}}>{{ title }}</rh-navigation-link>
-  {%- endfor -%}
+                        {{- ' current-page' if active -}}
+                        {{- ' hidden' if hidden -}}>{{ title }}</rh-navigation-link>
+    {%- endfor -%}
   </rh-subnav>
   {% endif %}
 </uxdot-header>

--- a/docs/_includes/partials/component/sidenav.njk
+++ b/docs/_includes/partials/component/sidenav.njk
@@ -29,7 +29,8 @@
                               href="{{ href }}"
                               {{ 'current-page' if active }}>
             {{- doc.alias or (doc.slug | deslugify) -}}
-            {%- if doc.planned -%}<rh-tag icon="notification-fill" color="purple" size="compact">Planned</rh-tag>{%- endif -%}
+            {%- if doc.planned -%}<rh-tag icon="notification-fill" color="purple" size="compact">Planned</rh-tag>
+            {%- elif doc.elementData and doc.elementData.since == "v" + packageinfo.version -%}<rh-tag icon="new" icon-set="ui" color="green" size="compact">New</rh-tag>{%- endif -%}
           </rh-navigation-link>
           {% endif %}
           {%- endfor -%}

--- a/docs/schemas/element-data.schema.json
+++ b/docs/schemas/element-data.schema.json
@@ -79,6 +79,11 @@
         "description": "Element tag name (e.g., 'rh-button') or pattern name (e.g., 'filter', 'link')"
       },
       "uniqueItems": true
+    },
+    "since": {
+      "type": "string",
+      "pattern": "^v\\d+\\.\\d+\\.\\d+$",
+      "description": "The first stable release version that included this element (e.g., 'v1.0.0')"
     }
   },
   "required": ["type", "overallStatus", "libraries"],

--- a/docs/styles/pages/backpage.css
+++ b/docs/styles/pages/backpage.css
@@ -112,6 +112,10 @@
 
   uxdot-header {
     grid-area: header;
+
+    & > h1 > rh-tag {
+      vertical-align: middle;
+    }
   }
 
   :where(article .container rh-code-block) {

--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -200,6 +200,10 @@
 
   uxdot-sidenav {
     grid-area: nav;
+
+    rh-tag {
+      margin-inline-start: var(--rh-space-md);
+    }
   }
 
   rh-footer-universal {

--- a/elements/rh-accordion/docs/data.yaml
+++ b/elements/rh-accordion/docs/data.yaml
@@ -12,3 +12,4 @@ relatedItems:
   - disclosure
   - filter
   - rh-footer
+since: v1.0.0

--- a/elements/rh-alert/docs/data.yaml
+++ b/elements/rh-alert/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-button
   - rh-badge
   - rh-popover
+since: v1.0.0

--- a/elements/rh-announcement/docs/data.yaml
+++ b/elements/rh-announcement/docs/data.yaml
@@ -8,3 +8,4 @@ libraries:
   rhds: ready
   shared: planned
   docs: ready
+since: v3.0.0

--- a/elements/rh-audio-player/docs/data.yaml
+++ b/elements/rh-audio-player/docs/data.yaml
@@ -10,3 +10,4 @@ libraries:
   docs: ready
 relatedItems:
   - video-thumbnail
+since: v1.1.0

--- a/elements/rh-avatar/docs/data.yaml
+++ b/elements/rh-avatar/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-badge
   - rh-card
   - rh-tag
+since: v1.0.0

--- a/elements/rh-back-to-top/docs/data.yaml
+++ b/elements/rh-back-to-top/docs/data.yaml
@@ -10,3 +10,4 @@ libraries:
   rhds: ready
   shared: planned
   docs: inProgress
+since: v1.4.0

--- a/elements/rh-badge/docs/data.yaml
+++ b/elements/rh-badge/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-alert
   - rh-avatar
   - rh-tag
+since: v1.0.0

--- a/elements/rh-blockquote/docs/data.yaml
+++ b/elements/rh-blockquote/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-card
   - rh-statistic
   - rh-video-embed
+since: v1.0.0

--- a/elements/rh-breadcrumb/docs/data.yaml
+++ b/elements/rh-breadcrumb/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-link
   - rh-navigation-secondary
   - rh-subnav
+since: v2.0.0

--- a/elements/rh-button-group/docs/data.yaml
+++ b/elements/rh-button-group/docs/data.yaml
@@ -12,3 +12,4 @@ relatedItems:
   - rh-button
   - rh-cta
   - rh-scheme-toggle
+since: v4.0.2

--- a/elements/rh-button/docs/data.yaml
+++ b/elements/rh-button/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-alert
   - rh-cta
   - search-bar
+since: v1.0.0

--- a/elements/rh-card/docs/data.yaml
+++ b/elements/rh-card/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-avatar
   - link
   - link-with-icon
+since: v1.1.0

--- a/elements/rh-chip/docs/data.yaml
+++ b/elements/rh-chip/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-badge
   - filter
   - rh-tag
+since: v3.0.0

--- a/elements/rh-code-block/docs/data.yaml
+++ b/elements/rh-code-block/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-blockquote
   - rh-card
   - rh-dialog
+since: v1.1.0

--- a/elements/rh-cta/docs/data.yaml
+++ b/elements/rh-cta/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-button
   - link
   - link-with-icon
+since: v1.0.0

--- a/elements/rh-dialog/docs/data.yaml
+++ b/elements/rh-dialog/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - announcement
   - sticky-banner
   - sticky-card
+since: v1.0.0

--- a/elements/rh-disclosure/docs/data.yaml
+++ b/elements/rh-disclosure/docs/data.yaml
@@ -14,3 +14,4 @@ libraries:
 relatedItems:
   - rh-accordion
   - rh-jump-links
+since: v3.0.0

--- a/elements/rh-footer/docs/data.yaml
+++ b/elements/rh-footer/docs/data.yaml
@@ -13,3 +13,4 @@ relatedItems:
   - rh-popover
   - rh-tooltip
   - rh-site-status
+since: v1.0.0

--- a/elements/rh-health-index/docs/data.yaml
+++ b/elements/rh-health-index/docs/data.yaml
@@ -12,3 +12,4 @@ relatedItems:
   - rh-avatar
   - rh-badge
   - rh-tag
+since: v2.0.0

--- a/elements/rh-icon/docs/data.yaml
+++ b/elements/rh-icon/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-alert
   - rh-card
   - rh-statistic
+since: v2.0.0

--- a/elements/rh-jump-links/docs/data.yaml
+++ b/elements/rh-jump-links/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-disclosure
   - rh-pagination
   - rh-tabs
+since: v3.0.0

--- a/elements/rh-menu-dropdown/docs/data.yaml
+++ b/elements/rh-menu-dropdown/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-button
   - rh-disclosure
   - rh-navigation-primary
+since: v4.0.0

--- a/elements/rh-menu/docs/data.yaml
+++ b/elements/rh-menu/docs/data.yaml
@@ -9,3 +9,4 @@ libraries:
   rhds: ready
   shared: planned
   docs: planned
+since: v1.1.0

--- a/elements/rh-navigation-link/docs/data.yaml
+++ b/elements/rh-navigation-link/docs/data.yaml
@@ -13,3 +13,4 @@ relatedItems:
   - rh-navigation-secondary
   - rh-navigation-vertical
   - rh-subnav
+since: v4.0.0

--- a/elements/rh-navigation-primary/docs/data.yaml
+++ b/elements/rh-navigation-primary/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-footer
   - rh-navigation-secondary
   - rh-skip-link
+since: v3.0.0

--- a/elements/rh-navigation-secondary/docs/data.yaml
+++ b/elements/rh-navigation-secondary/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-navigation
   - skip-navigation
   - rh-subnav
+since: v1.0.0

--- a/elements/rh-navigation-vertical/docs/data.yaml
+++ b/elements/rh-navigation-vertical/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-navigation-primary
   - rh-navigation-secondary
   - rh-subnav
+since: v4.0.0

--- a/elements/rh-pagination/docs/data.yaml
+++ b/elements/rh-pagination/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-jump-links
   - rh-progress-stepper
   - rh-tabs
+since: v1.0.0

--- a/elements/rh-progress-stepper/docs/data.yaml
+++ b/elements/rh-progress-stepper/docs/data.yaml
@@ -7,8 +7,7 @@ aka:
   - Wizard
   - Stepper
 description: >-
-  Progress steps guide a user through a task with multiple sequential steps toward the completion of
-  a linear process.
+  Progress steps guide a user through a task with multiple sequential steps toward the completion of a linear process.
 libraries:
   figma: ready
   rhds: ready
@@ -18,3 +17,4 @@ relatedItems:
   - rh-jump-links
   - rh-pagination
   - rh-tabs
+since: v3.1.0

--- a/elements/rh-readtime/docs/data.yaml
+++ b/elements/rh-readtime/docs/data.yaml
@@ -8,3 +8,4 @@ libraries:
   rhds: ready
   shared: planned
   docs: planned
+since: v4.1.0

--- a/elements/rh-scheme-toggle/docs/data.yaml
+++ b/elements/rh-scheme-toggle/docs/data.yaml
@@ -16,3 +16,4 @@ libraries:
 relatedItems:
   - rh-button
   - rh-switch
+since: v3.1.0

--- a/elements/rh-select/docs/data.yaml
+++ b/elements/rh-select/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-menu-dropdown
   - rh-scheme-toggle
   - rh-switch
+since: v4.1.0

--- a/elements/rh-site-status/docs/data.yaml
+++ b/elements/rh-site-status/docs/data.yaml
@@ -12,3 +12,4 @@ relatedItems:
   - rh-alert
   - rh-footer
   - rh-health-index
+since: v1.4.0

--- a/elements/rh-skeleton/docs/data.yaml
+++ b/elements/rh-skeleton/docs/data.yaml
@@ -13,3 +13,4 @@ libraries:
   docs: ready
 relatedItems:
   - rh-spinner
+since: v3.1.0

--- a/elements/rh-skip-link/docs/data.yaml
+++ b/elements/rh-skip-link/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-navigation
   - rh-navigation-secondary
   - rh-subnav
+since: v1.4.0

--- a/elements/rh-spinner/docs/data.yaml
+++ b/elements/rh-spinner/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - form
   - search-bar
   - rh-tag
+since: v1.0.0

--- a/elements/rh-stat/docs/data.yaml
+++ b/elements/rh-stat/docs/data.yaml
@@ -13,3 +13,4 @@ libraries:
   docs: ready
 relatedItems:
   - rh-blockquote
+since: v1.0.0

--- a/elements/rh-subnav/docs/data.yaml
+++ b/elements/rh-subnav/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-navigation
   - rh-navigation-secondary
   - skip-navigation
+since: v1.0.0

--- a/elements/rh-surface/docs/data.yaml
+++ b/elements/rh-surface/docs/data.yaml
@@ -8,3 +8,4 @@ libraries:
   rhds: ready
   shared: ready
   docs: ready
+since: v1.3.0

--- a/elements/rh-switch/docs/data.yaml
+++ b/elements/rh-switch/docs/data.yaml
@@ -13,3 +13,4 @@ libraries:
 relatedItems:
   - rh-button
   - form
+since: v2.0.0

--- a/elements/rh-table/docs/data.yaml
+++ b/elements/rh-table/docs/data.yaml
@@ -13,3 +13,4 @@ libraries:
   docs: ready
 relatedItems:
   - rh-code-block
+since: v1.2.0

--- a/elements/rh-tabs/docs/data.yaml
+++ b/elements/rh-tabs/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-jump-links
   - rh-pagination
   - rh-progress-stepper
+since: v1.0.0

--- a/elements/rh-tag/docs/data.yaml
+++ b/elements/rh-tag/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-badge
   - rh-button
   - rh-chip
+since: v1.0.0

--- a/elements/rh-tile/docs/data.yaml
+++ b/elements/rh-tile/docs/data.yaml
@@ -14,3 +14,4 @@ relatedItems:
   - rh-cta
   - rh-card
   - form
+since: v1.2.0

--- a/elements/rh-timestamp/docs/data.yaml
+++ b/elements/rh-timestamp/docs/data.yaml
@@ -14,3 +14,4 @@ libraries:
 relatedItems:
   - rh-blockquote
   - rh-statistic
+since: v1.2.0

--- a/elements/rh-tooltip/docs/data.yaml
+++ b/elements/rh-tooltip/docs/data.yaml
@@ -15,3 +15,4 @@ relatedItems:
   - rh-footer
   - form
   - rh-popover
+since: v1.0.0

--- a/elements/rh-video-embed/docs/data.yaml
+++ b/elements/rh-video-embed/docs/data.yaml
@@ -13,3 +13,4 @@ libraries:
 relatedItems:
   - rh-audio-player
   - rh-button
+since: v2.0.0

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,12 @@ import htmleslint from '@html-eslint/eslint-plugin';
 export default tseslint.config(
   ...pfe,
   {
+    name: 'local/ecmaVersion',
+    languageOptions: {
+      ecmaVersion: 2025,
+    },
+  },
+  {
     plugins: {
       '@html-eslint': htmleslint,
     },

--- a/scripts/since.js
+++ b/scripts/since.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 // Called by changesets/action after the version command.
 // Sets `since` on any element shipping for the first time.
 import { glob, readFile, writeFile } from 'node:fs/promises';
 import yaml from 'js-yaml';
-import pkgjson from '../package.json' with { type: 'json' }
+import pkgjson from '../package.json' with { type: 'json' };
 
 const since = `v${pkgjson.version}`;
 
@@ -11,9 +12,10 @@ for await (const dataPath of glob('elements/*/docs/data.yaml')) {
   const content = await readFile(dataPath, 'utf8');
   const data = yaml.load(content);
 
-  if (data.since) continue;
-  if (data.libraries?.rhds === 'planned') continue;
+  if (data.since || data.libraries?.rhds === 'planned') {
+    continue;
+  }
 
-  await writeFile(dataPath, content.trimEnd() + `\nsince: ${since}\n`);
+  await writeFile(dataPath, `${content.trimEnd()}\nsince: ${since}\n`);
   console.log(`Set since: ${since} for ${data.tagName}`);
 }

--- a/scripts/since.js
+++ b/scripts/since.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Called by changesets/action after the version command.
+// Sets `since` on any element shipping for the first time.
+import { glob, readFile, writeFile } from 'node:fs/promises';
+import yaml from 'js-yaml';
+import pkgjson from '../package.json' with { type: 'json' }
+
+const since = `v${pkgjson.version}`;
+
+for await (const dataPath of glob('elements/*/docs/data.yaml')) {
+  const content = await readFile(dataPath, 'utf8');
+  const data = yaml.load(content);
+
+  if (data.since) continue;
+  if (data.libraries?.rhds === 'planned') continue;
+
+  await writeFile(dataPath, content.trimEnd() + `\nsince: ${since}\n`);
+  console.log(`Set since: ${since} for ${data.tagName}`);
+}

--- a/scripts/validate-element-data.ts
+++ b/scripts/validate-element-data.ts
@@ -136,11 +136,13 @@ async function validateElementData(): Promise<ValidationResult> {
         });
       }
 
-      // Check if element has implementation but is marked as 'planned'
+      // Element has implementation but is still marked as 'planned'
       if (hasImpl && yamlData.libraries.rhds === 'planned') {
-        result.warnings.push({
+        result.valid = false;
+        result.errors.push({
           tagName,
-          message: 'Element has implementation files but is marked as planned in RHDS',
+          type: 'consistency',
+          message: 'Element has implementation files but libraries.rhds is still "planned"',
         });
       }
     } else {

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+set -eou pipefail
+npx changeset version
+scripts/since.js

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 npx changeset version
 scripts/since.js


### PR DESCRIPTION

## What I did

- Added `since` field to elements/*/docs/data.yaml
- Added "Since vX.Y.Z" tags to element page headers, linked to release
- Added "New" tag to sidebar for elements from the current release
- Automate addition of `since` to element data in release workflow
- Fail PRs which neglect to promote planned elements upon implementation

## Testing Instructions

1. Click around the DP's /elements/ section - observe "New" tag in sidebar, "Since" tags in header

## Notes to Reviewers

@coreyvickery I made the header tags `vertical-align: middle`, which should align them with baseline ("a", not "p" or "d"). Also PTAL at the "New" tag in sidebar.

After https://github.com/webcomponents/custom-elements-manifest/issues/146, we can move this to jsdoc, and derive it from `cem` (would require changes to the version script, or manual tagging)