### PR TITLE
feat(spinner): add CSS custom properties for unified animation overrides

### DIFF
--- a/.changeset/bright-circles-spin.md
+++ b/.changeset/bright-circles-spin.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-spinner>`: add public CSS custom properties for theme-based animation overrides. Adds `--rh-spinner-stroke-width`, `--rh-spinner-vector-effect`, `--rh-spinner-circle-radius`, `--rh-spinner-container-animation-name`, `--rh-spinner-container-animation-duration`, `--rh-spinner-container-animation-timing`, `--rh-spinner-animation-name`, `--rh-spinner-animation-duration`, `--rh-spinner-animation-timing`, `--rh-spinner-dash-array`, `--rh-spinner-dash-offset`, `--rh-spinner-rotate-start`, `--rh-spinner-track-display`, `--rh-spinner-sm-animation-name`, `--rh-spinner-sm-dash-array`, and `--rh-spinner-sm-dash-offset`. 
+Includes `felt-dash` and `felt-rotate` keyframes in the shadow root for Felt theme compatibility.

--- a/elements/rh-spinner/rh-spinner.css
+++ b/elements/rh-spinner/rh-spinner.css
@@ -1,4 +1,7 @@
 :host {
+  /** Stroke width of the spinner circle */
+  --rh-spinner-stroke-width: var(--rh-length-sm, 6px);
+
   display: inline-block;
   text-align: center;
   width: max-content;
@@ -28,31 +31,61 @@ svg {
   width: var(--rh-length-4xl, 64px);
 
   /** Default spinner circle stroke width */
-  stroke-width: var(--rh-length-sm, 6px);
+  stroke-width: var(--rh-spinner-stroke-width);
   overflow: hidden;
   display: block;
   margin-left: auto;
   margin-right: auto;
+  /** Container animation name for the SVG element */
+  animation-name: var(--rh-spinner-container-animation-name, none);
+
+  /** Container animation duration for the SVG element */
+  animation-duration: var(--rh-spinner-container-animation-duration, 0s);
+
+  /** Container animation timing function for the SVG element */
+  animation-timing-function: var(--rh-spinner-container-animation-timing, linear);
+  animation-iteration-count: infinite;
 }
 
 circle {
   width: 100%;
   height: 100%;
+  /** Circle radius in SVG user units */
+  r: var(--rh-spinner-circle-radius, 40);
   stroke-linecap: round;
+
+  /** SVG vector-effect for stroke scaling behavior */
+  vector-effect: var(--rh-spinner-vector-effect, non-scaling-stroke);
 }
 
 circle.dash {
   transform-origin: 50% 50%;
-  animation: rh-spinner-animation-dash 1.4s ease-out infinite;
+  /** Dash circle animation name */
+  animation-name: var(--rh-spinner-animation-name, rh-spinner-animation-dash);
+
+  /** Dash circle animation duration */
+  animation-duration: var(--rh-spinner-animation-duration, 1.4s);
+
+  /** Dash circle animation timing function */
+  animation-timing-function: var(--rh-spinner-animation-timing, ease-out);
+  animation-iteration-count: infinite;
 
   /** Animated indicator stroke color */
   stroke: var(--rh-color-accent-base);
-  stroke-dasharray: 283;
-  stroke-dashoffset: 280;
-  transform: rotate(-90deg);
+
+  /** Dash circle stroke-dasharray value */
+  stroke-dasharray: var(--rh-spinner-dash-array, 283);
+
+  /** Dash circle stroke-dashoffset value */
+  stroke-dashoffset: var(--rh-spinner-dash-offset, 280);
+
+  /** Dash circle initial rotation */
+  transform: rotate(var(--rh-spinner-rotate-start, -90deg));
 }
 
 circle.track {
+  /** Track circle display property */
+  display: var(--rh-spinner-track-display, revert);
   stroke:
     light-dark(
         /** Track stroke color in light mode */
@@ -63,49 +96,60 @@ circle.track {
   animation-duration: 0;
 }
 
-:host([size='lg']) svg {
-  /** Large spinner circle diameter */
-  width: var(--rh-size-icon-06, 64px);
-
+:host([size='lg']) {
   /** Large spinner circle stroke width */
-  stroke-width: var(--rh-length-sm, 6px);
+  --rh-spinner-stroke-width: var(--rh-length-sm, 6px);
+
+  & svg {
+    /** Large spinner circle diameter */
+    width: var(--rh-size-icon-06, 64px);
+  }
+
+  & ::slotted(p) {
+    /** Large spinner text label font size */
+    font-size: var(--rh-font-size-body-text-lg, 1.125rem);
+  }
 }
 
-:host([size='lg']) ::slotted(p) {
-  /** Large spinner text label font size */
-  font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-}
-
-:host([size='md']) svg {
-  /** Medium spinner circle diameter */
-  width: var(--rh-size-icon-04, 40px);
-
+:host([size='md']) {
   /** Medium spinner circle stroke width */
-  stroke-width: var(--rh-length-xs, 4px);
+  --rh-spinner-stroke-width: var(--rh-length-xs, 4px);
+
+  & svg {
+    /** Medium spinner circle diameter */
+    width: var(--rh-size-icon-04, 40px);
+  }
+
+  & ::slotted(p) {
+    /** Medium spinner text label font size */
+    font-size: var(--rh-font-size-body-text-md, 1rem);
+  }
 }
 
-:host([size='md']) ::slotted(p) {
-  /** Medium spinner text label font size */
-  font-size: var(--rh-font-size-body-text-md, 1rem);
-}
-
-:host([size='sm']) svg {
-  /** Small spinner circle diameter */
-  width: var(--rh-size-icon-01, 16px);
-
+:host([size='sm']) {
   /** Small spinner circle stroke width */
-  stroke-width: var(--rh-length-2xs, 3px);
-}
+  --rh-spinner-stroke-width: var(--rh-length-2xs, 3px);
 
-:host([size='sm']) circle.dash {
-  animation-name: rh-spinner-small-animation-dash;
-  stroke-dasharray: 71;
-  stroke-dashoffset: 71;
-}
+  & svg {
+    /** Small spinner circle diameter */
+    width: var(--rh-size-icon-01, 16px);
+  }
 
-:host([size='sm']) ::slotted(p) {
-  /** Small spinner text label font size */
-  font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+  & circle.dash {
+    /** Small dash circle animation name */
+    animation-name: var(--rh-spinner-sm-animation-name, rh-spinner-small-animation-dash);
+
+    /** Small dash circle stroke-dasharray value */
+    stroke-dasharray: var(--rh-spinner-sm-dash-array, 71);
+
+    /** Small dash circle stroke-dashoffset value */
+    stroke-dashoffset: var(--rh-spinner-sm-dash-offset, 71);
+  }
+
+  & ::slotted(p) {
+    /** Small spinner text label font size */
+    font-size: var(--rh-font-size-body-text-sm, 0.875rem);
+  }
 }
 
 @keyframes rh-spinner-animation-dash {
@@ -133,5 +177,31 @@ circle.track {
 
   100% {
     stroke-dashoffset: -71;
+  }
+}
+
+@keyframes felt-rotate {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+@keyframes felt-dash {
+  0% {
+    stroke-dashoffset: 280;
+    transform: rotate(0deg);
+  }
+
+  15% {
+    stroke-width: calc(var(--rh-spinner-stroke-width) - 4);
+  }
+
+  40% {
+    stroke-dasharray: 220;
+    stroke-dashoffset: 150;
+  }
+
+  100% {
+    stroke-dashoffset: 280;
+    transform: rotate(720deg);
   }
 }

--- a/elements/rh-spinner/rh-spinner.css
+++ b/elements/rh-spinner/rh-spinner.css
@@ -195,7 +195,7 @@ circle.track {
   }
 
   15% {
-    stroke-width: calc(var(--rh-spinner-stroke-width) - 4);
+    stroke-width: calc(var(--rh-spinner-stroke-width) - 4px);
   }
 
   40% {

--- a/elements/rh-spinner/rh-spinner.css
+++ b/elements/rh-spinner/rh-spinner.css
@@ -36,6 +36,7 @@ svg {
   display: block;
   margin-left: auto;
   margin-right: auto;
+
   /** Container animation name for the SVG element */
   animation-name: var(--rh-spinner-container-animation-name, none);
 
@@ -50,6 +51,7 @@ svg {
 circle {
   width: 100%;
   height: 100%;
+
   /** Circle radius in SVG user units */
   r: var(--rh-spinner-circle-radius, 40);
   stroke-linecap: round;
@@ -60,6 +62,7 @@ circle {
 
 circle.dash {
   transform-origin: 50% 50%;
+
   /** Dash circle animation name */
   animation-name: var(--rh-spinner-animation-name, rh-spinner-animation-dash);
 


### PR DESCRIPTION
## What I did

1. Related to unified theme / "Project Felt" spinner support.
2. The CSS changes in this PR expose public CSS custom properties on `rh-spinner` so that theme-level animation overrides can be applied entirely from the light DOM — no changes to the shadow root template are needed.
3. It adds the following public CSS vars to `rh-spinner`:
    - `--rh-spinner-stroke-width`
    - `--rh-spinner-vector-effect`
    - `--rh-spinner-circle-radius`
    - `--rh-spinner-container-animation-name`
    - `--rh-spinner-container-animation-duration`
    - `--rh-spinner-container-animation-timing`
    - `--rh-spinner-animation-name`
    - `--rh-spinner-animation-duration`
    - `--rh-spinner-animation-timing`
    - `--rh-spinner-dash-array`
    - `--rh-spinner-dash-offset`
    - `--rh-spinner-rotate-start`
    - `--rh-spinner-track-display`
    - `--rh-spinner-sm-animation-name`
    - `--rh-spinner-sm-dash-array`
    - `--rh-spinner-sm-dash-offset`
4. It includes `felt-dash` and `felt-rotate` `@keyframes` in the shadow root CSS — keyframes must live inside the shadow root because `@keyframes` defined outside shadow DOM are not accessible inside it.
5. The `felt-dash` keyframe uses PatternFly's exact source values (`stroke-dasharray: 283/220`, `stroke-dashoffset: 280/150`, `stroke-width: calc(var(--rh-spinner-stroke-width) - 4)`, `transform: rotate(720deg)`), verified pixel-for-pixel against PF v6 using the Web Animations API.

```css
  rh-spinner {
    --rh-spinner-track-display: none;
    --rh-spinner-vector-effect: none;
    --rh-spinner-stroke-width: 10;
    --rh-spinner-circle-radius: 45;
    --rh-spinner-container-animation-name: felt-rotate;
    --rh-spinner-container-animation-duration: 2.8s;
    --rh-spinner-animation-name: felt-dash;
    --rh-spinner-animation-duration: 1.4s;
    --rh-spinner-animation-timing: ease-in-out;
    --rh-spinner-rotate-start: 0deg;
    --rh-spinner-sm-animation-name: felt-dash;
    --rh-spinner-sm-dash-array: 283;
    --rh-spinner-sm-dash-offset: 280;
  }
```
This is what needs to be applied to `rh-spinner` from the theme.  **Note** These values are Patternfly's spinner animation values, not explicitly Felt Theme


## Testing Instructions

1. View the default spinner demo to confirm no regression — track circle, stroke width, and animation should be unchanged.
2. Apply the above CSS manually, and you should see the PF/Felt look and feel.

## Notes to Reviewers
- `vector-effect` is exposed as `--rh-spinner-vector-effect` (default: `non-scaling-stroke`). The felt theme sets it to `none` so stroke scales with the viewBox, matching PF's behavior.
- PF's `calc(var(--StrokeWidth) - 4)` produces `calc(6px)` in the browser, which cannot be interpolated with `10px` — this causes the stroke-width to animate discretely (step, not smooth). Our implementation uses the same expression and produces the same discrete behavior.