### PR TITLE
fix(code-block): replace JS line numbers with CSS counters

### DIFF
--- a/docs/_plugins/markdown-it.ts
+++ b/docs/_plugins/markdown-it.ts
@@ -54,6 +54,19 @@ const rhdsPermalink = makePermalink((_slug, _opts, _anchorOpts, state, idx) => {
   );
 });
 
+function wrapCodeLines(codeHtml: string): string {
+  return codeHtml.replace(
+    /(<code[^>]*>)([\s\S]*?)(<\/code>)/,
+    (_, open: string, content: string, close: string) => {
+      const lines = content.split('\n');
+      const wrapped = lines.map(line =>
+        `<span class="rh-code-block-line"><span class="rh-code-block-line-content">${line || ' '}</span></span>`,
+      ).join('\n');
+      return `${open}${wrapped}${close}`;
+    },
+  );
+}
+
 function rhdsCodeBlock(md: MarkdownIt) {
   const orig = md.renderer.rules.fence;
   // custom renderer for fences
@@ -67,12 +80,13 @@ function rhdsCodeBlock(md: MarkdownIt) {
     const normalized = block?.replaceAll('-', '');
     if (normalized?.endsWith('codeblock')) {
       const redactedToken = Object.assign(token, { info });
+      const wrapped = wrapCodeLines(rendered);
       return html`
         <rh-code-block ${normalized.startsWith('rh' ) ? 'full-height' : ''}
                        dedent
                        actions="${actions.join(' ')}"
                        highlighting="prerendered"
-                       ${slf.renderAttrs(redactedToken)}>${rendered}</rh-code-block>`.trim();
+                       ${slf.renderAttrs(redactedToken)}>${wrapped}</rh-code-block>`.trim();
     } else {
       return rendered;
     }

--- a/elements/rh-code-block/demo/below-the-fold.html
+++ b/elements/rh-code-block/demo/below-the-fold.html
@@ -1,9 +1,8 @@
 ---
-description: Code block positioned below the fold to test content-visibility optimization.
+description: Code block positioned below the fold to test CSS counter line numbers with content-visibility.
 ---
 <section class="tall-as-screen">
-  <p>Expect line numbers to not be calculated until just before code block scrolls into view</p>
-  <p>Expect line numbers to appear without flash when scrolling down to view codeblock</p>
+  <p>CSS counter line numbers render automatically via content-visibility, no JS timing dependency</p>
   <p><strong>Scroll down to view code block</strong></p>
 </section>
 
@@ -21,9 +20,7 @@ description: Code block positioned below the fold to test content-visibility opt
 </rh-code-block>
 
 <section class="tall-as-screen">
-  <p>Expect only the first code block to have computed line numbers</p>
-  <p>Expect second block's line numbers to compute only just before it scrolls into view</p>
-  <p><strong>Scroll down to view code block</strong></p>
+  <p><strong>Scroll down to view second code block</strong></p>
 </section>
 
 <rh-code-block>
@@ -41,28 +38,6 @@ description: Code block positioned below the fold to test content-visibility opt
 
 <script type="module">
   import '@rhds/elements/rh-code-block/rh-code-block.js';
-  import { RhAlert } from '@rhds/elements/rh-alert/rh-alert.js'
-  import { html } from 'lit';
-  RhAlert.toast({
-    persistent: true,
-    state: 'info',
-    message: html`
-      <dl>
-        <dt>1st code block:</dt>
-        <dd><em>Pending</em></dd>
-        <dt>2nd code block:</dt>
-        <dd><em>Pending</em></dd>
-      </dl>
-    `,
-  });
-
-  const [fst, snd] = document.querySelectorAll('rh-code-block');
-  const [fstP, sndP] = document.querySelectorAll('rh-alert dd em');
-
-  addEventListener('scroll', function() {
-    fstP.textContent = fst.shadowRoot.querySelectorAll('#line-numbers li').length ? 'Computed' : 'Pending'
-    sndP.textContent = snd.shadowRoot.querySelectorAll('#line-numbers li').length ? 'Computed' : 'Pending'
-  }, { passive: true });
 </script>
 
 <style>

--- a/elements/rh-code-block/prism.ts
+++ b/elements/rh-code-block/prism.ts
@@ -1,7 +1,5 @@
 import type { RhCodeBlock } from './rh-code-block.js';
 import { Prism } from 'prism-esm';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { html } from 'lit';
 
 const prism = new Prism({ manual: true });
 
@@ -35,8 +33,7 @@ async function autoloader(language: RhCodeBlock['language']) {
  */
 export async function highlight(textContent: string, language: RhCodeBlock['language']) {
   await autoloader(language);
-  const highlighted = prism.highlight(textContent, prism.languages[language!], language!);
-  return html`<code class="language-${language}">${unsafeHTML(highlighted)}</code>`;
+  return prism.highlight(textContent, prism.languages[language!], language!);
 }
 
 export { prismStyles, preRenderedLightDomStyles } from './prism.css.js';

--- a/elements/rh-code-block/rh-code-block-lightdom.css
+++ b/elements/rh-code-block/rh-code-block-lightdom.css
@@ -2,4 +2,45 @@ rh-code-block {
   & dd {
     margin: 0;
   }
+
+  & code[class*='language-']:has(.rh-code-block-line) {
+    counter-reset: line-number;
+    display: grid;
+    grid-template-columns: min-content 1fr;
+    column-gap: var(--rh-space-lg, 16px);
+    align-items: start;
+    font-family: var(--rh-font-family-code, RedHatMono, 'Red Hat Mono', 'Courier New', Courier, monospace);
+    line-height: var(--rh-line-height-code, 1.5);
+  }
+
+  & code[class*='language-'] .rh-code-block-line {
+    counter-increment: line-number;
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+  }
+
+  & code[class*='language-'] .rh-code-block-line::before {
+    content: counter(line-number);
+    text-align: end;
+    padding-inline-end: var(--rh-space-md, 8px);
+    color: var(--rh-color-text-secondary);
+    font-weight: var(--rh-font-weight-code-regular, 400);
+    border-inline-end: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+    user-select: none;
+    pointer-events: none;
+  }
+
+  & code[class*='language-'] .rh-code-block-line-content {
+    white-space: pre;
+    word-wrap: initial;
+  }
+
+  &[line-numbers='hidden'] code[class*='language-'] {
+    grid-template-columns: 1fr;
+  }
+
+  &[line-numbers='hidden'] code[class*='language-'] .rh-code-block-line::before {
+    display: none;
+  }
 }

--- a/elements/rh-code-block/rh-code-block.css
+++ b/elements/rh-code-block/rh-code-block.css
@@ -59,20 +59,8 @@
 #container,
 #content-lines,
 #content,
-#prism-output,
-#sizers {
+#code-with-line-numbers {
   max-width: 100%;
-}
-
-#prism-output {
-  margin: 0;
-
-  & code {
-    font-size: inherit;
-    font-family: inherit;
-    font-weight: inherit;
-    line-height: inherit;
-  }
 }
 
 #container {
@@ -344,19 +332,9 @@
         transparent 100%
       );
 
-  &:not(.line-numbers) {
-    &:not(.isIntersecting) {
-      content-visibility: visible;
-    }
-  }
-
-  &.isIntersecting {
-    content-visibility: visible;
-  }
 }
 
-#sizers,
-#prism-output,
+#code-with-line-numbers,
 #content {
   display: block;
 
@@ -370,8 +348,6 @@
   grid-area: code;
 }
 
-#sizers,
-#prism-output,
 #content::slotted(:is(script, pre)) {
   display: inline;
   white-space: var(--_code-white-space, pre);
@@ -424,52 +400,43 @@
   width: 100%;
 }
 
-#sizers {
-  position: absolute;
-  min-width: 100%;
-  width: 100%;
-  opacity: 0;
-  pointer-events: none;
-  z-index: -10000;
+#code-with-line-numbers {
+  counter-reset: line-number;
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  column-gap: var(--_line-number-code-gap);
+  align-items: start;
 
-  /** Sizer line height */
+  /** Code line height */
   line-height: var(--rh-line-height-code, 1.5);
-}
 
-#line-numbers {
-  pointer-events: none;
-  overflow-y: hidden;
-  margin: 0;
-  grid-area: lines;
-  list-style-type: none;
-  padding-inline: 0 var(--_line-number-code-gap);
-  text-align: end;
+  & .line {
+    counter-increment: line-number;
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
 
-  /** Line number typeface */
-  font-family: var(--rh-font-family-code, RedHatMono, 'Red Hat Mono', 'Courier New', Courier, monospace);
-  -webkit-text-size-adjust: 100%; /* stylelint-disable-line property-no-vendor-prefix */
-  text-size-adjust: 100%;
+    &::before {
+      content: counter(line-number);
+      text-align: end;
+      padding-inline-end: var(--_line-number-code-gap);
 
-  /** Line number text uses the secondary text design token for reduced emphasis */
-  color: var(--rh-color-text-secondary);
+      /** Line number text uses the secondary text design token for reduced emphasis */
+      color: var(--rh-color-text-secondary);
 
-  /** Line number font weight */
-  font-weight: var(--rh-font-weight-code-regular, 400);
+      /** Line number font weight */
+      font-weight: var(--rh-font-weight-code-regular, 400);
 
-  /** Separator width between line numbers and code content */
-  border-inline-end-width: var(--rh-border-width-sm, 1px);
-  border-inline-end-style: solid;
+      /** Separator width between line numbers and code content */
+      border-inline-end: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+      user-select: none;
+      pointer-events: none;
+    }
+  }
 
-  /* stylelint-disable declaration-block-no-redundant-longhand-properties */
-
-  /** Separator color between line numbers and code uses the subtle border token */
-  border-inline-end-color: var(--rh-color-border-subtle);
-  /* stylelint-enable declaration-block-no-redundant-longhand-properties */
-
-  li {
-    /** Line number item height */
-    line-height: var(--rh-line-height-code, 1.5);
-    display: block;
+  & .line-content {
+    white-space: var(--_code-white-space, pre);
+    word-wrap: var(--_code-word-wrap, initial);
   }
 }
 
@@ -583,8 +550,12 @@
   grid-template-columns: 1fr;
 }
 
-:host([line-numbers='hidden']) #line-numbers {
-  display: none;
+:host([line-numbers='hidden']) #code-with-line-numbers {
+  grid-template-columns: 1fr;
+
+  & .line::before {
+    display: none;
+  }
 }
 
 #container.expandable #content-lines {

--- a/elements/rh-code-block/rh-code-block.ts
+++ b/elements/rh-code-block/rh-code-block.ts
@@ -1,12 +1,10 @@
-import type { DirectiveResult } from 'lit/directive.js';
-
-import { CSSResult, LitElement, html, isServer, type PropertyValues } from 'lit';
+import { CSSResult, LitElement, type TemplateResult, html, isServer, type PropertyValues } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 import { state } from 'lit/decorators/state.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { styleMap } from 'lit/directives/style-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import { SlotController } from '@patternfly/pfe-core/controllers/slot-controller.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
@@ -26,17 +24,6 @@ function dedent(str: string) {
   const match = stripped.match(/^\s+/);
   const out = match ? stripped.replace(new RegExp(`^${match[0]}`, 'gm'), '') : str;
   return out.trim();
-}
-
-interface CodeLineHeightsInfo {
-  lines: string[];
-  lineHeights: (number | undefined)[];
-  sizer: HTMLElement;
-  oneLinerHeight: number;
-}
-
-interface ContentVisibilityAutoStateChangeEvent extends Event {
-  skipped: boolean;
 }
 
 const prismApplyPromises = new WeakMap();
@@ -191,27 +178,16 @@ export class RhCodeBlock extends LitElement {
     'legend',
   );
 
-  #prismOutput?: DirectiveResult;
+  #prismHighlightedHtml?: string;
 
   #copyFeedbackTimeout?: ReturnType<typeof setTimeout>;
 
-  #isIntersecting = false;
-  #ro?: ResizeObserver;
-
   #lines: string[] = [];
-  #lineHeights: `${string}px`[] = [];
+  #wrappedLines: TemplateResult[] = [];
 
   override connectedCallback() {
     super.connectedCallback();
-    if (!isServer) {
-      this.#updateResizeObserver();
-    }
     this.#onSlotChange();
-  }
-
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    this.#ro?.disconnect();
   }
 
   render() {
@@ -220,7 +196,7 @@ export class RhCodeBlock extends LitElement {
     const expandable = this.#lines.length > 5;
     const truncated = expandable && !fullHeight;
     const actions = !!this.actions.length;
-    const isIntersecting = this.#isIntersecting && this.lineNumbers !== 'hidden';
+    const hasWrappedLines = this.#wrappedLines.length > 0;
     const actionCopyLabelledBy =
        this.copyButtonState === 'default' ?
          'copy-to-clipboard-label'
@@ -229,17 +205,14 @@ export class RhCodeBlock extends LitElement {
            : 'copy-failed-label';
     return html`
       <div id="container"
-           class="${classMap({ actions, compact, expandable, fullHeight, isIntersecting, resizable, truncated, wrap, 'line-numbers': lineNumbers })}"
-           @code-action="${this.#onCodeAction}"
-           @contentvisibilityautostatechange="${this.#onVisibilityChange}">
+           class="${classMap({ actions, compact, expandable, fullHeight, resizable, truncated, wrap, 'line-numbers': lineNumbers })}"
+           @code-action="${this.#onCodeAction}">
         <div id="content-lines" tabindex="${ifDefined((!fullHeight || undefined) && 0)}">
-          <div id="sizers" aria-hidden="true"></div>
-          <ol id="line-numbers" inert aria-hidden="true">${this.#lineHeights.map((height, i) => html`
-            <li style="${styleMap({ height })}">${i + 1}</li>`)}
-          </ol>
-          <pre id="prism-output"
+          <div id="code-with-line-numbers"
                class="language-${this.language}"
-               ?hidden="${!this.#prismOutput}">${this.#prismOutput}</pre>
+               ?hidden="${!hasWrappedLines}"
+               aria-hidden="true"
+               inert>${this.#wrappedLines}</div>
           <!-- summary: code content (default slot)
                description: |
                  Expects a non-executable \`<script type="text/sample-...">\` or \`<pre>\`
@@ -248,7 +221,7 @@ export class RhCodeBlock extends LitElement {
                  and exposed to assistive technology as a scrollable code area;
                  avoid placing focusable or interactive children here. -->
           <slot id="content"
-                ?hidden="${!!this.#prismOutput}"
+                ?hidden="${hasWrappedLines}"
                 @slotchange="${this.#onSlotChange}"></slot>
         </div>
 
@@ -335,16 +308,16 @@ export class RhCodeBlock extends LitElement {
 
   protected override firstUpdated(): void {
     this.#computeLines();
-    // After computing lines, also update line heights if visible
-    this.#computeLineNumbers();
+    switch (this.highlighting) {
+      case 'prerendered': this.#wrapPrerenderedLines(); break;
+      case 'client': break;
+      default: this.#wrapDefaultContent(); break;
+    }
   }
 
   protected override updated(changed: PropertyValues<this>): void {
     if (changed.has('wrap')) {
       this.#wrapChanged();
-    }
-    if (changed.has('lineNumbers') && !isServer) {
-      this.#updateResizeObserver();
     }
     if (this.actions.length && !isServer) {
       import('@rhds/elements/rh-tooltip/rh-tooltip.js');
@@ -357,10 +330,12 @@ export class RhCodeBlock extends LitElement {
       // TODO: if we ever support other tokenizers e.g. highlightjs,
       // dispatch here off of some supplemental attribute like `tokenizer="highlightjs"`
       case 'prerendered': await this.#applyPrismPrerenderedStyles(); break;
+      default: this.#wrapDefaultContent(); break;
     }
     await this.#computeLines();
-    // After computing lines, also update line heights if visible
-    this.#computeLineNumbers();
+    if (this.highlighting === 'prerendered') {
+      this.#wrapPrerenderedLines();
+    }
   }
 
   async #applyPrismPrerenderedStyles() {
@@ -390,50 +365,54 @@ export class RhCodeBlock extends LitElement {
       const scripts = this.querySelectorAll('script[type]:not([type="javascript"])');
       const preprocess = this.dedent ? dedent : (x: string) => x;
       const textContent = preprocess(Array.from(scripts, x => x.textContent).join(''));
-      this.#prismOutput = await highlight(textContent, this.language);
-      this.requestUpdate('#prismOutput', {});
+      this.#prismHighlightedHtml = await highlight(textContent, this.language);
+      this.#wrapLinesInSpans(this.#prismHighlightedHtml);
       await this.updateComplete;
     }
   }
 
-  /**
-   * Handle content-visibility auto state changes
-   * When the element is rendered (not skipped), compute line numbers
-   * @param event - The contentvisibilityautostatechange event
-   */
-  #onVisibilityChange(event: Event) {
-    // skipped = true means content is NOT being rendered (off-screen)
-    // skipped = false means content IS being rendered (on/near screen)
-    const { skipped } = event as ContentVisibilityAutoStateChangeEvent;
-    const old = this.#isIntersecting;
-    this.#isIntersecting = !skipped;
+  #wrapLinesInSpans(htmlContent?: string) {
+    if (!htmlContent) {
+      this.#wrappedLines = [];
+      return;
+    }
+    const lines = htmlContent.split('\n');
+    this.#wrappedLines = lines.map(line => html`
+      <span class="line"><span class="line-content">${unsafeHTML(line || ' ')}</span></span>`);
+    this.requestUpdate();
+  }
 
-    if (old !== this.#isIntersecting) {
-      this.requestUpdate();
-      if (this.#isIntersecting && this.lineNumbers !== 'hidden') {
-        this.#computeLineNumbers();
-      }
+  #wrapDefaultContent() {
+    if (isServer) {
+      return;
+    }
+    const scripts = this.querySelectorAll('script[type]:not([type="javascript"])');
+    const preprocess = this.dedent ? dedent : (x: string) => x;
+    const textContent = preprocess(Array.from(scripts, x => x.textContent).join(''));
+    if (textContent) {
+      const div = document.createElement('div');
+      div.textContent = textContent;
+      this.#wrapLinesInSpans(div.innerHTML);
     }
   }
 
-  #updateResizeObserver() {
-    const shouldHaveObserver = this.wrap && this.lineNumbers !== 'hidden';
-
-    if (!shouldHaveObserver && this.#ro) {
-      // Clean up observer when not needed
-      this.#ro.disconnect();
-      this.#ro = undefined;
-    } else if (shouldHaveObserver && !this.#ro) {
-      // Create observer only when both conditions are met
-      this.#ro = new ResizeObserver(() => this.#computeLineNumbers());
-      this.#ro.observe(this);
+  #wrapPrerenderedLines() {
+    if (isServer || this.highlighting !== 'prerendered') {
+      return;
     }
+    const codes = this.querySelectorAll('code[class*="language-"]');
+    if (codes.length !== 1) {
+      return;
+    }
+    const [code] = codes;
+    if (code.querySelector('.rh-code-block-line')) {
+      return;
+    }
+    this.#wrapLinesInSpans(code.innerHTML);
   }
 
   async #wrapChanged() {
-    this.#updateResizeObserver();
     await this.updateComplete;
-    this.#computeLineNumbers();
     this.#setSlottedLabelState('action-label-wrap', this.wrap ? 'active' : undefined);
   }
 
@@ -455,80 +434,16 @@ export class RhCodeBlock extends LitElement {
       : []);
   }
 
-  /**
-   * Calculate the number of lines in the code block
-   */
   async #computeLines() {
     await this.updateComplete;
-    const codes =
-        this.#prismOutput ? [this.shadowRoot?.getElementById('prism-output')].filter(x => !!x)
-      : this.#getSlottedCodeElements();
-
-    this.#lines = codes.flatMap(element =>
-      element.textContent?.split(/\n(?!$)/g) ?? []);
+    if (this.#prismHighlightedHtml) {
+      this.#lines = this.#prismHighlightedHtml.split(/\n(?!$)/g);
+    } else {
+      const codes = this.#getSlottedCodeElements();
+      this.#lines = codes.flatMap(element =>
+        element.textContent?.split(/\n(?!$)/g) ?? []);
+    }
     this.requestUpdate();
-  }
-
-  /**
-   * Calculate line heights for line numbers display
-   * @license MIT
-   * Portions copyright prism.js authors (MIT license)
-   */
-  async #computeLineNumbers() {
-    if (!this.#isIntersecting || this.lineNumbers === 'hidden') {
-      return;
-    }
-
-    await this.updateComplete;
-    const codes =
-        this.#prismOutput ? [this.shadowRoot?.getElementById('prism-output')].filter(x => !!x)
-      : this.#getSlottedCodeElements();
-
-    const infos: CodeLineHeightsInfo[] = codes.map(element => {
-      const codeElement = this.#prismOutput ? element.querySelector('code') : element;
-      if (codeElement) {
-        const sizer = document.createElement('span');
-        sizer.className = 'sizer';
-        sizer.innerText = '0';
-        sizer.style.display = 'block';
-        this.shadowRoot?.getElementById('sizers')?.appendChild(sizer);
-        return {
-          lines: element.textContent?.split(/\n(?!$)/g) ?? [],
-          lineHeights: [],
-          sizer,
-          oneLinerHeight: sizer.getBoundingClientRect().height,
-        };
-      }
-    }).filter(x => !!x);
-
-    for (const { lines, lineHeights, sizer, oneLinerHeight } of infos) {
-      lineHeights[lines.length - 1] = undefined; // why?
-      lines.forEach((line, i) => {
-        if (line.length > 1) {
-          const e = sizer.appendChild(document.createElement('span'));
-          e.style.display = 'block';
-          e.textContent = line;
-        } else {
-          lineHeights[i] = oneLinerHeight;
-        }
-      });
-    }
-
-    for (const { sizer, lineHeights } of infos) {
-      let childIndex = 0;
-      for (let i = 0; i < lineHeights.length; i++) {
-        if (lineHeights[i] === undefined) {
-          lineHeights[i] = sizer.children[childIndex++].getBoundingClientRect()?.height ?? 0;
-        }
-      }
-      sizer.remove();
-    }
-
-    this.#lineHeights = infos.flatMap(x =>
-      x.lineHeights?.map(y =>
-        `${y ?? x.oneLinerHeight}px` as const));
-
-    this.requestUpdate('#linesNumbers', 0);
   }
 
   #onActionsClick(event: Event) {

--- a/elements/rh-code-block/test/rh-code-block.spec.ts
+++ b/elements/rh-code-block/test/rh-code-block.spec.ts
@@ -43,6 +43,121 @@ describe('<rh-code-block>', function() {
     });
   });
 
+  describe('line numbers', function() {
+    describe('default mode (no highlighting)', function() {
+      let element: RhCodeBlock;
+      beforeEach(async function() {
+        element = await createFixture<RhCodeBlock>(html`
+          <rh-code-block>
+            <script type="text/html">line one
+line two
+line three</script>
+          </rh-code-block>
+        `);
+        await allUpdates(element);
+      });
+
+      it('should render line spans in shadow DOM', function() {
+        const lines = element.shadowRoot!.querySelectorAll('#code-with-line-numbers .line');
+        expect(lines.length).to.equal(3);
+      });
+
+      it('should have line-content spans inside each line', function() {
+        const contents = element.shadowRoot!.querySelectorAll('#code-with-line-numbers .line-content');
+        expect(contents.length).to.equal(3);
+      });
+    });
+
+    describe('client-side highlighting', function() {
+      let element: RhCodeBlock;
+      beforeEach(async function() {
+        element = await createFixture<RhCodeBlock>(html`
+          <rh-code-block highlighting="client" language="css">
+            <script type="text/css">body {
+  color: red;
+}</script>
+          </rh-code-block>
+        `);
+        await allUpdates(element);
+        // Prism loads asynchronously; wait for wrapped lines to render
+        await aTimeout(500);
+        await allUpdates(element);
+      });
+
+      it('should render line spans with highlighted content', function() {
+        const lines = element.shadowRoot!.querySelectorAll('#code-with-line-numbers .line');
+        expect(lines.length).to.be.greaterThan(0);
+      });
+    });
+
+    describe('prerendered highlighting (legacy format)', function() {
+      let element: RhCodeBlock;
+      beforeEach(async function() {
+        element = await createFixture<RhCodeBlock>(html`
+          <rh-code-block highlighting="prerendered">
+            <pre class="language-css"><code class="language-css"><span class="token selector">body</span> <span class="token punctuation">{</span>
+  <span class="token property">color</span><span class="token punctuation">:</span> red<span class="token punctuation">;</span>
+<span class="token punctuation">}</span></code></pre>
+          </rh-code-block>
+        `);
+        await allUpdates(element);
+      });
+
+      it('should wrap legacy prerendered content into shadow DOM lines', function() {
+        const lines = element.shadowRoot!.querySelectorAll('#code-with-line-numbers .line');
+        expect(lines.length).to.equal(3);
+      });
+    });
+
+    describe('line-numbers="hidden"', function() {
+      let element: RhCodeBlock;
+      beforeEach(async function() {
+        element = await createFixture<RhCodeBlock>(html`
+          <rh-code-block line-numbers="hidden">
+            <script type="text/html">line one
+line two</script>
+          </rh-code-block>
+        `);
+        await allUpdates(element);
+      });
+
+      it('should still render line spans', function() {
+        const lines = element.shadowRoot!.querySelectorAll('#code-with-line-numbers .line');
+        expect(lines.length).to.equal(2);
+      });
+
+      it('should hide the code-with-line-numbers via CSS', function() {
+        const container = element.shadowRoot!.querySelector('#code-with-line-numbers');
+        const style = getComputedStyle(container!);
+        expect(style.gridTemplateColumns).to.not.include('min-content');
+      });
+    });
+
+    describe('prerendered callout (multiple code elements)', function() {
+      let element: RhCodeBlock;
+      beforeEach(async function() {
+        element = await createFixture<RhCodeBlock>(html`
+          <rh-code-block highlighting="prerendered">
+            <pre class="language-html"><code class="language-html">first block</code></pre>
+            <span>badge</span>
+            <pre class="language-html"><code class="language-html">second block</code></pre>
+          </rh-code-block>
+        `);
+        await allUpdates(element);
+      });
+
+      it('should not pull content into shadow DOM', function() {
+        const lines = element.shadowRoot!.querySelectorAll('#code-with-line-numbers .line');
+        expect(lines.length).to.equal(0);
+      });
+
+      it('should keep slot visible', function() {
+        const slot = element.shadowRoot!.querySelector<HTMLSlotElement>('#content');
+        expect(slot!.hidden).to.be.false;
+      });
+    });
+  });
+
   describe('with copy action', function() {
     let element: RhCodeBlock;
     let tooltip: TooltipLike;


### PR DESCRIPTION
## Summary

- Replaces JS-based line number computation (getBoundingClientRect, sizer elements, ResizeObserver) with CSS counters + subgrid
- Fixes #2968 where line numbers never appeared on page load due to DSD timing: `contentvisibilityautostatechange` fired before Lit hydrated

## What changed

**CSS** -- Line numbers are now `::before` pseudo-elements on per-line `<span class="line">` elements, aligned via CSS Grid subgrid. No JS height measurement needed.

**Three rendering paths:**
| Path | Mechanism | When |
|------|-----------|------|
| Client highlighting | JS wraps Prism output into shadow DOM line spans | At highlight time |
| Prerendered (new format) | Lightdom CSS counters on `.rh-code-block-line` wrappers | Before hydration |
| Prerendered (legacy) | JS wraps into shadow DOM at hydration | At hydration |

**Removed:** `#computeLineNumbers`, `#onVisibilityChange`, `#updateResizeObserver`, ResizeObserver, sizer elements, `<ol id="line-numbers">`, `contentvisibilityautostatechange` handler, `styleMap` import, `CodeLineHeightsInfo`/`ContentVisibilityAutoStateChangeEvent` interfaces

**Added:** `#wrapLinesInSpans()`, `#wrapDefaultContent()`, `#wrapPrerenderedLines()`, CSS counter styles in shadow and light DOM, line wrapping in markdown-it plugin for uxdot

**Callout pattern** (multiple `<code>` elements with interleaved badges): stays in slot mode, no line numbers -- same as before since badges break the flow.

## Test plan

- [x] 13 tests pass (8 new: default mode, client, prerendered legacy, hidden, callout)
- [ ] Verify client-side highlighting demo shows line numbers + syntax colors
- [ ] Verify prerendered demo shows line numbers + syntax colors
- [ ] Verify `line-numbers="hidden"` hides numbers
- [ ] Verify callout prerendered shows badges without line numbers
- [ ] Verify below-the-fold code blocks show line numbers on scroll
- [ ] Verify copy and wrap actions still work
- [ ] Verify expand/collapse still works
- [ ] Test on uxdot staging with DSD -- line numbers visible on page load