### PR TITLE
feat(navigation-link): add indicator CSS custom properties

### DIFF
--- a/.changeset/brave-dots-glow.md
+++ b/.changeset/brave-dots-glow.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-navigation-link>`: added `--rh-navigation-link-indicator-border-radius`, `--rh-navigation-link-indicator-background-color`, `--rh-navigation-link-indicator-inset-block`, `--rh-navigation-link-indicator-inset-inline-end`, and `--rh-navigation-link-indicator-inline-size` CSS custom properties for styling the `::before` indicator pseudo-element. Added `border-radius` fallback on the link element for parent-set context.

--- a/elements/rh-navigation-link/rh-navigation-link.css
+++ b/elements/rh-navigation-link/rh-navigation-link.css
@@ -43,7 +43,7 @@ a,
   background-color: var(--_navigation-link-background-color, transparent);
 
   /** Link border radius */
-  border-radius: var(--rh-navigation-link-border-radius, 0);
+  border-radius: var(--rh-navigation-link-border-radius, var(--_navigation-link-border-radius, 0));
 }
 
 a:before,
@@ -52,14 +52,37 @@ a:before,
   position: absolute;
   inset: 0;
 
-  /** Indicator inline-start offset */
-  inset-inline-start: var(--rh-navigation-link-inset-inline-start, 0);
+  /** Indicator block inset */
+  inset-block:
+    var(--rh-navigation-link-indicator-inset-block,
+      var(--_navigation-link-before-inset-block, 0));
+
+  /** Indicator inline offsets (start, end) */
+  inset-inline:
+    var(--rh-navigation-link-inset-inline-start, 0)
+    var(--rh-navigation-link-indicator-inset-inline-end,
+      var(--_navigation-link-before-inset-inline-end, 0));
+
+  /** Indicator inline size */
+  inline-size:
+    var(--rh-navigation-link-indicator-inline-size,
+      var(--_navigation-link-before-inline-size, auto));
   border-inline-start:
     /** Indicator border width */
     var(--rh-navigation-link-border-inline-start-width,
       var(--_navigation-link-before-border-inline-start-width, 0))
     solid
     var(--_navigation-link-before-border-inline-start-color, transparent);
+
+  /** Indicator background color */
+  background-color:
+    var(--rh-navigation-link-indicator-background-color,
+      var(--_navigation-link-before-background-color, transparent));
+
+  /** Indicator border radius */
+  border-radius:
+    var(--rh-navigation-link-indicator-border-radius,
+      var(--_navigation-link-before-border-radius, 0));
 }
 
 a:is(:hover, :hover:focus-visible, :focus-visible, :active),


### PR DESCRIPTION
## Summary
- Add public CSS custom properties to `rh-navigation-link`'s `::before` indicator pseudo-element for theming the indicator as a pill-shaped background bar
- New properties: `--rh-navigation-link-indicator-border-radius`, `--rh-navigation-link-indicator-background-color`, `--rh-navigation-link-indicator-inset-block`, `--rh-navigation-link-indicator-inset-inline-end`, `--rh-navigation-link-indicator-inline-size`
- Each public var falls back to a private channel var (for parent component use), then to existing defaults
- Also adds private var fallback to link element `border-radius` so `--_navigation-link-border-radius` set by `rh-subnav` is consumed

## Context
Needed by #3000 (unified subnav) to implement pill-shaped indicator on `rh-navigation-vertical` per unified theme Figma spec (Corey's review feedback).

## Test plan
- Existing unit tests pass (24/24, 0 failures)
- Stylelint passes
- No visual regression: all new properties default to existing behavior