### PR TITLE
fix(navigation-primary): bento box regression

### DIFF
--- a/.changeset/five-pants-fall.md
+++ b/.changeset/five-pants-fall.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-primary>`: corrected regression in bento box dropdown behavior
+  

--- a/elements/rh-navigation-primary/rh-navigation-primary-item.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary-item.css
@@ -471,14 +471,12 @@
 
 :host([slot='links']) {
   & #container {
-    &.compact {
-      min-inline-size: 188px;
+    min-inline-size: 188px;
 
-      /** Compact links slot inline end padding */
-      padding-inline-end: var(--rh-space-xl, 24px);
-    }
+    /** Links slot inline end padding */
+    padding-inline-end: var(--rh-space-xl, 24px);
 
-    @container navigation-primary (min-width: 1200px) {
+    @container navigation-primary (min-width: 1440px) {
       min-inline-size: unset;
       padding-inline-end: 0;
     }

--- a/elements/rh-navigation-primary/rh-navigation-primary.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary.css
@@ -849,7 +849,7 @@
     & #links-menu {
       /* stylelint-disable-next-line no-descending-specificity */
       & summary {
-        @container navigation-primary (min-width: 14400px) {
+        @container navigation-primary (min-width: 1440px) {
           display: flex;
         }
       }

--- a/elements/rh-navigation-primary/rh-navigation-primary.ts
+++ b/elements/rh-navigation-primary/rh-navigation-primary.ts
@@ -401,10 +401,15 @@ export class RhNavigationPrimary extends LitElement {
       if (secondaryEventToggle) {
         if (this.compact) {
           this.#closeHamburger();
+        }
+        if (this.linksCompact) {
           this.#closeLinksMenu();
         }
         this.#openSecondaryDropdowns.add(item);
       } else {
+        if (this.linksCompact) {
+          this.#closeLinksMenu();
+        }
         this.#openPrimaryDropdowns.add(item);
       }
       this.#openOverlay();
@@ -421,7 +426,8 @@ export class RhNavigationPrimary extends LitElement {
 
       if (!this.compact
         && this.#openPrimaryDropdowns.size === 0
-        && this.#openSecondaryDropdowns.size === 0) {
+        && this.#openSecondaryDropdowns.size === 0
+        && !this._linksMenuOpen) {
         this.#closeOverlay();
       }
     }
@@ -611,17 +617,20 @@ export class RhNavigationPrimary extends LitElement {
         if (this.compact && this._hamburgerOpen) {
           this.#closeHamburger();
         }
+        // close any open primary dropdowns when links menu opens
+        this.#closePrimaryDropdowns();
         // close any open secondary dropdowns when links menu opens
-        if (this.compact && this.#openSecondaryDropdowns.size > 0) {
+        if (this.linksCompact && this.#openSecondaryDropdowns.size > 0) {
           this.#closeSecondaryDropdowns();
         }
-        // Only open overlay in compact (mobile) mode
-        if (this.compact) {
+        if (this.linksCompact) {
           this.#openOverlay();
         }
       } else {
         this.#closeLinksMenu();
-        if (this.compact && this.#openSecondaryDropdowns.size === 0 && !this._hamburgerOpen) {
+        if (this.linksCompact && this.#openSecondaryDropdowns.size === 0
+            && this.#openPrimaryDropdowns.size === 0
+            && (!this._hamburgerOpen || !this.compact)) {
           this.#closeOverlay();
         }
       }


### PR DESCRIPTION
## What I did

 Fixed three regressions introduced in #2984 when the links menu breakpoint was separated from the  compact state. Between 1200–1440px container widths, the bento box dropdown was broken:

1. **Dropdown width collapsed** from 252px to ~123px at 1200px because the link items'
  `min-inline-size: 188px` was gated on the `.compact` class (removed at 1200px) and the
  `@container` override that unsets it fired at 1200px instead of 1440px
2. **Overlay stopped appearing** because the overlay open/close logic in `#linksMenuToggle` was
  gated on `this.compact` instead of `this.linksCompact`
3. **Dropdowns stopped coordinating**  bento and search/Products could be open simultaneously, and the overlay flickered off when switching between them, because the mutual-exclusion guards were
  all gated on `this.compact`
4. **Typo**: `14400px` instead of `1440px` in the links menu summary container query

  ## Changes

  ### `rh-navigation-primary-item.css`
  - Removed `.compact` gate on `min-inline-size: 188px` for `[slot='links']` items so dropdown
  sizing applies regardless of compact state
  - Changed the unset breakpoint from `1200px` to `1440px`

  ### `rh-navigation-primary.css`
  - Fixed `14400px` → `1440px` typo

  ### `rh-navigation-primary.ts`
  - `#linksMenuToggle`: use `this.linksCompact` for overlay and secondary dropdown coordination;
  keep `this.compact` for hamburger-only guards
  - `#linksMenuToggle`: close primary dropdowns when bento opens
  - `#onDropdownToggle`: close links menu when `linksCompact` (not just `compact`) for both primary
  and secondary dropdown opens
  - Overlay close checks now account for links menu and primary dropdowns being open to prevent
  flicker during transitions

  ## Test plan

  - [ ] At 1199px: open bento — dropdown is 252px wide with overlay
  - [ ] At 1200px: open bento — dropdown is 252px wide with overlay
  - [ ] At 1200px: open Products, click bento — Products closes, bento opens, overlay stays
  - [ ] At 1200px: open bento, click Products — bento closes, Products opens, overlay stays
  - [ ] At 1200px: open bento, click search — bento closes, search opens, overlay stays
  - [ ] At 1200px: open search, click bento — search closes, bento opens, overlay stays
  - [ ] At 1200px: close bento — overlay closes
  - [ ] At 1440px: links display inline, no bento icon
  - [ ] Below 1200px (compact): all existing behavior unchanged


Closes #3017 

## Testing Instructions

1.

## Notes to Reviewers
