### PR TITLE
docs: updating rh-footer examples to have a 2026 copyright date inste…

### DIFF
--- a/elements/rh-footer/README.md
+++ b/elements/rh-footer/README.md
@@ -85,7 +85,7 @@ import '@rhds/elements/rh-footer/rh-footer.js';
       <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
       <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+    <rh-footer-copyright slot="links-secondary">© 2026 Red Hat, Inc.</rh-footer-copyright>
     <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
     <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
       <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>
@@ -126,7 +126,7 @@ import '@rhds/elements/rh-footer/rh-footer-universal.js';
     <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
     <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
   </ul>
-  <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+  <rh-footer-copyright slot="links-secondary">© 2026 Red Hat, Inc.</rh-footer-copyright>
   <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
   <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
     <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>

--- a/elements/rh-footer/demo/footer-universal.html
+++ b/elements/rh-footer/demo/footer-universal.html
@@ -35,7 +35,7 @@ description: Standalone universal footer used on orphan pages or landing pages w
          data-analytics-category="Footer|Corporate"
          data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
   </ul>
-  <rh-footer-copyright slot="links-secondary">© 2025 Red Hat</rh-footer-copyright>
+  <rh-footer-copyright slot="links-secondary">© 2026 Red Hat</rh-footer-copyright>
   <h3 slot="links-secondary"
       data-analytics-text="Red Hat legal and privacy links"
       hidden>Red Hat legal and privacy links</h3>

--- a/elements/rh-footer/demo/index.html
+++ b/elements/rh-footer/demo/index.html
@@ -169,7 +169,7 @@ description: "Full website footer with logo, social links, navigation columns, p
            data-analytics-category="Footer|Corporate"
            data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2025 Red Hat</rh-footer-copyright>
+    <rh-footer-copyright slot="links-secondary">© 2026 Red Hat</rh-footer-copyright>
     <h3 slot="links-secondary"
         data-analytics-text="Red Hat legal and privacy links"
         hidden>Red Hat legal and privacy links</h3>

--- a/elements/rh-footer/demo/slotted-social-links.html
+++ b/elements/rh-footer/demo/slotted-social-links.html
@@ -161,7 +161,7 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
            data-analytics-category="Footer|Corporate"
            data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2025 Red Hat</rh-footer-copyright>
+    <rh-footer-copyright slot="links-secondary">© 2026 Red Hat</rh-footer-copyright>
     <h3 slot="links-secondary"
         data-analytics-text="Red Hat legal and privacy links"
         hidden>Red Hat legal and privacy links</h3>


### PR DESCRIPTION
docs: updating rh-footer examples to have a 2026 copyright date instead of 2025

## What I did

1. Updated instances of 2025 in the rh-footer directory to 2026


## Testing Instructions

1. View the updated dates

## Notes to Reviewers
