### PR TITLE
feat(accordion): unified — add public CSS custom props for `rh-accordion-panel` padding

### DIFF
--- a/.changeset/grumpy-brooms-judge.md
+++ b/.changeset/grumpy-brooms-judge.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-accordion>`: added `body` CSS part to the panel slot for external padding overrides
+  

--- a/.changeset/grumpy-brooms-judge.md
+++ b/.changeset/grumpy-brooms-judge.md
@@ -2,5 +2,4 @@
 "@rhds/elements": minor
 ---
 
-`<rh-accordion>`: added `body` CSS part to the panel slot for external padding overrides
-  
+`<rh-accordion>`: promoted internal panel padding variables to public CSS custom properties (`--rh-accordion-panel-padding-block-start`, `--rh-accordion-panel-padding-inline-end`, `--rh-accordion-panel-padding-block-end`, `--rh-accordion-panel-padding-inline-start`)

--- a/.changeset/grumpy-brooms-judge.md
+++ b/.changeset/grumpy-brooms-judge.md
@@ -1,5 +1,5 @@
 ---
-"@rhds/elements": patch
+"@rhds/elements": minor
 ---
 
 `<rh-accordion>`: added `body` CSS part to the panel slot for external padding overrides

--- a/.changeset/grumpy-brooms-judge.md
+++ b/.changeset/grumpy-brooms-judge.md
@@ -2,4 +2,4 @@
 "@rhds/elements": minor
 ---
 
-`<rh-accordion>`: promoted internal panel padding variables to public CSS custom properties (`--rh-accordion-panel-padding-block-start`, `--rh-accordion-panel-padding-inline-end`, `--rh-accordion-panel-padding-block-end`, `--rh-accordion-panel-padding-inline-start`)
+`<rh-accordion>`: added new public CSS custom properties (`--rh-accordion-panel-padding-block-start`, `--rh-accordion-panel-padding-inline-end`, `--rh-accordion-panel-padding-block-end`, `--rh-accordion-panel-padding-inline-start`)

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -20,25 +20,20 @@
 }
 
 .large {
-  --rh-accordion-panel-padding-block-start: var(--rh-space-xl, 24px);
-  --rh-accordion-panel-padding-inline-end: var(--rh-space-xl, 24px);
-  --rh-accordion-panel-padding-block-end: var(--rh-space-xl, 24px);
-  --rh-accordion-panel-padding-inline-start: var(--rh-space-xl, 24px);
+  --rh-accordion-panel-padding-block: var(--rh-space-xl, 24px);
+  --rh-accordion-panel-padding-inline: var(--rh-space-xl, 24px);
 }
 
 .body {
   position: relative;
   overflow: hidden;
   display: block;
-  padding:
-    /** Panel block-start (top) padding */
-    var(--rh-accordion-panel-padding-block-start, var(--rh-space-lg, 16px))
-    /** Panel inline-end (right) padding */
-    var(--rh-accordion-panel-padding-inline-end, var(--rh-space-xl, 24px))
-    /** Panel block-end (bottom) padding */
-    var(--rh-accordion-panel-padding-block-end, var(--rh-space-lg, 16px))
-    /** Panel inline-start (left) padding */
-    var(--rh-accordion-panel-padding-inline-start, var(--rh-space-xl, 24px));
+
+  /** Panel block (top and bottom) padding */
+  padding-block: var(--rh-accordion-panel-padding-block, var(--rh-space-lg, 16px));
+
+  /** Panel inline (left and right) padding */
+  padding-inline: var(--rh-accordion-panel-padding-inline, var(--rh-space-xl, 24px));
 }
 
 :host([fixed]) {

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -2,18 +2,6 @@
   display: block;
   overflow: hidden;
   will-change: height;
-
-  /** Panel block-start (top) padding */
-  --rh-accordion-panel-padding-block-start: var(--rh-space-lg, 16px);
-
-  /** Panel inline-end (right) padding */
-  --rh-accordion-panel-padding-inline-end: var(--rh-space-xl, 24px);
-
-  /** Panel block-end (bottom) padding */
-  --rh-accordion-panel-padding-block-end: var(--rh-space-lg, 16px);
-
-  /** Panel inline-start (left) padding */
-  --rh-accordion-panel-padding-inline-start: var(--rh-space-xl, 24px);
 }
 
 :host(:not([expanded])) {
@@ -43,9 +31,13 @@
   overflow: hidden;
   display: block;
   padding:
+    /** Panel block-start (top) padding */
     var(--rh-accordion-panel-padding-block-start, var(--rh-space-lg, 16px))
+    /** Panel inline-end (right) padding */
     var(--rh-accordion-panel-padding-inline-end, var(--rh-space-xl, 24px))
+    /** Panel block-end (bottom) padding */
     var(--rh-accordion-panel-padding-block-end, var(--rh-space-lg, 16px))
+    /** Panel inline-start (left) padding */
     var(--rh-accordion-panel-padding-inline-start, var(--rh-space-xl, 24px));
 }
 

--- a/elements/rh-accordion/rh-accordion-panel.css
+++ b/elements/rh-accordion/rh-accordion-panel.css
@@ -3,10 +3,17 @@
   overflow: hidden;
   will-change: height;
 
-  --_panel-body-padding-block-start: var(--rh-space-lg, 16px);
-  --_panel-body-padding-inline-end: var(--rh-space-xl, 24px);
-  --_panel-body-padding-block-end: var(--rh-space-lg, 16px);
-  --_panel-body-padding-inline-start: var(--rh-space-xl, 24px);
+  /** Panel block-start (top) padding */
+  --rh-accordion-panel-padding-block-start: var(--rh-space-lg, 16px);
+
+  /** Panel inline-end (right) padding */
+  --rh-accordion-panel-padding-inline-end: var(--rh-space-xl, 24px);
+
+  /** Panel block-end (bottom) padding */
+  --rh-accordion-panel-padding-block-end: var(--rh-space-lg, 16px);
+
+  /** Panel inline-start (left) padding */
+  --rh-accordion-panel-padding-inline-start: var(--rh-space-xl, 24px);
 }
 
 :host(:not([expanded])) {
@@ -25,10 +32,10 @@
 }
 
 .large {
-  --_panel-body-padding-block-start: var(--rh-space-xl, 24px);
-  --_panel-body-padding-inline-end: var(--rh-space-xl, 24px);
-  --_panel-body-padding-block-end: var(--rh-space-xl, 24px);
-  --_panel-body-padding-inline-start: var(--rh-space-xl, 24px);
+  --rh-accordion-panel-padding-block-start: var(--rh-space-xl, 24px);
+  --rh-accordion-panel-padding-inline-end: var(--rh-space-xl, 24px);
+  --rh-accordion-panel-padding-block-end: var(--rh-space-xl, 24px);
+  --rh-accordion-panel-padding-inline-start: var(--rh-space-xl, 24px);
 }
 
 .body {
@@ -36,10 +43,10 @@
   overflow: hidden;
   display: block;
   padding:
-    var(--_panel-body-padding-block-start, var(--rh-space-md, 8px))
-    var(--_panel-body-padding-inline-end, var(--rh-space-lg, 16px))
-    var(--_panel-body-padding-block-end, var(--rh-space-md, 8px))
-    var(--_panel-body-padding-inline-start, var(--rh-space-lg, 16px));
+    var(--rh-accordion-panel-padding-block-start, var(--rh-space-lg, 16px))
+    var(--rh-accordion-panel-padding-inline-end, var(--rh-space-xl, 24px))
+    var(--rh-accordion-panel-padding-block-end, var(--rh-space-lg, 16px))
+    var(--rh-accordion-panel-padding-inline-start, var(--rh-space-xl, 24px));
 }
 
 :host([fixed]) {

--- a/elements/rh-accordion/rh-accordion-panel.ts
+++ b/elements/rh-accordion/rh-accordion-panel.ts
@@ -71,12 +71,16 @@ export class RhAccordionPanel extends LitElement {
            class="${classMap({ large, expanded, content: true })}"
            part="container"
            tabindex="-1">
-        <!-- summary: the panel body slot. The content of the accordion panel can be any basic
-               markup including but not limited to div, paragraph, or nested accordion panels.
-             description: |
-               The body part wraps the default slot that holds panel content.
-               Use it to override padding, such as block-start and block-end
-               spacing, from outside the shadow DOM via \`::part(body)\`. -->
+        <!--
+          slot:
+            summary: panel body content
+            description: |
+              Accepts any basic markup including div, paragraph, or nested
+              accordion panels. Renders inside the wrapper element targeted
+              by the \`body\` CSS part.
+          part:
+            summary: panel body wrapper
+        -->
         <slot class="body" part="body"></slot>
       </div>
     `;

--- a/elements/rh-accordion/rh-accordion-panel.ts
+++ b/elements/rh-accordion/rh-accordion-panel.ts
@@ -71,9 +71,13 @@ export class RhAccordionPanel extends LitElement {
            class="${classMap({ large, expanded, content: true })}"
            part="container"
            tabindex="-1">
-        <!-- The content of the accordion panel can be any basic markup including but not limited
-             to div, paragraph, or nested accordion panels. -->
-        <slot class="body"></slot>
+        <!-- summary: the panel body slot. The content of the accordion panel can be any basic
+               markup including but not limited to div, paragraph, or nested accordion panels.
+             description: |
+               The body part wraps the default slot that holds panel content.
+               Use it to override padding, such as block-start and block-end
+               spacing, from outside the shadow DOM via \`::part(body)\`. -->
+        <slot class="body" part="body"></slot>
       </div>
     `;
   }

--- a/elements/rh-accordion/rh-accordion-panel.ts
+++ b/elements/rh-accordion/rh-accordion-panel.ts
@@ -71,17 +71,9 @@ export class RhAccordionPanel extends LitElement {
            class="${classMap({ large, expanded, content: true })}"
            part="container"
            tabindex="-1">
-        <!--
-          slot:
-            summary: panel body content
-            description: |
-              Accepts any basic markup including div, paragraph, or nested
-              accordion panels. Renders inside the wrapper element targeted
-              by the \`body\` CSS part.
-          part:
-            summary: panel body wrapper
-        -->
-        <slot class="body" part="body"></slot>
+        <!-- The content of the accordion panel can be any basic markup including but not limited
+             to div, paragraph, or nested accordion panels. -->
+        <slot class="body"></slot>
       </div>
     `;
   }


### PR DESCRIPTION
## What I did

1. Added `body` CSS part to enable Unified/Felt styling on `rh-accordion-panel`


## Testing Instructions

1. Verify code and documentation accuracy

## Notes to Reviewers

Related to https://github.com/RedHat-UX/red-hat-design-system/pull/2986