### PR TITLE
feat(chip): fix close icon animation arc and expose  CSS part

### DIFF
--- a/.changeset/swift-beans-vanish.md
+++ b/.changeset/swift-beans-vanish.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-chip>`: fix close icon animation arc and expose `btn-link` CSS part
+  

--- a/elements/rh-chip/rh-chip-group.ts
+++ b/elements/rh-chip/rh-chip-group.ts
@@ -70,7 +70,7 @@ export class RhChipGroup extends LitElement {
             Each chip must have a unique text label for screen readers.
         -->
         <slot></slot>
-        <button class="btn-link" type="button" @click="${this.#uncheckAllChips}">
+        <button class="btn-link" part="btn-link" type="button" @click="${this.#uncheckAllChips}">
           <!--
             summary: Clear all button label
             description: |

--- a/elements/rh-chip/rh-chip.css
+++ b/elements/rh-chip/rh-chip.css
@@ -131,12 +131,12 @@ label {
 }
 
 #close-icon {
-  block-size: 0;
+  block-size: auto;
   inline-size: 0;
   opacity: 0;
   transition-behavior: allow-discrete;
   transition-duration: 0.2s;
-  transition-property: inline-size, block-size, opacity, margin-inline-start;
+  transition-property: inline-size, opacity, margin-inline-start;
   transition-timing-function: ease-in-out;
 }
 


### PR DESCRIPTION
## What I did

1. Fxed close icon animation arc, by removing unnecessary `block-size` animation
2. Exposed `btn-link` CSS part (to allow proper styling of "clear all" button in `<rh-chip-group>`

Related to https://github.com/RedHat-UX/red-hat-design-system/pull/2992