### PR TITLE
fix(navigation-primary): overlay regression on large viewports

### DIFF
--- a/.changeset/ready-bobcats-joke.md
+++ b/.changeset/ready-bobcats-joke.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-primary>`: corrected overlay closure regression on large viewport dropdown toggle
+  

--- a/elements/rh-navigation-primary/rh-navigation-primary-item.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary-item.css
@@ -142,12 +142,12 @@
       @container (min-width: 1200px) {
         border-block-end: 4px solid transparent; /* Non standard border width */
 
-        &:hover {
+        &:is(:hover, :focus-visible, :focus-within) {
           /** Hamburger item hover indicator color at containers >= xl */
           border-block-end-color: var(--rh-color-border-subtle);
         }
 
-        &:is(:active, :focus-within, :has(details[open])) {
+        &:is(:active, :has(details[open])) {
           /** Hamburger item active indicator color at containers >= xl */
           border-block-end-color: var(--rh-color-accent-brand);
         }
@@ -289,14 +289,14 @@
             border-block-end: 4px solid transparent;
           }
 
-          &:is(:hover, :focus-visible) {
+          &:is(:hover, :focus-visible, :focus-within) {
             &:after {
               /** Secondary area slotted item hover indicator color */
               border-block-end-color: var(--rh-color-border-subtle);
             }
           }
 
-          &:is(:active, :focus-within) {
+          &:is(:active) {
             &:after {
               /** Secondary area slotted item active indicator color */
               border-block-end-color: var(--rh-color-accent-brand);

--- a/elements/rh-navigation-primary/rh-navigation-primary.ts
+++ b/elements/rh-navigation-primary/rh-navigation-primary.ts
@@ -356,6 +356,8 @@ export class RhNavigationPrimary extends LitElement {
 
     if (this.compact) {
       this.#closeHamburger();
+    }
+    if (this.linksCompact) {
       this.#closeLinksMenu();
     }
 
@@ -472,7 +474,7 @@ export class RhNavigationPrimary extends LitElement {
       if (this.#linksMenuContains(event.relatedTarget as Node)) {
         return;
       }
-      if (this.compact) {
+      if (this.linksCompact) {
         this.#closeLinksMenu();
       }
     }
@@ -486,7 +488,7 @@ export class RhNavigationPrimary extends LitElement {
       if (this.#linksMenuContains(event.relatedTarget as Node)) {
         return;
       }
-      if (this.compact) {
+      if (this.linksCompact) {
         this.#closeLinksMenu();
       }
     }
@@ -534,7 +536,7 @@ export class RhNavigationPrimary extends LitElement {
     } else if (this._hamburgerOpen && this.compact) {
       this.#closeHamburger();
       this._hamburger.querySelector('summary')?.focus();
-    } else if (this._linksMenuOpen && this.compact) {
+    } else if (this._linksMenuOpen && (this.linksCompact)) {
       this.#closeLinksMenu();
       this._linksMenu.querySelector('summary')?.focus();
     }
@@ -693,6 +695,8 @@ export class RhNavigationPrimary extends LitElement {
     }
     if (this.compact && !skip) {
       this.#closeHamburger();
+    }
+    if ((this.linksCompact) && !skip) {
       this.#closeLinksMenu();
     }
     this.#closeOverlay();

--- a/elements/rh-navigation-primary/rh-navigation-primary.ts
+++ b/elements/rh-navigation-primary/rh-navigation-primary.ts
@@ -427,7 +427,7 @@ export class RhNavigationPrimary extends LitElement {
       if (!this.compact
         && this.#openPrimaryDropdowns.size === 0
         && this.#openSecondaryDropdowns.size === 0
-        && !this._linksMenuOpen) {
+        && (!this._linksMenuOpen || !this.linksCompact)) {
         this.#closeOverlay();
       }
     }

--- a/elements/rh-navigation-primary/test/rh-navigation-primary.spec.ts
+++ b/elements/rh-navigation-primary/test/rh-navigation-primary.spec.ts
@@ -490,6 +490,245 @@ describe('<rh-navigation-primary>', function() {
           });
         });
       });
+
+      describe('overlay behavior', function() {
+        async function toggleDropdown(item: RhNavigationPrimaryItem | null) {
+          item?.shadowRoot?.querySelector('details')?.querySelector('summary')?.focus();
+          await sendKeys({ press: 'Enter' });
+        }
+
+        describe('primary dropdown', function() {
+          let navItem: RhNavigationPrimaryItem | null;
+
+          beforeEach(function() {
+            navItem = element.querySelector<RhNavigationPrimaryItem>('rh-navigation-primary-item[variant="dropdown"]:not([slot])');
+          });
+
+          it('overlay should be closed initially', function() {
+            expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+          });
+
+          describe('opening a dropdown', function() {
+            beforeEach(async function() {
+              await toggleDropdown(navItem);
+              await nextFrame();
+            });
+            beforeEach(async () => await element.updateComplete);
+
+            it('should open the overlay', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.exist;
+            });
+
+            it('should expand the dropdown', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).to.have.axQuery({ name: HamburgerItem1Name, expanded: true });
+            });
+
+            describe('pressing Enter again', function() {
+              beforeEach(async function() {
+                await toggleDropdown(navItem);
+                await nextFrame();
+              });
+              beforeEach(async () => await element.updateComplete);
+
+              it('should close the overlay', function() {
+                expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+              });
+
+              it('should collapse the dropdown', async function() {
+                const snapshot = await a11ySnapshot();
+                expect(snapshot).to.not.have.axQuery({ name: HamburgerItem1Name, expanded: true });
+              });
+            });
+
+            describe('pressing Escape', function() {
+              beforeEach(async function() {
+                await sendKeys({ press: 'Escape' });
+                await nextFrame();
+              });
+              beforeEach(async () => await element.updateComplete);
+
+              it('should close the overlay', function() {
+                expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+              });
+
+              it('should collapse the dropdown', async function() {
+                const snapshot = await a11ySnapshot();
+                expect(snapshot).to.not.have.axQuery({ name: HamburgerItem1Name, expanded: true });
+              });
+
+              it('should return focus to the toggle', async function() {
+                const snapshot = await a11ySnapshot();
+                expect(snapshot).to.have.axQuery({ name: HamburgerItem1Name, focused: true });
+              });
+            });
+
+            describe('closing via hide()', function() {
+              beforeEach(async function() {
+                navItem!.hide();
+                await nextFrame();
+              });
+              beforeEach(async () => await element.updateComplete);
+
+              it('should close the overlay', function() {
+                expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+              });
+            });
+
+            describe('opening another primary dropdown', function() {
+              beforeEach(async function() {
+                const items = element.querySelectorAll<RhNavigationPrimaryItem>('rh-navigation-primary-item[variant="dropdown"]:not([slot])');
+                await toggleDropdown(items[1]);
+                await nextFrame();
+              });
+              beforeEach(async () => await element.updateComplete);
+
+              it('should keep the overlay open', function() {
+                expect(element.shadowRoot?.querySelector('#overlay.open')).to.exist;
+              });
+
+              it('should expand the second dropdown', async function() {
+                const snapshot = await a11ySnapshot();
+                expect(snapshot).to.have.axQuery({ name: HamburgerItem2Name, expanded: true });
+              });
+
+              it('should collapse the first dropdown', async function() {
+                const snapshot = await a11ySnapshot();
+                expect(snapshot).to.not.have.axQuery({ name: HamburgerItem1Name, expanded: true });
+              });
+
+              describe('pressing Enter on second dropdown', function() {
+                beforeEach(async function() {
+                  const items = element.querySelectorAll<RhNavigationPrimaryItem>('rh-navigation-primary-item[variant="dropdown"]:not([slot])');
+                  await toggleDropdown(items[1]);
+                  await nextFrame();
+                });
+                beforeEach(async () => await element.updateComplete);
+
+                it('should close the overlay', function() {
+                  expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+                });
+              });
+
+              describe('pressing Escape', function() {
+                beforeEach(async function() {
+                  await sendKeys({ press: 'Escape' });
+                  await nextFrame();
+                });
+                beforeEach(async () => await element.updateComplete);
+
+                it('should close the overlay', function() {
+                  expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+                });
+              });
+            });
+          });
+        });
+
+        describe('secondary dropdown', function() {
+          describe('opening a secondary dropdown', function() {
+            beforeEach(async function() {
+              const item = element.querySelector<RhNavigationPrimaryItem>('rh-navigation-primary-item[slot="dropdowns"][variant="dropdown"]');
+              await toggleDropdown(item);
+              await nextFrame();
+            });
+            beforeEach(async () => await element.updateComplete);
+
+            it('should open the overlay', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.exist;
+            });
+
+            it('should expand the dropdown', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).to.have.axQuery({ name: 'Item 6', expanded: true });
+            });
+
+            describe('pressing Enter again', function() {
+              beforeEach(async function() {
+                const item = element.querySelector<RhNavigationPrimaryItem>('rh-navigation-primary-item[slot="dropdowns"][variant="dropdown"]');
+                await toggleDropdown(item);
+                await nextFrame();
+              });
+              beforeEach(async () => await element.updateComplete);
+
+              it('should close the overlay', function() {
+                expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+              });
+            });
+
+            describe('pressing Escape', function() {
+              beforeEach(async function() {
+                await sendKeys({ press: 'Escape' });
+                await nextFrame();
+              });
+              beforeEach(async () => await element.updateComplete);
+
+              it('should close the overlay', function() {
+                expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+              });
+
+              it('should collapse the dropdown', async function() {
+                const snapshot = await a11ySnapshot();
+                expect(snapshot).to.not.have.axQuery({ name: 'Item 6', expanded: true });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('medium viewport (1200-1440px)', function() {
+      beforeEach(async function() {
+        await setViewport({ width: 1300, height: 800 });
+      });
+      beforeEach(async () => await element.updateComplete);
+      beforeEach(nextFrame);
+
+      describe('overlay behavior', function() {
+        async function toggleDropdown(item: RhNavigationPrimaryItem | null) {
+          item?.shadowRoot?.querySelector('details')?.querySelector('summary')?.focus();
+          await sendKeys({ press: 'Enter' });
+        }
+
+        describe('opening a primary dropdown', function() {
+          let navItem: RhNavigationPrimaryItem | null;
+
+          beforeEach(async function() {
+            navItem = element.querySelector<RhNavigationPrimaryItem>('rh-navigation-primary-item[variant="dropdown"]:not([slot])');
+            await toggleDropdown(navItem);
+            await nextFrame();
+          });
+          beforeEach(async () => await element.updateComplete);
+
+          it('should open the overlay', function() {
+            expect(element.shadowRoot?.querySelector('#overlay.open')).to.exist;
+          });
+
+          describe('pressing Enter again', function() {
+            beforeEach(async function() {
+              await toggleDropdown(navItem);
+              await nextFrame();
+            });
+            beforeEach(async () => await element.updateComplete);
+
+            it('should close the overlay', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+            });
+          });
+
+          describe('pressing Escape', function() {
+            beforeEach(async function() {
+              await sendKeys({ press: 'Escape' });
+              await nextFrame();
+            });
+            beforeEach(async () => await element.updateComplete);
+
+            it('should close the overlay', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+            });
+          });
+        });
+      });
     });
   });
 

--- a/elements/rh-navigation-primary/test/rh-navigation-primary.spec.ts
+++ b/elements/rh-navigation-primary/test/rh-navigation-primary.spec.ts
@@ -729,6 +729,102 @@ describe('<rh-navigation-primary>', function() {
           });
         });
       });
+
+      describe('bento box behavior', function() {
+        function openBento() {
+          return async function() {
+            const summary = element.shadowRoot?.querySelector<HTMLElement>('#links-menu summary');
+            summary?.focus();
+            await sendKeys({ press: 'Enter' });
+          };
+        }
+
+        describe('opening the bento box', function() {
+          beforeEach(openBento());
+          beforeEach(async () => await element.updateComplete);
+          beforeEach(nextFrame);
+
+          it('should open the bento box', async function() {
+            const snapshot = await a11ySnapshot();
+            expect(snapshot).to.have.axQuery({ name: 'Explore Red Hat', expanded: true });
+          });
+
+          it('should open the overlay', function() {
+            expect(element.shadowRoot?.querySelector('#overlay.open')).to.exist;
+          });
+
+          describe('pressing Escape', function() {
+            beforeEach(press('Escape'));
+            beforeEach(async () => await element.updateComplete);
+            beforeEach(nextFrame);
+
+            it('should close the bento box', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).axQuery({ name: 'Explore Red Hat' }).to.not.have.property('expanded', true);
+            });
+
+            it('should close the overlay', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+            });
+
+            it('should return focus to the bento trigger', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).to.have.axQuery({ name: 'Explore Red Hat', focused: true });
+            });
+          });
+
+          describe('clicking the overlay', function() {
+            beforeEach(async function() {
+              const overlay = element.shadowRoot?.querySelector<HTMLElement>('#overlay');
+              overlay?.click();
+            });
+            beforeEach(async () => await element.updateComplete);
+            beforeEach(nextFrame);
+
+            it('should close the bento box', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).axQuery({ name: 'Explore Red Hat' }).to.not.have.property('expanded', true);
+            });
+
+            it('should close the overlay', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.not.exist;
+            });
+          });
+
+          describe('tabbing past the bento box', function() {
+            beforeEach(press('Tab'));
+            beforeEach(press('Tab'));
+            beforeEach(press('Tab'));
+            beforeEach(press('Tab'));
+            beforeEach(async () => await element.updateComplete);
+            beforeEach(nextFrame);
+
+            it('should close the bento box', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).axQuery({ name: 'Explore Red Hat' }).to.not.have.property('expanded', true);
+            });
+          });
+
+          describe('opening a primary dropdown', function() {
+            beforeEach(async function() {
+              const navItem = element.querySelector<RhNavigationPrimaryItem>('rh-navigation-primary-item[variant="dropdown"]:not([slot])');
+              navItem?.shadowRoot?.querySelector('details')?.querySelector('summary')?.focus();
+              await sendKeys({ press: 'Enter' });
+            });
+            beforeEach(async () => await element.updateComplete);
+            beforeEach(nextFrame);
+
+            it('should close the bento box', async function() {
+              const snapshot = await a11ySnapshot();
+              expect(snapshot).axQuery({ name: 'Explore Red Hat' }).to.not.have.property('expanded', true);
+            });
+
+            it('should keep the overlay open', function() {
+              expect(element.shadowRoot?.querySelector('#overlay.open')).to.exist;
+            });
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## What I did

1. Corrected overlay not closing on large viewports when dropdowns were toggled via reclicking the dropdown or using the escape key.    Regression was caused by the bifurcation of the compact states of the hamburger and links menu.
2. Increased test coverage around the overlay state

Reported by @zhawkins 

## Testing Instructions

1. View deploy preview at >= 1200px < 1440px.  Click or keyboard-navigate to a dropdown to open it, then close a main nav dropdown item.  Should open and close the overlay.

## Notes to Reviewers
