### PR TITLE
feat(button): add --rh-button-icon-color prop

### DIFF
--- a/.changeset/chilly-clowns-agree.md
+++ b/.changeset/chilly-clowns-agree.md
@@ -2,4 +2,4 @@
 "@rhds/elements": minor
 ---
 
-`rh-button`: add `--rh-button-icon-color` CSS custom property to allow theming the icon color independently from the button text color. Set on the `rh-button` host; falls back to `currentcolor`.
+`<rh-button>`: added `--rh-button-icon-color` CSS custom property to allow theming the icon color independently from the button text color

--- a/.changeset/chilly-clowns-agree.md
+++ b/.changeset/chilly-clowns-agree.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": minor
+---
+
+`rh-button`: add `--rh-button-icon-color` CSS custom property to allow theming the icon color independently from the button text color. Set on the `rh-button` host; falls back to `currentcolor`.

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -13,7 +13,8 @@
 }
 
 rh-icon {
-  color: currentcolor;
+  /** Set on the rh-button host to give the icon a distinct color from the button text. */
+  color: var(--rh-button-icon-color, currentcolor);
 }
 
 /* Base button styles: rounded corners, variant-driven colors */


### PR DESCRIPTION
## What I did

1. Added `--rh-button-icon-color` CSS custom prop

## Testing Instructions

1. Verify that `--rh-button-icon-color` can change the icon color, like `red-orange-40`

## Notes to Reviewers

This is needed for [Felt / Unified theme](https://github.com/RedHat-UX/red-hat-design-system/pull/2990#issuecomment-4772139492), and a patch for this exists in that PR too.