### PR TITLE
fix(spinner): use unitless SVG user units for stroke-width

### DIFF
--- a/elements/rh-spinner/rh-spinner.css
+++ b/elements/rh-spinner/rh-spinner.css
@@ -1,6 +1,6 @@
 :host {
-  /** Stroke width of the spinner circle */
-  --rh-spinner-stroke-width: var(--rh-length-sm, 6px);
+  /** Stroke width of the spinner circle, in unitless SVG user units */
+  --rh-spinner-stroke-width: 6;
 
   display: inline-block;
   text-align: center;
@@ -101,7 +101,7 @@ circle.track {
 
 :host([size='lg']) {
   /** Large spinner circle stroke width */
-  --rh-spinner-stroke-width: var(--rh-length-sm, 6px);
+  --rh-spinner-stroke-width: 6;
 
   & svg {
     /** Large spinner circle diameter */
@@ -116,7 +116,7 @@ circle.track {
 
 :host([size='md']) {
   /** Medium spinner circle stroke width */
-  --rh-spinner-stroke-width: var(--rh-length-xs, 4px);
+  --rh-spinner-stroke-width: 4;
 
   & svg {
     /** Medium spinner circle diameter */
@@ -131,7 +131,7 @@ circle.track {
 
 :host([size='sm']) {
   /** Small spinner circle stroke width */
-  --rh-spinner-stroke-width: var(--rh-length-2xs, 3px);
+  --rh-spinner-stroke-width: 3;
 
   & svg {
     /** Small spinner circle diameter */
@@ -195,7 +195,7 @@ circle.track {
   }
 
   15% {
-    stroke-width: calc(var(--rh-spinner-stroke-width) - 4px);
+    stroke-width: calc(var(--rh-spinner-stroke-width) - 4);
   }
 
   40% {


### PR DESCRIPTION
## What I did

1. Changed `--rh-spinner-stroke-width` defaults from px-based design tokens to unitless SVG user units (6, 4, 3 for lg/md/sm)
2. Reverted the `felt-dash` keyframe calc from `calc(var(--rh-spinner-stroke-width) - 4px)` to `calc(var(--rh-spinner-stroke-width) - 4)`
3. Updated CSS comment to note unitless SVG user units

## Testing Instructions

1. Run `npm run serve`
2. Open http://localhost:8080/elements/spinner/demo/
3. Open browser console and paste to apply unified theme:

```js
document.head.appendChild(Object.assign(document.createElement('style'), { textContent: `
  rh-spinner {
    --rh-spinner-track-display: none;
    --rh-spinner-vector-effect: none;
    --rh-spinner-stroke-width: 10;
    --rh-spinner-circle-radius: 45;
    --rh-spinner-container-animation-name: felt-rotate;
    --rh-spinner-container-animation-duration: 2.8s;
    --rh-spinner-animation-name: felt-dash;
    --rh-spinner-animation-duration: 1.4s;
    --rh-spinner-animation-timing: ease-in-out;
    --rh-spinner-rotate-start: 0deg;
    --rh-spinner-sm-animation-name: felt-dash;
    --rh-spinner-sm-dash-array: 283;
    --rh-spinner-sm-dash-offset: 280;
  }
`}));
```

4. Verify felt-dash animation shows a rotating arc with visible stroke-width pulse
5. To confirm the calc resolves, paste:

```js
const dash = document.querySelector('rh-spinner').shadowRoot.querySelector('circle.dash');
dash.style.animationPlayState = 'paused';
dash.style.animationDelay = '-0.21s'; // 15% of 1.4s
console.log('stroke-width at 15%:', getComputedStyle(dash).strokeWidth);
// Expected: calc(6px) i.e. calc(10 - 4) = 6
dash.style.animationPlayState = '';
dash.style.animationDelay = '';
```

## Notes to Reviewers

The unified theme sets `--rh-spinner-stroke-width: 10` (unitless) and `--rh-spinner-vector-effect: none`. With the previous `- 4px` in the calc, `calc(10 - 4px)` is invalid CSS (type mismatch: unitless minus px) and silently ignored by the browser, breaking the stroke pulse in `felt-dash`.

DOES NOT NEED CHANGESET since this is a fix for an unreleased regression I introduced in #3059 