### PR TITLE
fix(dev-server): strip YAML frontmatter from demo pages

### DIFF
--- a/patches/@patternfly+pfe-tools+6.0.1.patch
+++ b/patches/@patternfly+pfe-tools+6.0.1.patch
@@ -1,0 +1,32 @@
+diff --git a/node_modules/@patternfly/pfe-tools/custom-elements-manifest/lib/Manifest.js b/node_modules/@patternfly/pfe-tools/custom-elements-manifest/lib/Manifest.js
+index 2d5ecfe..712a955 100644
+--- a/node_modules/@patternfly/pfe-tools/custom-elements-manifest/lib/Manifest.js
++++ b/node_modules/@patternfly/pfe-tools/custom-elements-manifest/lib/Manifest.js
+@@ -90,10 +90,10 @@ export class Manifest {
+     /**
+      */
+     getTagNames() {
+-        return this.manifest?.modules
++        return [...new Set(this.manifest?.modules
+             ?.flatMap?.(m => m.exports
+             ?.filter?.(x => x.kind === 'custom-element-definition')
+-            ?.map?.(x => x.name)) ?? [];
++            ?.map?.(x => x.name)) ?? [])];
+     }
+     /**
+      * @param tagName tag to get attributes for
+diff --git a/node_modules/@patternfly/pfe-tools/test/playwright/PfeDemoPage.js b/node_modules/@patternfly/pfe-tools/test/playwright/PfeDemoPage.js
+index e29a423..6232821 100644
+--- a/node_modules/@patternfly/pfe-tools/test/playwright/PfeDemoPage.js
++++ b/node_modules/@patternfly/pfe-tools/test/playwright/PfeDemoPage.js
+@@ -10,8 +10,9 @@ export class PfeDemoPage {
+     async navigate(pathnameOrOptions) {
+         const selectorOverride = typeof pathnameOrOptions === 'string' ? undefined
+             : pathnameOrOptions?.selector;
++        const slug = this.tagName.replace(/^pf-(?:v\d+-)?/, '');
+         const pathname = typeof pathnameOrOptions === 'string' ? pathnameOrOptions
+-            : `${this.workspace}/${this.tagName.replace('pf-', '')}/demo`;
++            : `${this.workspace}/${slug}/demo`;
+         const url = new URL(pathname, this.origin).toString();
+         // eslint-disable-next-line no-console
+         console.log(`NAVIGATING to ${url}`);

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -10,6 +10,7 @@ import {
   getAttribute,
   getTextContent,
   isElementNode,
+  isTextNode,
   query,
   removeAttribute,
   setAttribute,
@@ -123,6 +124,38 @@ function transformDevServerHTML(document) {
   }
 }
 
+
+const FRONTMATTER_RE = /^---\n[\s\S]*?\n---\n?/;
+
+/**
+ * Strip YAML frontmatter from demo HTML served by pfe-tools' template middleware.
+ * pfe-tools reads demo files raw, so frontmatter appears as visible text.
+ *
+ * NB: can be removed once we migrate to cem serve
+ */
+export function stripFrontmatterPlugin() {
+  return {
+    name: 'strip-frontmatter',
+    transform(context) {
+      if (!context.response.is('html') || typeof context.body !== 'string') {
+        return;
+      }
+      const document = parse(context.body);
+      const demoDiv = query(document, node =>
+        isElementNode(node)
+          && node.tagName === 'div'
+          && getAttribute(node, 'data-demo') != null);
+      if (!demoDiv || !isElementNode(demoDiv)) {
+        return;
+      }
+      const firstText = demoDiv.childNodes.find(n => isTextNode(n));
+      if (firstText && isTextNode(firstText) && FRONTMATTER_RE.test(firstText.value)) {
+        firstText.value = firstText.value.replace(FRONTMATTER_RE, '');
+        return { body: serialize(document) };
+      }
+    },
+  };
+}
 
 /**
  * Web dev server plugin to strip CSS import attributes from element source files
@@ -280,6 +313,7 @@ export default pfeDevServerConfig({
     },
   ],
   plugins: [
+    stripFrontmatterPlugin(),
     stripCssImportAttributesPlugin(),
     {
       name: 'watch-demos',

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -125,7 +125,7 @@ function transformDevServerHTML(document) {
 }
 
 
-const FRONTMATTER_RE = /^---\n[\s\S]*?\n---\n?/;
+const FRONTMATTER_RE = /^\s*---\n[\s\S]*?\n---\n?/;
 
 /**
  * Strip YAML frontmatter from demo HTML served by pfe-tools' template middleware.


### PR DESCRIPTION
## Summary
- Add WDS plugin to strip YAML frontmatter from demo HTML before serving. pfe-tools' template middleware reads demo files raw, so frontmatter from #2951 renders as visible text. The plugin uses parse5 to find the `<div data-demo>` element and strip frontmatter from its first text node. Can be removed once we migrate to cem serve.
- Add patch-package patch for `@patternfly/pfe-tools@6.0.1` backporting two fixes from `staging/pfv6`:
  - `Manifest.getTagNames()` deduplication via `Set`
  - `PfeDemoPage.navigate()` slug regex for versioned `pf-v5-*` tag prefixes

## Test plan
- [ ] Start dev server, navigate to any element demo page (e.g. `/elements/rh-button/`)
- [ ] Verify no `---` frontmatter text visible in the rendered demo
- [ ] Verify demo content renders correctly
- [ ] Run `npm install` and verify patch applies cleanly