### PR TITLE
fix(jump-links): replaced after psuedo in favor of outline

### DIFF
--- a/.changeset/fiery-coins-march.md
+++ b/.changeset/fiery-coins-march.md
@@ -2,4 +2,4 @@
 "@rhds/elements": minor
 ---
 
-`<rh-jump-links>`: added new public CSS custom properties (`--rh-jump-link-border`, `--rh-jump-link-gap`, `--rh-jump-link-active-border`, `--rh-jump-link-link-border`, `--rh-jump-link-hover-background-color`, `--rh-jump-link-hover-border-radius`, `--rh-jump-link-focus-inset`, `--rh-jump-link-active-indicator-offset`, `--rh-jump-link-active-indicator-inset-inline`)
+`<rh-jump-links>`: added new public CSS custom properties (`--rh-jump-link-border`, `--rh-jump-link-gap`, `--rh-jump-link-active-border`, `--rh-jump-link-link-border`, `--rh-jump-link-hover-background-color`, `--rh-jump-link-hover-border-radius`, `--rh-jump-link-active-indicator-offset`, `--rh-jump-link-active-indicator-inset-inline`)

--- a/elements/rh-jump-links/rh-jump-link.css
+++ b/elements/rh-jump-links/rh-jump-link.css
@@ -73,18 +73,11 @@ a {
   }
 
   &:focus-visible {
-    outline: none;
+    /** Jump links focus outline color **/
+    outline: 2px solid var(--rh-color-interactive-primary-default);
 
-    &:after {
-      content: '';
-      display: block;
-      position: absolute;
-
-      /** Inset of the focus ring. Use negative values for outline offset. */
-      inset: var(--rh-jump-link-focus-inset, 0);
-      border: 2px solid var(--rh-color-interactive-primary-default);
-      border-radius: var(--rh-border-radius-default, 3px);
-    }
+    /** Jump links focus ouline radius */
+    border-radius: var(--rh-border-radius-default, 3px);
   }
 
   &.active {


### PR DESCRIPTION
## What I did

1. Removed `::after` psuedo in favor of `outline` reduces need for the focus-offset css var in unified support
2. Updated changeset to reflect removal


## Testing Instructions

1.

## Notes to Reviewers

May close this PR; outline is broken in horizontal variant; this approach may not work as hoped.
