### PR TITLE
fix(footer): Q2 design updates — structural

### DIFF
--- a/.changeset/gentle-foxes-glow.md
+++ b/.changeset/gentle-foxes-glow.md
@@ -1,0 +1,24 @@
+---
+"@rhds/elements": minor
+---
+
+feat(footer): move social links and copyright to universal footer's new `tertiary` slot
+
+Social links have moved from `slot="social-links"` in the header to
+`slot="tertiary"` inside `<rh-footer-universal>`, wrapped in
+`<rh-footer-links>`. Copyright has moved from `slot="links-secondary"`
+to `slot="tertiary"`.
+
+The previous slot pattern (`slot="social-links"` and copyright in
+`slot="links-secondary"`) continues to work for backward compatibility.
+Users should migrate to the new pattern at their convenience.
+
+```html
+<rh-footer-universal slot="universal">
+  <!-- ...links-primary, links-secondary... -->
+  <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+  <rh-footer-links slot="tertiary" role="list">
+    <rh-footer-social-link icon="linkedin" href="..." accessible-label="LinkedIn"></rh-footer-social-link>
+  </rh-footer-links>
+</rh-footer-universal>
+```

--- a/.changeset/gentle-foxes-glow.md
+++ b/.changeset/gentle-foxes-glow.md
@@ -2,16 +2,12 @@
 "@rhds/elements": minor
 ---
 
-feat(footer): move social links and copyright to universal footer's new `tertiary` slot
+`<rh-footer-universal>`: added `tertiary` slot for social links and copyright. The previous slot pattern continues to work for backward compatibility.
 
-Social links have moved from `slot="social-links"` in the header to
-`slot="tertiary"` inside `<rh-footer-universal>`, wrapped in
-`<rh-footer-links>`. Copyright has moved from `slot="links-secondary"`
-to `slot="tertiary"`.
+### Migration
 
-The previous slot pattern (`slot="social-links"` and copyright in
-`slot="links-secondary"`) continues to work for backward compatibility.
-Users should migrate to the new pattern at their convenience.
+1. Move `<rh-footer-social-link>` elements from `slot="social-links"` on `<rh-footer>` into a `<rh-footer-links slot="tertiary">` inside `<rh-footer-universal>`.
+2. Move `<rh-footer-copyright>` from `slot="links-secondary"` to `slot="tertiary"` inside `<rh-footer-universal>`.
 
 ```html
 <rh-footer-universal slot="universal">

--- a/.changeset/tricky-paths-care.md
+++ b/.changeset/tricky-paths-care.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-footer>`: updated fedora logo to brand red, added a top border, responsive link header font sizes, and updated content for both footer and universal footer
+`<rh-footer>`: updated visual design with top border, responsive link header font sizes, and brand-red Fedora logo

--- a/elements/rh-footer/README.md
+++ b/elements/rh-footer/README.md
@@ -24,56 +24,53 @@ import '@rhds/elements/rh-footer/rh-footer.js';
   <a slot="logo" href="https://redhat.com/en" data-analytics-category="Footer" data-analytics-text="Logo">
     <img alt="Red Hat logo" src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg" loading="lazy" />
   </a>
-  <rh-footer-social-link slot="social-links" icon="linkedin"><a href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn">LinkedIn</a></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links" icon="youtube"><a href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube">YouTube</a></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links" icon="facebook"><a href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook">Facebook</a></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links" icon="twitter"><a href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Twitter">Twitter</a></rh-footer-social-link>
-  <h3 slot="links" data-analytics-text="Products">Products</h3>
+  <div slot="header-secondary">
+    <label class="visually-hidden" for="select-language">Choose page language:</label>
+    <rh-select id="select-language">
+      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
+      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
+      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+    </rh-select>
+  </div>
+  <h3 slot="links" data-analytics-text="Platforms">Platforms</h3>
   <ul slot="links">
-    <li><a href="https://redhat.com/en/technologies/linux-platforms/enterprise-linux" data-analytics-category="Footer|Products" data-analytics-text="Red Hat Enterprise Linux">Red Hat Enterprise Linux</a></li>
-    <li><a href="https://redhat.com/en/technologies/cloud-computing/openshift" data-analytics-category="Footer|Products" data-analytics-text="Red Hat OpenShift">Red Hat OpenShift</a></li>
-    <li><a href="https://redhat.com/en/technologies/management/ansible" data-analytics-category="Footer|Products" data-analytics-text="Red Hat Ansible Automation Platform">Red Hat Ansible Automation Platform</a></li>
-    <li><a href="https://redhat.com/en/technologies/cloud-computing/openshift/cloud-services" data-analytics-category="Footer|Products" data-analytics-text="Cloud services">Cloud services</a></li>
-    <li><a href="https://redhat.com/en/technologies/all-products" data-analytics-category="Footer|Products" data-analytics-text="See all products">See all products</a></li>
+    <li><a href="https://redhat.com/en/technologies/cloud-computing/openshift/lightspeed" data-analytics-category="Footer|Platforms" data-analytics-text="Red Hat AI">Red Hat AI</a></li>
+    <li><a href="https://redhat.com/en/technologies/linux-platforms/enterprise-linux" data-analytics-category="Footer|Platforms" data-analytics-text="Red Hat Enterprise Linux">Red Hat Enterprise Linux</a></li>
+    <li><a href="https://redhat.com/en/technologies/cloud-computing/openshift" data-analytics-category="Footer|Platforms" data-analytics-text="Red Hat OpenShift">Red Hat OpenShift</a></li>
+    <li><a href="https://redhat.com/en/technologies/management/ansible" data-analytics-category="Footer|Platforms" data-analytics-text="Red Hat Ansible Automation Platform">Red Hat Ansible Automation Platform</a></li>
+    <li><a href="https://redhat.com/en/technologies/all-products" data-analytics-category="Footer|Platforms" data-analytics-text="See all products">See all products</a></li>
   </ul>
   <h3 slot="links" data-analytics-text="Tools">Tools</h3>
   <ul slot="links">
-    <li><a href="https://sso.redhat.com" data-analytics-category="Footer|Tools" data-analytics-text="My account">My account</a></li>
     <li><a href="https://redhat.com/en/services/training-and-certification" data-analytics-category="Footer|Tools" data-analytics-text="Training and certification">Training and certification</a></li>
+    <li><a href="https://sso.redhat.com" data-analytics-category="Footer|Tools" data-analytics-text="My account">My account</a></li>
     <li><a href="https://access.redhat.com" data-analytics-category="Footer|Tools" data-analytics-text="Customer support">Customer support</a></li>
     <li><a href="https://developers.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Developer resources">Developer resources</a></li>
-    <li><a href="https://learn.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Learning community">Learning community</a></li>
-    <li><a href="https://connect.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Partner resources">Partner resources</a></li>
-    <li><a href="https://redhat.com/en/resources" data-analytics-category="Footer|Tools" data-analytics-text="Resource library">Resource library</a></li>
+    <li><a href="http://redhat.force.com/finder/" data-analytics-category="Footer|Tools" data-analytics-text="Find a partner">Find a partner</a></li>
+    <li><a href="https://catalog.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Red Hat Ecosystem Catalog">Red Hat Ecosystem Catalog</a></li>
+    <li><a href="https://docs.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Documentation">Documentation</a></li>
   </ul>
-  <h3 slot="links" data-analytics-text="Try buy sell">Try, buy & sell</h3>
+  <h3 slot="links" data-analytics-text="Try buy sell">Try, buy, &amp; sell</h3>
   <ul slot="links">
     <li><a href="https://redhat.com/en/products/trials" data-analytics-category="Footer|Try buy sell" data-analytics-text="Product trial center">Product trial center</a></li>
-    <li><a href="https://marketplace.redhat.com" data-analytics-category="Footer|Try buy sell" data-analytics-text="Red Hat Marketplace">Red Hat Marketplace</a></li>
-    <li><a href="https://catalog.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Red Hat Ecosystem Catalog">Red Hat Ecosystem Catalog</a></li>
-    <li><a href="http://redhat.force.com/finder/" data-analytics-category="Footer|Try buy sell" data-analytics-text="Find a partner">Find a partner</a></li>
     <li><a href="https://www.redhat.com/en/store" data-analytics-category="Footer|Try buy sell" data-analytics-text="Red Hat Store">Red Hat Store</a></li>
-    <li><a href="https://cloud.redhat.com/" data-analytics-category="Footer|Tools" data-analytics-text="Console">Console</a></li>
+    <li><a href="https://cloud.redhat.com/" data-analytics-category="Footer|Try buy sell" data-analytics-text="Console">Console</a></li>
   </ul>
   <h3 slot="links" data-analytics-text="Communicate">Communicate</h3>
   <ul slot="links">
-    <li><a href="https://redhat.com/en/services/consulting-overview#contact-us" data-analytics-category="Footer|Communicate" data-analytics-text="Contact consulting">Contact consulting</a></li>
     <li><a href="https://redhat.com/en/contact" data-analytics-category="Footer|Communicate" data-analytics-text="Contact sales">Contact sales</a></li>
+    <li><a href="https://redhat.com/en/services/support" data-analytics-category="Footer|Communicate" data-analytics-text="Contact customer service">Contact customer service</a></li>
     <li><a href="https://redhat.com/en/services/training-and-certification/contact-us" data-analytics-category="Footer|Communicate" data-analytics-text="Contact training">Contact training</a></li>
     <li><a href="https://redhat.com/en/about/social" data-analytics-category="Footer|Communicate" data-analytics-text="Social">Social</a></li>
   </ul>
   <rh-footer-block slot="main-secondary">
     <h3 slot="header" data-analytics-text="About Red Hat">About Red Hat</h3>
-    <p> We’re the world’s leading provider of enterprise open source solutions—including Linux, cloud, container, and Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
-  </rh-footer-block>
-  <rh-footer-block slot="main-secondary">
-    <h3 slot="header" data-analytics-text="Subscribe to our newsletter Red Hat Shares">Subscribe to our newsletter, Red Hat Shares</h3>
-    <rh-cta><a href="https://www.redhat.com/en/email-preferences?newsletter=RH-Shares&intcmp=7016000000154xCAAQ" data-analytics-category="Footer|About Red Hat" data-analytics-text="Sign up now">Sign up now</a></rh-cta>
+    <p>Red Hat is an open hybrid cloud technology leader, delivering a consistent, comprehensive foundation for transformative IT and artificial intelligence (AI) applications in the enterprise.</p>
   </rh-footer-block>
 
   <!-- Universal Footer -->
   <rh-footer-universal slot="universal">
-    <h3 slot="links-primary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
+    <h3 slot="links-primary" data-analytics-text="Red Hat corporate links" hidden>Red Hat corporate links</h3>
     <ul slot="links-primary" data-analytics-region="page-footer-bottom-primary">
       <li><a href="https://redhat.com/en/about/company" data-analytics-category="Footer|Corporate" data-analytics-text="About Red Hat">About Red Hat</a></li>
       <li><a href="https://redhat.com/en/jobs" data-analytics-category="Footer|Corporate" data-analytics-text="Jobs">Jobs</a></li>
@@ -85,24 +82,29 @@ import '@rhds/elements/rh-footer/rh-footer.js';
       <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
       <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2026 Red Hat, Inc.</rh-footer-copyright>
     <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
     <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
       <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>
       <li><a href="https://redhat.com/en/about/terms-use" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Terms of use">Terms of use</a></li>
       <li><a href="https://redhat.com/en/about/all-policies-guidelines" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="All policies and guidelines">All policies and guidelines</a></li>
-      <li><a href="https://redhat.com/en/about/digital-accessibility" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Digital accessibility" class="active">Digital accessibility</a></li>
-      <!-- If your website supports trustarc include this item to add Cookie Preferences to your site. -->
-      <!-- <li><span id="teconsent"> </span></li> -->
+      <li><a href="https://redhat.com/en/about/digital-accessibility" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Digital accessibility">Digital accessibility</a></li>
+      <li><a href="#" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
+    <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+    <rh-footer-social-link slot="tertiary" icon="linkedin" href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn" accessible-label="LinkedIn"></rh-footer-social-link>
+    <rh-footer-social-link slot="tertiary" icon="youtube" href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube" accessible-label="YouTube"></rh-footer-social-link>
+    <rh-footer-social-link slot="tertiary" icon="facebook" href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook" accessible-label="Facebook"></rh-footer-social-link>
+    <rh-footer-social-link slot="tertiary" icon="x" href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="X/Twitter" accessible-label="X/Twitter"></rh-footer-social-link>
+    <rh-footer-social-link slot="tertiary" icon="instagram" href="https://www.instagram.com/redhat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Instagram" accessible-label="Instagram"></rh-footer-social-link>
   </rh-footer-universal>
 </rh-footer>
 ```
+
 ## Universal Footer
 
-Pages which do not require the full footer, but do require the about links, 
-copyright, legal info, or privacy policy may use the `<rh-footer-universal>`. 
-Those pages can import the universal footer separately from the `<rh-footer>` to 
+Pages which do not require the full footer, but do require the about links,
+copyright, legal info, or privacy policy may use the `<rh-footer-universal>`.
+Those pages can import the universal footer separately from the `<rh-footer>` to
 improve page loading performance.
 
 ```js
@@ -114,7 +116,7 @@ import '@rhds/elements/rh-footer/rh-footer-universal.js';
 
 ```html
 <rh-footer-universal>
-  <h3 slot="links-primary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
+  <h3 slot="links-primary" data-analytics-text="Red Hat corporate links" hidden>Red Hat corporate links</h3>
   <ul slot="links-primary" data-analytics-region="page-footer-bottom-primary">
     <li><a href="https://redhat.com/en/about/company" data-analytics-category="Footer|Corporate" data-analytics-text="About Red Hat">About Red Hat</a></li>
     <li><a href="https://redhat.com/en/jobs" data-analytics-category="Footer|Corporate" data-analytics-text="Jobs">Jobs</a></li>
@@ -126,23 +128,27 @@ import '@rhds/elements/rh-footer/rh-footer-universal.js';
     <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
     <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
   </ul>
-  <rh-footer-copyright slot="links-secondary">© 2026 Red Hat, Inc.</rh-footer-copyright>
   <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
   <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
     <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>
     <li><a href="https://redhat.com/en/about/terms-use" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Terms of use">Terms of use</a></li>
     <li><a href="https://redhat.com/en/about/all-policies-guidelines" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="All policies and guidelines">All policies and guidelines</a></li>
-    <li><a href="https://redhat.com/en/about/digital-accessibility" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Digital accessibility" class="active">Digital accessibility</a></li>
-    <!-- If your website supports trustarc include this item to add Cookie Preferences to your site. -->
-    <!-- <li><span id="teconsent"> </span></li> -->
+    <li><a href="https://redhat.com/en/about/digital-accessibility" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Digital accessibility">Digital accessibility</a></li>
+    <li><a href="#" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Cookie preferences">Cookie preferences</a></li>
   </ul>
+  <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+  <rh-footer-social-link slot="tertiary" icon="linkedin" href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn" accessible-label="LinkedIn"></rh-footer-social-link>
+  <rh-footer-social-link slot="tertiary" icon="youtube" href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube" accessible-label="YouTube"></rh-footer-social-link>
+  <rh-footer-social-link slot="tertiary" icon="facebook" href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook" accessible-label="Facebook"></rh-footer-social-link>
+  <rh-footer-social-link slot="tertiary" icon="x" href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="X/Twitter" accessible-label="X/Twitter"></rh-footer-social-link>
+  <rh-footer-social-link slot="tertiary" icon="instagram" href="https://www.instagram.com/redhat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Instagram" accessible-label="Instagram"></rh-footer-social-link>
 </rh-footer-universal>
 ```
 
 ## Questions and Feedback
 
 Questions? Comments? Feedback? Need help installing or implementing?
-Please [open a discussion thread][qa] here on GitHub. The Design Systems team 
+Please [open a discussion thread][qa] here on GitHub. The Design Systems team
 will help.
 
 [spec]: https://ux.redhat.com/elements/footer/

--- a/elements/rh-footer/demo/footer-universal.html
+++ b/elements/rh-footer/demo/footer-universal.html
@@ -35,7 +35,6 @@ description: Standalone universal footer used on orphan pages or landing pages w
          data-analytics-category="Footer|Corporate"
          data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
   </ul>
-  <rh-footer-copyright slot="links-secondary">© 2026 Red Hat</rh-footer-copyright>
   <h3 slot="links-secondary"
       data-analytics-text="Red Hat legal and privacy links"
       hidden>Red Hat legal and privacy links</h3>
@@ -56,7 +55,40 @@ description: Standalone universal footer used on orphan pages or landing pages w
     <li><a href="#"
          data-analytics-category="Footer|Red Hat legal and privacy links"
          data-analytics-text="Cookie preferences">Cookie preferences</a></li>
-  </ul>
+    </ul>
+  <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+  <rh-footer-links slot="tertiary" role="list">
+    <rh-footer-social-link icon="linkedin"
+                           href="https://www.linkedin.com/company/red-hat"
+                           data-analytics-region="social-links-exit"
+                           data-analytics-category="Footer|social-links"
+                           data-analytics-text="LinkedIn"
+                           accessible-label="LinkedIn"></rh-footer-social-link>
+    <rh-footer-social-link icon="youtube"
+                           href="https://www.youtube.com/user/RedHatVideos"
+                           data-analytics-region="social-links-exit"
+                           data-analytics-category="Footer|social-links"
+                           data-analytics-text="YouTube"
+                           accessible-label="YouTube"></rh-footer-social-link>
+    <rh-footer-social-link icon="facebook"
+                           href="https://www.facebook.com/redhatinc"
+                           data-analytics-region="social-links-exit"
+                           data-analytics-category="Footer|social-links"
+                           data-analytics-text="Facebook"
+                           accessible-label="Facebook"></rh-footer-social-link>
+    <rh-footer-social-link icon="x"
+                           href="https://twitter.com/RedHat"
+                           data-analytics-region="social-links-exit"
+                           data-analytics-category="Footer|social-links"
+                           data-analytics-text="X/Twitter"
+                           accessible-label="X/Twitter"></rh-footer-social-link>
+    <rh-footer-social-link icon="instagram"
+                           href="https://www.instagram.com/redhat"
+                           data-analytics-region="social-links-exit"
+                           data-analytics-category="Footer|social-links"
+                           data-analytics-text="Instagram"
+                           accessible-label="Instagram"></rh-footer-social-link>
+  </rh-footer-links>
 </rh-footer-universal>
 
 <link rel="stylesheet"
@@ -64,4 +96,6 @@ description: Standalone universal footer used on orphan pages or landing pages w
 
 <script type="module">
   import '@rhds/elements/rh-footer/rh-footer-universal.js';
+  import '@rhds/elements/rh-footer/rh-footer-links.js';
+  import '@rhds/elements/rh-footer/rh-footer-social-link.js';
 </script>

--- a/elements/rh-footer/demo/index.html
+++ b/elements/rh-footer/demo/index.html
@@ -10,34 +10,14 @@ description: "Full website footer with logo, social links, navigation columns, p
          src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg"
          loading="lazy" />
   </a>
-  <rh-footer-social-link slot="social-links"
-                         icon="linkedin"
-                         href="https://www.linkedin.com/company/red-hat"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="LinkedIn"
-                         accessible-label="LinkedIn"></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="youtube"
-                         href="https://www.youtube.com/user/RedHatVideos"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="YouTube"
-                         accessible-label="YouTube"></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="facebook"
-                         href="https://www.facebook.com/redhatinc"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="Facebook"
-                         accessible-label="Facebook"></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="x"
-                         href="https://twitter.com/RedHat"
-                         data-analytics-region="social-links-exit"
-                         data-analytics-category="Footer|social-links"
-                         data-analytics-text="Twitter"
-                         accessible-label="X/Twitter"></rh-footer-social-link>
+  <div slot="header-secondary">
+    <label class="visually-hidden" for="select-language">Choose page language:</label>
+    <rh-select id="select-language">
+      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
+      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
+      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+    </rh-select>
+  </div>
   <h3 slot="links"
       data-analytics-text="Platforms">Platforms</h3>
   <ul slot="links">
@@ -178,7 +158,6 @@ description: "Full website footer with logo, social links, navigation columns, p
            data-analytics-category="Footer|Corporate"
            data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2026 Red Hat</rh-footer-copyright>
     <h3 slot="links-secondary"
         data-analytics-text="Red Hat legal and privacy links"
         hidden>Red Hat legal and privacy links</h3>
@@ -200,6 +179,39 @@ description: "Full website footer with logo, social links, navigation columns, p
            data-analytics-category="Footer|Red Hat legal and privacy links"
            data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
+    <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+    <rh-footer-links slot="tertiary" role="list">
+      <rh-footer-social-link icon="linkedin"
+                             href="https://www.linkedin.com/company/red-hat"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="LinkedIn"
+                             accessible-label="LinkedIn"></rh-footer-social-link>
+      <rh-footer-social-link icon="youtube"
+                             href="https://www.youtube.com/user/RedHatVideos"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="YouTube"
+                             accessible-label="YouTube"></rh-footer-social-link>
+      <rh-footer-social-link icon="facebook"
+                             href="https://www.facebook.com/redhatinc"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="Facebook"
+                             accessible-label="Facebook"></rh-footer-social-link>
+      <rh-footer-social-link icon="x"
+                             href="https://twitter.com/RedHat"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="X/Twitter"
+                             accessible-label="X/Twitter"></rh-footer-social-link>
+      <rh-footer-social-link icon="instagram"
+                             href="https://www.instagram.com/redhat"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="Instagram"
+                             accessible-label="Instagram"></rh-footer-social-link>
+    </rh-footer-links>
   </rh-footer-universal>
 </rh-footer>
 
@@ -207,6 +219,23 @@ description: "Full website footer with logo, social links, navigation columns, p
       href="../rh-footer-lightdom.css">
 
 <style>
+  .visually-hidden {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    block-size: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    inline-size: 1px;
+  }
+
+  rh-select {
+    margin-inline-start: auto;
+    max-inline-size: var(--rh-length-7xl, 128px);
+  }
+
   rh-footer-block p {
     margin-block: 0 var(--rh-space-2xl, 32px);
   }
@@ -256,4 +285,5 @@ description: "Full website footer with logo, social links, navigation columns, p
 
 <script type="module">
   import '@rhds/elements/rh-footer/rh-footer.js';
+  import '@rhds/elements/rh-select/rh-select.js';
 </script>

--- a/elements/rh-footer/demo/index.html
+++ b/elements/rh-footer/demo/index.html
@@ -13,9 +13,9 @@ description: "Full website footer with logo, social links, navigation columns, p
   <div slot="header-secondary">
     <label class="visually-hidden" for="select-language">Choose page language:</label>
     <rh-select id="select-language">
-      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
-      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
-      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+      <rh-option value="English">English</rh-option>
+      <rh-option value="French">French</rh-option>
+      <rh-option value="Spanish">Spanish</rh-option>
     </rh-select>
   </div>
   <h3 slot="links"
@@ -233,7 +233,7 @@ description: "Full website footer with logo, social links, navigation columns, p
 
   rh-select {
     margin-inline-start: auto;
-    max-inline-size: var(--rh-length-7xl, 128px);
+    inline-size: fit-content;
   }
 
   rh-footer-block p {

--- a/elements/rh-footer/demo/legacy.html
+++ b/elements/rh-footer/demo/legacy.html
@@ -1,0 +1,261 @@
+---
+description: "Legacy footer slot pattern. Demonstrates backward compatibility with existing implementations that have not yet migrated social links and copyright to slot='tertiary'."
+---
+<p><strong>Note:</strong> This demo uses the legacy slot pattern. Social links are in <code>slot="social-links"</code> and copyright is in <code>slot="links-secondary"</code>. Users should migrate to the new pattern where both move to <code>slot="tertiary"</code> inside <code>&lt;rh-footer-universal&gt;</code>. See the <a href="/elements/footer/">default demo</a> for the current recommended pattern.</p>
+
+<rh-footer data-analytics-region="page-footer">
+  <a slot="logo"
+     href="https://redhat.com/en"
+     data-analytics-category="Footer"
+     data-analytics-text="Logo">
+    <img alt="Red Hat logo"
+         src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg"
+         loading="lazy" />
+  </a>
+  <rh-footer-social-link slot="social-links"
+                         icon="linkedin"
+                         href="https://www.linkedin.com/company/red-hat"
+                         data-analytics-region="social-links-exit"
+                         data-analytics-category="Footer|social-links"
+                         data-analytics-text="LinkedIn"
+                         accessible-label="LinkedIn"></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links"
+                         icon="youtube"
+                         href="https://www.youtube.com/user/RedHatVideos"
+                         data-analytics-region="social-links-exit"
+                         data-analytics-category="Footer|social-links"
+                         data-analytics-text="YouTube"
+                         accessible-label="YouTube"></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links"
+                         icon="facebook"
+                         href="https://www.facebook.com/redhatinc"
+                         data-analytics-region="social-links-exit"
+                         data-analytics-category="Footer|social-links"
+                         data-analytics-text="Facebook"
+                         accessible-label="Facebook"></rh-footer-social-link>
+  <rh-footer-social-link slot="social-links"
+                         icon="x"
+                         href="https://twitter.com/RedHat"
+                         data-analytics-region="social-links-exit"
+                         data-analytics-category="Footer|social-links"
+                         data-analytics-text="Twitter"
+                         accessible-label="X/Twitter"></rh-footer-social-link>
+  <h3 slot="links"
+      data-analytics-text="Platforms">Platforms</h3>
+  <ul slot="links">
+    <li><a href="https://redhat.com/en/technologies/cloud-computing/openshift/lightspeed"
+         data-analytics-category="Footer|Platforms"
+         data-analytics-text="Red Hat AI">Red Hat AI</a></li>
+    <li><a href="https://redhat.com/en/technologies/linux-platforms/enterprise-linux"
+         data-analytics-category="Footer|Platforms"
+         data-analytics-text="Red Hat Enterprise Linux">Red Hat Enterprise Linux</a></li>
+    <li><a href="https://redhat.com/en/technologies/cloud-computing/openshift"
+         data-analytics-category="Footer|Platforms"
+         data-analytics-text="Red Hat OpenShift">Red Hat OpenShift</a></li>
+    <li><a href="https://redhat.com/en/technologies/management/ansible"
+         data-analytics-category="Footer|Platforms"
+         data-analytics-text="Red Hat Ansible Automation Platform">Red Hat Ansible Automation Platform</a></li>
+    <li><a href="https://redhat.com/en/technologies/all-products"
+         data-analytics-category="Footer|Platforms"
+         data-analytics-text="See all products">See all products</a></li>
+  </ul>
+  <h3 slot="links"
+      data-analytics-text="Tools">Tools</h3>
+  <ul slot="links">
+    <li><a href="https://redhat.com/en/services/training-and-certification"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="Training and certification">Training and certification</a></li>
+    <li><a href="https://sso.redhat.com"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="My account">My account</a></li>
+    <li><a href="https://access.redhat.com"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="Customer support">Customer support</a></li>
+    <li><a href="https://developers.redhat.com/"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="Developer resources">Developer resources</a></li>
+    <li><a href="http://redhat.force.com/finder/"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="Find a partner">Find a partner</a></li>
+    <li><a href="https://catalog.redhat.com/"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="Red Hat Ecosystem Catalog">Red Hat Ecosystem Catalog</a></li>
+    <li><a href="https://docs.redhat.com/"
+         data-analytics-category="Footer|Tools"
+         data-analytics-text="Documentation">Documentation</a></li>
+  </ul>
+  <h3 slot="links"
+      data-analytics-text="Try buy sell">Try, buy, &amp; sell</h3>
+  <ul slot="links">
+    <li><a href="https://redhat.com/en/products/trials"
+         data-analytics-category="Footer|Try buy sell"
+         data-analytics-text="Product trial center">Product trial center</a></li>
+    <li><a href="https://www.redhat.com/en/store"
+         data-analytics-category="Footer|Try buy sell"
+         data-analytics-text="Red Hat Store">Red Hat Store</a></li>
+    <li><a href="https://cloud.redhat.com/"
+         data-analytics-category="Footer|Try buy sell"
+         data-analytics-text="Console">Console</a></li>
+  </ul>
+  <h3 slot="links"
+      data-analytics-text="Communicate">Communicate</h3>
+  <ul slot="links">
+    <li><a href="https://redhat.com/en/contact"
+         data-analytics-category="Footer|Communicate"
+         data-analytics-text="Contact sales">Contact sales</a></li>
+    <li><a href="https://redhat.com/en/services/support"
+         data-analytics-category="Footer|Communicate"
+         data-analytics-text="Contact customer service">Contact customer service</a></li>
+    <li><a href="https://redhat.com/en/services/training-and-certification/contact-us"
+         data-analytics-category="Footer|Communicate"
+         data-analytics-text="Contact training">Contact training</a></li>
+    <li><a href="https://redhat.com/en/about/social"
+         data-analytics-category="Footer|Communicate"
+         data-analytics-text="Social">Social</a></li>
+  </ul>
+  <rh-footer-block slot="main-secondary">
+    <h3 slot="header"
+        data-analytics-text="About Red Hat">About Red Hat</h3>
+    <p>Red Hat is an open hybrid cloud technology leader, delivering a consistent, comprehensive foundation for transformative IT and artificial intelligence (AI) applications in the enterprise. As a <a href="https://redhat.com/en/about/company">trusted adviser to the Fortune 500</a>, Red Hat offers cloud, developer, Linux, automation, and application platform technologies, as well as <a href="https://redhat.com/en/about/our-culture/awards">award-winning</a> services.</p>
+    <ul>
+      <li><a href="https://redhat.com/en/about/company"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Our company">Our company</a></li>
+      <li><a href="https://redhat.com/en/about/newsroom"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Newsroom">Newsroom</a></li>
+      <li><a href="https://redhat.com/en/about/development-model"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="How we work">How we work</a></li>
+      <li><a href="https://redhat.com/en/about/open-source"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Open source commitments">Open source commitments</a></li>
+      <li><a href="https://redhat.com/en/success-stories"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Customer success stories">Customer success stories</a></li>
+      <li><a href="https://redhat.com/en/about/social-responsibility"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Our social impact">Our social impact</a></li>
+      <li><a href="https://redhat.com/en/about/analyst-relations"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Analyst relations">Analyst relations</a></li>
+      <li><a href="https://redhat.com/en/jobs"
+           data-analytics-category="Footer|About Red Hat"
+           data-analytics-text="Jobs">Jobs</a></li>
+    </ul>
+  </rh-footer-block>
+
+  <!-- Universal Footer -->
+  <rh-footer-universal slot="universal">
+    <h3 slot="links-primary"
+        data-analytics-text="Red Hat corporate links"
+        hidden>Red Hat corporate links</h3>
+    <ul slot="links-primary"
+        data-analytics-region="page-footer-bottom-primary">
+      <li><a href="https://redhat.com/en/about/company"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="About Red Hat">About Red Hat</a></li>
+      <li><a href="https://redhat.com/en/jobs"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Jobs">Jobs</a></li>
+      <li><a href="https://redhat.com/en/events"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Events">Events</a></li>
+      <li><a href="https://redhat.com/en/about/office-locations"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Locations">Locations</a></li>
+      <li><a href="https://redhat.com/en/contact"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Contact Red Hat">Contact Red Hat</a></li>
+      <li><a href="https://redhat.com/en/blog"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Red Hat Blog">Red Hat Blog</a></li>
+      <li><a href="https://redhat.com/en/about/our-culture/diversity-equity-inclusion"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Diversity equity and inclusion">Diversity, equity, and inclusion</a></li>
+      <li><a href="https://coolstuff.redhat.com/"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
+      <li><a href="https://www.redhat.com/en/summit"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
+    </ul>
+    <rh-footer-copyright slot="links-secondary">&copy; 2026 Red Hat</rh-footer-copyright>
+    <h3 slot="links-secondary"
+        data-analytics-text="Red Hat legal and privacy links"
+        hidden>Red Hat legal and privacy links</h3>
+    <ul slot="links-secondary"
+        data-analytics-region="page-footer-bottom-secondary">
+      <li><a href="https://redhat.com/en/about/privacy-policy"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Privacy statement">Privacy statement</a></li>
+      <li><a href="https://redhat.com/en/about/terms-use"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Terms of use">Terms of use</a></li>
+      <li><a href="https://redhat.com/en/about/all-policies-guidelines"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="All policies and guidelines">All policies and guidelines</a></li>
+      <li><a href="https://redhat.com/en/about/digital-accessibility"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Digital accessibility">Digital accessibility</a></li>
+      <li><a href="#"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Cookie preferences">Cookie preferences</a></li>
+    </ul>
+  </rh-footer-universal>
+</rh-footer>
+
+<link rel="stylesheet"
+      href="../rh-footer-lightdom.css">
+
+<style>
+  rh-footer-block p {
+    margin-block: 0 var(--rh-space-2xl, 32px);
+  }
+
+  rh-footer-block ul {
+    padding-inline-start: 0;
+    margin-block: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--rh-space-md, 8px) var(--rh-space-2xl, 32px);
+  }
+
+  rh-footer-block p a {
+    color: var(--rh-color-interactive-primary-default) !important;
+    text-decoration: underline;
+    text-decoration-thickness: var(--rh-border-width-sm, 1px);
+    text-decoration-style: dashed;
+    text-underline-offset: max(5px, 0.28em);
+  }
+
+  rh-footer-block p a:hover {
+    text-decoration-color: inherit;
+    text-underline-offset: max(6px, 0.33em);
+  }
+
+  rh-footer-block ul a {
+    color: var(--rh-color-text-primary);
+    display: inline-block;
+    font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+    padding-block: var(--rh-space-xs, 4px);
+    text-decoration: none;
+    transition-timing-function: ease;
+    transition-property: text-underline-offset, color, text-decoration-color;
+    transition-duration: 0.3s;
+  }
+
+  rh-footer-block ul a:is(:hover, :focus, :focus-visible) {
+    color: var(--rh-color-text-primary);
+    text-decoration:
+      underline
+      var(--rh-border-width-sm, 1px)
+      dashed;
+    text-decoration-color: inherit;
+    text-underline-offset: max(5px, 0.28em);
+  }
+</style>
+
+<script type="module">
+  import '@rhds/elements/rh-footer/rh-footer.js';
+</script>

--- a/elements/rh-footer/demo/slotted-social-links.html
+++ b/elements/rh-footer/demo/slotted-social-links.html
@@ -13,9 +13,9 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
   <div slot="header-secondary">
     <label class="visually-hidden" for="select-language">Choose page language:</label>
     <rh-select id="select-language">
-      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
-      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
-      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+      <rh-option value="English">English</rh-option>
+      <rh-option value="French">French</rh-option>
+      <rh-option value="Spanish">Spanish</rh-option>
     </rh-select>
   </div>
   <h3 slot="links"
@@ -224,7 +224,7 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
 
   rh-select {
     margin-inline-start: auto;
-    max-inline-size: var(--rh-length-7xl, 128px);
+    inline-size: fit-content;
   }
 
   rh-footer-block p {

--- a/elements/rh-footer/demo/slotted-social-links.html
+++ b/elements/rh-footer/demo/slotted-social-links.html
@@ -10,26 +10,14 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
          src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg"
          loading="lazy" />
   </a>
-  <rh-footer-social-link slot="social-links"
-                         icon="linkedin"><a href="https://www.linkedin.com/company/red-hat"
-       data-analytics-region="social-links-exit"
-       data-analytics-category="Footer|social-links"
-       data-analytics-text="LinkedIn">LinkedIn</a></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="youtube"><a href="https://www.youtube.com/user/RedHatVideos"
-       data-analytics-region="social-links-exit"
-       data-analytics-category="Footer|social-links"
-       data-analytics-text="YouTube">YouTube</a></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="facebook"><a href="https://www.facebook.com/redhatinc"
-       data-analytics-region="social-links-exit"
-       data-analytics-category="Footer|social-links"
-       data-analytics-text="Facebook">Facebook</a></rh-footer-social-link>
-  <rh-footer-social-link slot="social-links"
-                         icon="x"><a href="https://twitter.com/RedHat"
-       data-analytics-region="social-links-exit"
-       data-analytics-category="Footer|social-links"
-       data-analytics-text="Twitter">X/Twitter</a></rh-footer-social-link>
+  <div slot="header-secondary">
+    <label class="visually-hidden" for="select-language">Choose page language:</label>
+    <rh-select id="select-language">
+      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
+      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
+      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+    </rh-select>
+  </div>
   <h3 slot="links"
       data-analytics-text="Platforms">Platforms</h3>
   <ul slot="links">
@@ -170,7 +158,6 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
            data-analytics-category="Footer|Corporate"
            data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary">© 2026 Red Hat</rh-footer-copyright>
     <h3 slot="links-secondary"
         data-analytics-text="Red Hat legal and privacy links"
         hidden>Red Hat legal and privacy links</h3>
@@ -192,6 +179,30 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
            data-analytics-category="Footer|Red Hat legal and privacy links"
            data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
+    <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+    <!-- Slotted <a> pattern: anchor elements inside rh-footer-social-link -->
+    <rh-footer-links slot="tertiary" role="list">
+      <rh-footer-social-link icon="linkedin"><a href="https://www.linkedin.com/company/red-hat"
+         data-analytics-region="social-links-exit"
+         data-analytics-category="Footer|social-links"
+         data-analytics-text="LinkedIn">LinkedIn</a></rh-footer-social-link>
+      <rh-footer-social-link icon="youtube"><a href="https://www.youtube.com/user/RedHatVideos"
+         data-analytics-region="social-links-exit"
+         data-analytics-category="Footer|social-links"
+         data-analytics-text="YouTube">YouTube</a></rh-footer-social-link>
+      <rh-footer-social-link icon="facebook"><a href="https://www.facebook.com/redhatinc"
+         data-analytics-region="social-links-exit"
+         data-analytics-category="Footer|social-links"
+         data-analytics-text="Facebook">Facebook</a></rh-footer-social-link>
+      <rh-footer-social-link icon="x"><a href="https://twitter.com/RedHat"
+         data-analytics-region="social-links-exit"
+         data-analytics-category="Footer|social-links"
+         data-analytics-text="X/Twitter">X/Twitter</a></rh-footer-social-link>
+      <rh-footer-social-link icon="instagram"><a href="https://www.instagram.com/redhat"
+         data-analytics-region="social-links-exit"
+         data-analytics-category="Footer|social-links"
+         data-analytics-text="Instagram">Instagram</a></rh-footer-social-link>
+    </rh-footer-links>
   </rh-footer-universal>
 </rh-footer>
 
@@ -199,6 +210,23 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
       href="../rh-footer-lightdom.css">
 
 <style>
+  .visually-hidden {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    block-size: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    inline-size: 1px;
+  }
+
+  rh-select {
+    margin-inline-start: auto;
+    max-inline-size: var(--rh-length-7xl, 128px);
+  }
+
   rh-footer-block p {
     margin-block: 0 var(--rh-space-2xl, 32px);
   }
@@ -248,4 +276,5 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
 
 <script type="module">
   import '@rhds/elements/rh-footer/rh-footer.js';
+  import '@rhds/elements/rh-select/rh-select.js';
 </script>

--- a/elements/rh-footer/demo/subdomain.html
+++ b/elements/rh-footer/demo/subdomain.html
@@ -184,7 +184,7 @@ description: "Subdomain footer for docs or other Red Hat properties. Shows domai
 
   .header-controls {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     gap: var(--rh-space-lg, 16px);
   }
 

--- a/elements/rh-footer/demo/subdomain.html
+++ b/elements/rh-footer/demo/subdomain.html
@@ -1,0 +1,219 @@
+---
+description: "Subdomain footer for docs or other Red Hat properties. Shows domain name, language/theme switcher placeholders, and fewer navigation columns."
+---
+<rh-footer data-analytics-region="page-footer">
+  <a slot="logo"
+     href="https://docs.redhat.com"
+     data-analytics-category="Footer"
+     data-analytics-text="Logo">Docs</a>
+  <div slot="header-secondary" class="header-controls">
+    <label class="visually-hidden" for="select-language">Choose page language:</label>
+    <rh-select id="select-language">
+      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
+      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
+      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+    </rh-select>
+    <rh-scheme-dropdown></rh-scheme-dropdown>
+  </div>
+  <h3 slot="links"
+      data-analytics-text="Learn">Learn</h3>
+  <ul slot="links">
+    <li><a href="https://developers.redhat.com/"
+         data-analytics-category="Footer|Learn"
+         data-analytics-text="Developer resources">Developer resources</a></li>
+    <li><a href="https://learn.redhat.com/"
+         data-analytics-category="Footer|Learn"
+         data-analytics-text="Cloud learning hub">Cloud learning hub</a></li>
+    <li><a href="https://developers.redhat.com/learn"
+         data-analytics-category="Footer|Learn"
+         data-analytics-text="Interactive labs">Interactive labs</a></li>
+    <li><a href="https://redhat.com/en/services/training-and-certification"
+         data-analytics-category="Footer|Learn"
+         data-analytics-text="Training and certification">Training and certification</a></li>
+    <li><a href="https://access.redhat.com"
+         data-analytics-category="Footer|Learn"
+         data-analytics-text="Customer support">Customer support</a></li>
+    <li><a href="https://docs.redhat.com/"
+         data-analytics-category="Footer|Learn"
+         data-analytics-text="See all documentation">See all documentation</a></li>
+  </ul>
+  <h3 slot="links"
+      data-analytics-text="Try buy sell">Try, buy, &amp; sell</h3>
+  <ul slot="links">
+    <li><a href="https://redhat.com/en/products/trials"
+         data-analytics-category="Footer|Try buy sell"
+         data-analytics-text="Product trial center">Product trial center</a></li>
+    <li><a href="https://catalog.redhat.com/"
+         data-analytics-category="Footer|Try buy sell"
+         data-analytics-text="Red Hat Ecosystem Catalog">Red Hat Ecosystem Catalog</a></li>
+    <li><a href="https://www.redhat.com/en/store"
+         data-analytics-category="Footer|Try buy sell"
+         data-analytics-text="Red Hat Store">Red Hat Store</a></li>
+  </ul>
+  <h3 slot="links"
+      data-analytics-text="Communities">Communities</h3>
+  <ul slot="links">
+    <li><a href="https://access.redhat.com/community"
+         data-analytics-category="Footer|Communities"
+         data-analytics-text="Customer Portal Community">Customer Portal Community</a></li>
+    <li><a href="https://redhat.com/en/events"
+         data-analytics-category="Footer|Communities"
+         data-analytics-text="Events">Events</a></li>
+    <li><a href="https://redhat.com/en/about/open-source"
+         data-analytics-category="Footer|Communities"
+         data-analytics-text="How we contribute">How we contribute</a></li>
+  </ul>
+  <rh-footer-block slot="main-secondary">
+    <h3 slot="header"
+        data-analytics-text="About Red Hat Documentation">About Red Hat Documentation</h3>
+    <p>We help Red Hat users innovate and achieve their goals with our products and services with content they can trust. <a href="https://docs.redhat.com/en/documentation">Explore our recent updates</a>.</p>
+    <h3 data-analytics-text="Making open source more inclusive">Making open source more inclusive</h3>
+    <p>Red Hat is committed to replacing problematic language in our code, documentation, and web properties. For more details, see the <a href="https://redhat.com/en/blog">Red Hat Blog</a>.</p>
+    <h3 data-analytics-text="About Red Hat">About Red Hat</h3>
+    <p>We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
+    <rh-site-status></rh-site-status>
+  </rh-footer-block>
+
+  <!-- Universal Footer -->
+  <rh-footer-universal slot="universal">
+    <h3 slot="links-primary"
+        data-analytics-text="Red Hat corporate links"
+        hidden>Red Hat corporate links</h3>
+    <ul slot="links-primary"
+        data-analytics-region="page-footer-bottom-primary">
+      <li><a href="https://redhat.com/en/about/company"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="About Red Hat">About Red Hat</a></li>
+      <li><a href="https://redhat.com/en/jobs"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Jobs">Jobs</a></li>
+      <li><a href="https://redhat.com/en/events"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Events">Events</a></li>
+      <li><a href="https://redhat.com/en/about/office-locations"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Locations">Locations</a></li>
+      <li><a href="https://redhat.com/en/contact"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Contact Red Hat">Contact Red Hat</a></li>
+      <li><a href="https://redhat.com/en/blog"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Red Hat Blog">Red Hat Blog</a></li>
+      <li><a href="https://redhat.com/en/about/our-culture/diversity-equity-inclusion"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Inclusion at Red Hat">Inclusion at Red Hat</a></li>
+      <li><a href="https://coolstuff.redhat.com/"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
+      <li><a href="https://www.redhat.com/en/summit"
+           data-analytics-category="Footer|Corporate"
+           data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
+    </ul>
+    <h3 slot="links-secondary"
+        data-analytics-text="Red Hat legal and privacy links"
+        hidden>Red Hat legal and privacy links</h3>
+    <ul slot="links-secondary"
+        data-analytics-region="page-footer-bottom-secondary">
+      <li><a href="https://redhat.com/en/about/privacy-policy"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Privacy statement">Privacy statement</a></li>
+      <li><a href="https://redhat.com/en/about/terms-use"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Terms of use">Terms of use</a></li>
+      <li><a href="https://redhat.com/en/about/all-policies-guidelines"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="All policies and guidelines">All policies and guidelines</a></li>
+      <li><a href="https://redhat.com/en/about/digital-accessibility"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Digital accessibility">Digital accessibility</a></li>
+      <li><a href="#"
+           data-analytics-category="Footer|Red Hat legal and privacy links"
+           data-analytics-text="Cookie preferences">Cookie preferences</a></li>
+    </ul>
+    <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
+    <rh-footer-links slot="tertiary" role="list">
+      <rh-footer-social-link icon="linkedin"
+                             href="https://www.linkedin.com/company/red-hat"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="LinkedIn"
+                             accessible-label="LinkedIn"></rh-footer-social-link>
+      <rh-footer-social-link icon="youtube"
+                             href="https://www.youtube.com/user/RedHatVideos"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="YouTube"
+                             accessible-label="YouTube"></rh-footer-social-link>
+      <rh-footer-social-link icon="facebook"
+                             href="https://www.facebook.com/redhatinc"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="Facebook"
+                             accessible-label="Facebook"></rh-footer-social-link>
+      <rh-footer-social-link icon="x"
+                             href="https://twitter.com/RedHat"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="X/Twitter"
+                             accessible-label="X/Twitter"></rh-footer-social-link>
+      <rh-footer-social-link icon="instagram"
+                             href="https://www.instagram.com/redhat"
+                             data-analytics-region="social-links-exit"
+                             data-analytics-category="Footer|social-links"
+                             data-analytics-text="Instagram"
+                             accessible-label="Instagram"></rh-footer-social-link>
+    </rh-footer-links>
+  </rh-footer-universal>
+</rh-footer>
+
+<link rel="stylesheet"
+      href="../rh-footer-lightdom.css">
+
+<style>
+  .visually-hidden {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    block-size: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    inline-size: 1px;
+  }
+
+  .header-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--rh-space-lg, 16px);
+  }
+
+  rh-select {
+    margin-inline-start: auto;
+    max-inline-size: var(--rh-length-7xl, 128px);
+  }
+
+  rh-footer-block p {
+    margin-block: 0 var(--rh-space-lg, 16px);
+  }
+
+  rh-footer-block p a {
+    color: var(--rh-color-interactive-primary-default) !important;
+    text-decoration: underline;
+    text-decoration-thickness: var(--rh-border-width-sm, 1px);
+    text-decoration-style: dashed;
+    text-underline-offset: max(5px, 0.28em);
+  }
+
+  rh-footer-block p a:hover {
+    text-decoration-color: inherit;
+    text-underline-offset: max(6px, 0.33em);
+  }
+</style>
+
+<script type="module">
+  import '@rhds/elements/rh-footer/rh-footer.js';
+  import '@rhds/elements/rh-select/rh-select.js';
+  import '@rhds/elements/rh-scheme-dropdown/rh-scheme-dropdown.js';
+  import '@rhds/elements/rh-site-status/rh-site-status.js';
+</script>

--- a/elements/rh-footer/demo/subdomain.html
+++ b/elements/rh-footer/demo/subdomain.html
@@ -190,7 +190,8 @@ description: "Subdomain footer for docs or other Red Hat properties. Shows domai
 
   rh-select {
     margin-inline-start: auto;
-    max-inline-size: var(--rh-length-7xl, 128px);
+    min-inline-size: var(--rh-length-7xl, 128px);;
+    inline-size: fit-content;
   }
 
   rh-footer-block p {

--- a/elements/rh-footer/demo/subdomain.html
+++ b/elements/rh-footer/demo/subdomain.html
@@ -9,9 +9,9 @@ description: "Subdomain footer for docs or other Red Hat properties. Shows domai
   <div slot="header-secondary" class="header-controls">
     <label class="visually-hidden" for="select-language">Choose page language:</label>
     <rh-select id="select-language">
-      <rh-option value="English" icon-set="ui" icon="language">English</rh-option>
-      <rh-option value="French" icon-set="ui" icon="language">French</rh-option>
-      <rh-option value="Spanish" icon-set="ui" icon="language">Spanish</rh-option>
+      <rh-option value="English">English</rh-option>
+      <rh-option value="French">French</rh-option>
+      <rh-option value="Spanish">Spanish</rh-option>
     </rh-select>
     <rh-scheme-dropdown></rh-scheme-dropdown>
   </div>
@@ -190,12 +190,11 @@ description: "Subdomain footer for docs or other Red Hat properties. Shows domai
 
   rh-select {
     margin-inline-start: auto;
-    min-inline-size: var(--rh-length-7xl, 128px);;
     inline-size: fit-content;
   }
 
   rh-footer-block p {
-    margin-block: 0 var(--rh-space-lg, 16px);
+    margin-block: 0 var(--rh-space-2xl, 32px);
   }
 
   rh-footer-block p a {

--- a/elements/rh-footer/rh-footer-block.css
+++ b/elements/rh-footer/rh-footer-block.css
@@ -22,7 +22,7 @@
   /** Footer block default font size */
   font-size: var(--rh-font-size-body-text-sm, 0.875rem) !important;
   text-decoration: none;
-  max-width: 650px;
+  max-width: none;
 }
 
 ::slotted(:is(h1, h2, h3, h4, h5)) {

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -131,7 +131,7 @@ rh-footer-universal [slot^='links'] a {
   width: auto;
 
   /** Logo image height */
-  height: var(--rh-size-icon-02, 24px);
+  height: var(--rh-size-icon-03, 32px);
 }
 
 @media screen and (min-width: 768px) {
@@ -140,7 +140,7 @@ rh-footer-universal [slot^='links'] a {
   }
 
   :is(rh-footer) a[slot^='logo'] > :is(img, svg) {
-    height: var(--rh-size-icon-04, 40px);
+    height: var(--rh-size-icon-03, 32px);
   }
 }
 

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -350,8 +350,8 @@
   display: block;
   width: auto;
 
-  /** Logo image height (mobile) */
-  height: var(--rh-size-icon-02, 24px);
+  /** Logo image height */
+  height: var(--rh-size-icon-03, 32px);
 }
 
 .social-links {
@@ -522,7 +522,7 @@
 
   .logo a > :is(img, svg) {
     /** Logo image height (desktop) */
-    height: var(--rh-size-icon-04, 40px);
+    height: var(--rh-size-icon-03, 32px);
   }
 
   .global-logo {

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -253,11 +253,36 @@
   justify-content: space-between;
 }
 
+.global-secondary-end {
+  display: flex;
+
+  /** Social links gap in universal footer */
+  gap: var(--rh-space-xl, 24px);
+  align-items: center;
+}
+
 .global-tertiary {
   grid-area: tertiary;
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   justify-content: start;
-  align-items: start;
+  align-items: center;
+
+  /** Gap between copyright and social icons row */
+  gap: var(--rh-space-lg, 16px);
+}
+
+::slotted(rh-footer-copyright) {
+  grid-column: -1/1;
+}
+
+/* Copyright takes full width so social icons flow to the next line */
+.global-tertiary ::slotted(rh-footer-copyright) {
+  flex-basis: 100%;
+}
+
+.global-tertiary ::slotted(rh-footer-links) {
+  display: contents;
 }
 
 .global-links-primary {
@@ -486,10 +511,6 @@
   color: var(--rh-color-text-primary) !important;
 }
 
-::slotted(rh-footer-copyright) {
-  grid-column: -1/1;
-}
-
 @media screen and (min-width: 768px) {
   .header-primary ::slotted(:not(a, img, svg, picture)) {
     /** Subdomain name font size (desktop) */
@@ -519,32 +540,43 @@
       'logo      logo      logo'
       'primary   primary   primary'
       'spacer    spacer    spacer'
-      'secondary secondary secondary';
-  }
-
-  .global-base:is(.hasTertiary) {
-    grid-template-columns: 4fr 4fr 4fr;
-    grid-template-areas:
-      'logo      logo      logo'
-      'primary   primary   primary'
-      'spacer    spacer    spacer'
-      'secondary secondary tertiary';
+      'secondary secondary secondary'
+      'tertiary  tertiary  tertiary';
   }
 }
 
 @media screen and /* --rh-media-md */ (min-width: 992px) {
-  /* :not(.nothing) is a hack to match CSS specificity with :is(.hasTertiary) */
+  /* Match CSS specificity with :is(.hasTertiary) */
   .global-base:not(.nothing) {
-    grid-template-columns: auto 10fr 2fr;
-    grid-template-rows: max-content max-content;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: max-content max-content auto;
     grid-template-areas:
-      'logo primary  tertiary'
-      'logo secondary tertiary';
-    gap: 24px 32px;
+      'logo    primary'
+      'logo    secondary'
+      '.       tertiary';
+    gap: var(--rh-space-xl, 24px) var(--rh-space-2xl, 32px);
   }
 
   .global-primary {
     display: flex;
+  }
+}
+
+@media screen and /* WARNING: not an @rhds/tokens media query */ (min-width: 1200px) {
+  .global-base:not(.nothing) {
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: max-content max-content;
+    grid-template-areas:
+      'logo primary  tertiary'
+      'logo secondary tertiary';
+  }
+
+  .global-tertiary {
+    place-content: center flex-end;
+  }
+
+  .global-tertiary ::slotted(rh-footer-copyright) {
+    text-align: end;
   }
 }
 
@@ -560,10 +592,17 @@
 }
 
 @media screen and /* --rh-media-md */ (min-width: 992px) {
-  .global-tertiary {
-    display: grid;
-    justify-content: flex-end;
+  .global-secondary {
+    flex-flow: row wrap;
     align-items: center;
+  }
+
+  .global-links-secondary {
+    flex: 0 1 auto;
+  }
+
+  .global-secondary-end {
+    margin-inline-start: auto;
   }
 }
 
@@ -589,11 +628,6 @@
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
   }
-
-  .hasTertiary .global-links-secondary {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
 }
 
 @media screen and /* --rh-media-md */ (min-width: 992px) {
@@ -605,7 +639,7 @@
 }
 
 @media screen and /* --rh-media-md */ (min-width: 992px) {
-  :not(.hasTertiary) .global-links-secondary {
+  .global-links-secondary {
     display: flex;
     flex-flow: row wrap;
     gap: 8px 24px;

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -228,12 +228,15 @@
 
 .global-logo {
   grid-area: logo;
-  width: var(--_logo-width);
+  width: auto;
+  height: var(--rh-size-icon-02, 24px);
 }
 
 .global-logo-image {
   /** Red Hat fedora brand color */
   fill: var(--rh-color-brand-red, #ee0000);
+  height: 100%;
+  width: auto;
 }
 
 .global-primary {
@@ -519,6 +522,10 @@
 
   .logo a > :is(img, svg) {
     /** Logo image height (desktop) */
+    height: var(--rh-size-icon-04, 40px);
+  }
+
+  .global-logo {
     height: var(--rh-size-icon-04, 40px);
   }
 

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -437,10 +437,10 @@ describe('<rh-footer>', function() {
         expect(Math.abs(lastChild.getBoundingClientRect().bottom - block.getBoundingClientRect().bottom) < 5).to.be.true;
       });
 
-      it('has a max-width for contents', async function() {
+      it('has no max-width constraint on contents', async function() {
         const element = await fixture<RhFooter>(KITCHEN_SINK_TEMPLATE);
         const block = element.querySelector('rh-footer-block');
-        expect(getComputedStyle(block?.querySelector('p') as Element)?.maxWidth).to.equal('650px');
+        expect(getComputedStyle(block?.querySelector('p') as Element)?.maxWidth).to.equal('none');
       });
     });
 

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -12,21 +12,6 @@ const KITCHEN_SINK_TEMPLATE = html`
       <img src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg" alt="Red Hat logo"
         loading="lazy"/>
     </a>
-    <rh-footer-social-link slot="social-links" icon="linkedin">
-      <a href="http://www.linkedin.com/company/red-hat">LinkedIn</a>
-    </rh-footer-social-link>
-    <rh-footer-social-link slot="social-links" icon="youtube">
-      <a href="http://www.youtube.com/user/RedHatVideos">Youtube</a>
-    </rh-footer-social-link>
-    <rh-footer-social-link slot="social-links" icon="facebook">
-      <a href="https://www.facebook.com/redhatinc">Facebook</a>
-    </rh-footer-social-link>
-    <!-- This is commented out because logos are exempt from contrast checks
-     and was throwing an error in automated axe test.
-     https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html
-    <rh-footer-social-link slot="social-links" icon="x">
-      <a href="https://twitter.com/RedHat">Twitter</a>
-    </rh-footer-social-link> -->
     <h3 slot="links">Products</h3>
     <ul slot="links">
       <li><a href="#">Red Hat Ansible Automation Platform</a></li>
@@ -103,7 +88,6 @@ const KITCHEN_SINK_TEMPLATE = html`
         <li><a href="#">Cool Stuff Store</a></li>
         <li><a href="#">Red Hat Summit</a></li>
       </ul>
-      <rh-footer-copyright slot="links-secondary"></rh-footer-copyright>
       <h3 slot="links-secondary" hidden>Red Hat legal and privacy links</h3>
       <ul slot="links-secondary">
         <li><a href="#">Privacy statement</a></li>
@@ -112,6 +96,21 @@ const KITCHEN_SINK_TEMPLATE = html`
         <li><a href="#">Digital accessibility</a></li>
         <li><a href="#">Cookie preferences</a></li>
       </ul>
+      <rh-footer-copyright slot="tertiary"></rh-footer-copyright>
+      <rh-footer-links slot="tertiary" role="list">
+        <rh-footer-social-link icon="linkedin"
+                               href="https://www.linkedin.com/company/red-hat"
+                               accessible-label="LinkedIn"></rh-footer-social-link>
+        <rh-footer-social-link icon="youtube"
+                               href="https://www.youtube.com/user/RedHatVideos"
+                               accessible-label="YouTube"></rh-footer-social-link>
+        <rh-footer-social-link icon="facebook"
+                               href="https://www.facebook.com/redhatinc"
+                               accessible-label="Facebook"></rh-footer-social-link>
+        <rh-footer-social-link icon="x"
+                               href="https://twitter.com/RedHat"
+                               accessible-label="X/Twitter"></rh-footer-social-link>
+      </rh-footer-links>
     </rh-footer-universal>
   </rh-footer>
   <link rel="stylesheet" href="/elements/rh-footer/rh-footer-lightdom.css">
@@ -131,7 +130,6 @@ const UNIVERSAL_FOOTER_TEMPLATE = html`
       <li><a href="#">Cool Stuff Store</a></li>
       <li><a href="#">Red Hat Summit</a></li>
     </ul>
-    <rh-footer-copyright slot="links-secondary"></rh-footer-copyright>
     <h3 slot="links-secondary" hidden>Red Hat legal and privacy links</h3>
     <ul slot="links-secondary">
       <li><a href="#">Privacy statement</a></li>
@@ -140,6 +138,21 @@ const UNIVERSAL_FOOTER_TEMPLATE = html`
       <li><a href="#">Digital accessibility</a></li>
       <li><a href="#">Cookie preferences</a></li>
     </ul>
+    <rh-footer-copyright slot="tertiary"></rh-footer-copyright>
+    <rh-footer-links slot="tertiary" role="list">
+      <rh-footer-social-link icon="linkedin"
+                             href="https://www.linkedin.com/company/red-hat"
+                             accessible-label="LinkedIn"></rh-footer-social-link>
+      <rh-footer-social-link icon="youtube"
+                             href="https://www.youtube.com/user/RedHatVideos"
+                             accessible-label="YouTube"></rh-footer-social-link>
+      <rh-footer-social-link icon="facebook"
+                             href="https://www.facebook.com/redhatinc"
+                             accessible-label="Facebook"></rh-footer-social-link>
+      <rh-footer-social-link icon="x"
+                             href="https://twitter.com/RedHat"
+                             accessible-label="X/Twitter"></rh-footer-social-link>
+    </rh-footer-links>
   </rh-footer-universal>
   <link rel="stylesheet" href="/elements/rh-footer/rh-footer-lightdom.css">
 `;
@@ -345,7 +358,7 @@ describe('<rh-footer>', function() {
         logo = universalFooter?.shadowRoot?.querySelector('.global-logo');
         primary = universalFooter?.shadowRoot?.querySelector('.global-primary');
         spacer = universalFooter?.shadowRoot?.querySelector('.spacer');
-        secondaryContent = universalFooter?.querySelector('[slot*=secondary]');
+        secondaryContent = universalFooter?.shadowRoot?.querySelector('.global-links-secondary');
         tertiary = universalFooter?.shadowRoot?.querySelector('.global-tertiary');
         redHatLogo = element.querySelector('[slot*="logo"]');
       });


### PR DESCRIPTION
## What I did

1. Related to #3032 #2870 #3054 #3052
2. Updated universal footer grid layout for the new `slot="tertiary"` region at 768px, 992px, and 1200px breakpoints
3. Moved social links from `slot="social-links"` (header) to `slot="tertiary"` inside `<rh-footer-universal>`
4. Moved copyright from `slot="links-secondary"` to `slot="tertiary"`
5. Added language switcher (`<rh-select>`) to `slot="header-secondary"` in full footer demos
6. Added subdomain demo with text-only logo, `<rh-scheme-dropdown>`, and `<rh-site-status>`
7. Added legacy demo proving backward compatibility with the old slot pattern
8. Removed obsolete `.hasTertiary` CSS rules
9. Updated tests, README, and changeset

## Testing Instructions

1. Review the [Figma](https://www.figma.com/design/3wQSDZwhzcBZeCKLdVr8gk/Footer-updates-Q1-2026?node-id=72-5964&m=dev).
2. Visit the [default demo](http://deploy-preview-3058--red-hat-design-system.netlify.app/elements/footer/demo/). Verify social icons appear in the universal footer tertiary area (not the header) and the language switcher is in the header.
3. Visit the [subdomain demo](http://deploy-preview-3058--red-hat-design-system.netlify.app/elements/footer/demo/subdomain/). Verify text-only logo, `<rh-scheme-dropdown>` + language switcher side by side, and `<rh-site-status>`.
4. Visit the [legacy demo](http://deploy-preview-3058--red-hat-design-system.netlify.app/elements/footer/demo/legacy/). Verify social icons still render in the header (old pattern).
5. Check the [slotted social links](http://deploy-preview-3058--red-hat-design-system.netlify.app/elements/footer/demo/slotted-social-links/) and [universal footer](http://deploy-preview-3058--red-hat-design-system.netlify.app/elements/footer/demo/footer-universal/) demos.
6. Resize to 360px, 768px, 992px, and 1200px — verify layout at each breakpoint.
7. Test the subdomain demo in Firefox / non-custom select supporting browsers — the scheme dropdown renders as a native `<select>` (expected). Both controls should stay on the same line at >= 768px.
8. Test for accessibility.
9. Verify demos match design specs ala Figma.

## Backward Compatibility

The previous slot pattern (`slot="social-links"` and copyright in `slot="links-secondary"`) continues to work. The legacy demo proves this. Users should migrate to the new `slot="tertiary"` pattern at their convenience.