### PR TITLE
feat(button): add background-color css property

### DIFF
--- a/.changeset/early-cats-march.md
+++ b/.changeset/early-cats-march.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": minor
+---
+
+feat(button): add close variant background-color props and fix :focus/:active source-order specificity
+  

--- a/.changeset/early-cats-march.md
+++ b/.changeset/early-cats-march.md
@@ -2,4 +2,4 @@
 "@rhds/elements": minor
 ---
 
-feat(button): add close variant background-color and width props, fix :focus/:active source-order specificity
+feat(button): add close variant background colors (`--rh-button-close-active-background`, `--rh-button-close-focus-background`, and `--rh-button-close-hover-background`) and `--rh-button-close-width` props, fix `:focus`/`:active` source-order specificity

--- a/.changeset/early-cats-march.md
+++ b/.changeset/early-cats-march.md
@@ -2,5 +2,4 @@
 "@rhds/elements": minor
 ---
 
-feat(button): add close variant background-color props and fix :focus/:active source-order specificity
-  
+feat(button): add close variant background-color and width props, fix :focus/:active source-order specificity

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -353,18 +353,24 @@ button {
 
     /** Close active icon color */
     --_active-color: var(--rh-color-interactive-secondary-active);
-    --_active-background-color: transparent;
+
+    /** @csspart close - Close button active background color */
+    --_active-background-color: var(--rh-button-close-active-background, transparent);
 
     /** Close focus icon color */
     --_focus-color: var(--rh-color-interactive-secondary-focus);
-    --_focus-background-color: transparent;
+
+    /** @csspart close - Close button focus background color */
+    --_focus-background-color: var(--rh-button-close-focus-background, transparent);
 
     /** Close focus outline color */
     --_focus-outline-color: var(--rh-color-interactive-primary-default);
 
     /** Close hover icon color */
     --_hover-color: var(--rh-color-interactive-secondary-hover);
-    --_hover-background-color: transparent;
+
+    /** @csspart close - Close button hover background color */
+    --_hover-background-color: var(--rh-button-close-hover-background, transparent);
 
     /** Button width */
     width: var(--rh-length-lg, 16px);

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -347,7 +347,7 @@ button {
     --_hover-background-color: var(--rh-button-close-hover-background, transparent);
 
     /** Button width */
-    width: var(--rh-length-lg, 16px);
+    width: var(--rh-button-close-width, var(--rh-length-lg, 16px));
     aspect-ratio: 1;
 
     rh-icon {

--- a/elements/rh-button/rh-button.css
+++ b/elements/rh-button/rh-button.css
@@ -48,12 +48,6 @@ button {
   /** Button focus ring offset */
   outline-offset: var(--rh-length-4xs, 1px);
 
-  &:active {
-    --_color: var(--_active-color);
-    --_background-color: var(--_active-background-color);
-    --_border-width: var(--_active-border-width);
-  }
-
   &:after {
     position: absolute;
     inset: 0;
@@ -64,26 +58,6 @@ button {
 
     /** Button corner rounding */
     border-radius: var(--rh-border-radius-default, 3px);
-  }
-
-  &:focus {
-    --_color: var(--_focus-color);
-    --_background-color: var(--_focus-background-color);
-    --_border-width: var(--_focus-border-width);
-
-    outline:
-      /** Focus outline width */
-      var(--rh-border-width-md, 2px)
-      solid
-      /** Focus outline color */
-      var(--rh-color-interactive-primary-default);
-
-    &:after {
-      border-width:
-        var(--_border-width,
-          /** Focus pseudo-element border width fallback */
-          var(--rh-border-width-md, 2px));
-    }
   }
 
   &.hasIcon {
@@ -466,6 +440,32 @@ button {
     --_color: var(--_hover-color);
     --_background-color: var(--_hover-background-color);
     --_border-width: var(--_hover-border-width);
+  }
+
+  &:focus {
+    --_color: var(--_focus-color);
+    --_background-color: var(--_focus-background-color);
+    --_border-width: var(--_focus-border-width);
+
+    outline:
+      /** Focus outline width */
+      var(--rh-border-width-md, 2px)
+      solid
+      /** Focus outline color */
+      var(--rh-color-interactive-primary-default);
+
+    &:after {
+      border-width:
+        var(--_border-width,
+          /** Focus pseudo-element border width fallback */
+          var(--rh-border-width-md, 2px));
+    }
+  }
+
+  &:active {
+    --_color: var(--_active-color);
+    --_background-color: var(--_active-background-color);
+    --_border-width: var(--_active-border-width);
   }
 
   & > span {


### PR DESCRIPTION
## What I did

1. add close variant background-color props for Unified theming
2. fixed `:focus`/`:active` source-order specificity — necessary for inheritance of BG props above

## Testing

- Please make sure the specificity changes above don't have any regressions!


Related to https://github.com/RedHat-UX/red-hat-design-system/pull/2987/ and https://github.com/RedHat-UX/red-hat-design-system/pull/3062