### PR TITLE
feat(tabs): add CSS custom properties and overflow-button parts for theme support

### DIFF
--- a/.changeset/lazy-pumas-enter.md
+++ b/.changeset/lazy-pumas-enter.md
@@ -2,6 +2,6 @@
 "@rhds/elements": minor
 ---
 
-`<rh-tab>`: add CSS custom properties for theming the inner tab link area: `--rh-tabs-link-inner-radius`, `--rh-tabs-link-inner-padding`, `--rh-tabs-link-inner-justify`, `--rh-tabs-link-hover-background`, `--rh-tabs-link-focus-background`, `--rh-tabs-link-focus-outline`, `--rh-tabs-link-focus-outline-offset`, `--rh-tabs-link-focus-inner-outline`, `--rh-tabs-link-focus-inner-outline-offset`. Add `--rh-tabs-box-border-color` CSS custom property to control the side border color on box-style tabs.
+`<rh-tab>`: add `--rh-tabs-link-*` CSS custom properties for theming the inner tab link area (pill radius, padding, hover/focus backgrounds, focus outlines). Add `--rh-tabs-box-border-color` for box-style tab side borders.
 
-`<rh-tabs>`: add `overflow-button`, `overflow-button previous`, and `overflow-button next` CSS parts on the overflow scroll buttons, enabling themed padding, sizing, and focus/hover styling. Add CSS custom properties: `--rh-tabs-overflow-button-padding-block`, `--rh-tabs-overflow-button-padding-inline`, `--rh-tabs-overflow-button-radius`, `--rh-tabs-overflow-button-min-size`, `--rh-tabs-overflow-border-color`, `--rh-tabs-overflow-hover-indicator`, `--rh-tabs-overflow-icon-size`, `--rh-tabs-overflow-icon-radius`, `--rh-tabs-overflow-hover-background`, `--rh-tabs-overflow-focus-background`, `--rh-tabs-overflow-focus-outline`, `--rh-tabs-overflow-focus-outline-offset`.
+`<rh-tabs>`: add `overflow-button`, `overflow-button previous`, and `overflow-button next` CSS parts on the overflow scroll buttons. Add `--rh-tabs-overflow-*` CSS custom properties for overflow button padding, sizing, border radius, hover/focus backgrounds, and focus outlines.

--- a/.changeset/lazy-pumas-enter.md
+++ b/.changeset/lazy-pumas-enter.md
@@ -2,6 +2,6 @@
 "@rhds/elements": minor
 ---
 
-`<rh-tab>`: add `wrapper` CSS part — the inner pill-shaped element wrapping the icon and label, enabling themed hover/focus backgrounds.
+`<rh-tab>`: add CSS custom properties for theming the inner tab link area: `--rh-tabs-link-inner-radius`, `--rh-tabs-link-inner-padding`, `--rh-tabs-link-inner-justify`, `--rh-tabs-link-hover-background`, `--rh-tabs-link-focus-background`, `--rh-tabs-link-focus-outline`, `--rh-tabs-link-focus-outline-offset`, `--rh-tabs-link-focus-inner-outline`, `--rh-tabs-link-focus-inner-outline-offset`. Add `--rh-tabs-box-border-color` CSS custom property to control the side border color on box-style tabs.
 
-`<rh-tabs>`: add `overflow-button`, `overflow-button previous`, and `overflow-button next` CSS parts on the overflow scroll buttons, enabling themed padding, sizing, and focus/hover styling.
+`<rh-tabs>`: add `overflow-button`, `overflow-button previous`, and `overflow-button next` CSS parts on the overflow scroll buttons, enabling themed padding, sizing, and focus/hover styling. Add CSS custom properties: `--rh-tabs-overflow-button-padding-block`, `--rh-tabs-overflow-button-padding-inline`, `--rh-tabs-overflow-button-radius`, `--rh-tabs-overflow-button-min-size`, `--rh-tabs-overflow-border-color`, `--rh-tabs-overflow-hover-indicator`, `--rh-tabs-overflow-icon-size`, `--rh-tabs-overflow-icon-radius`, `--rh-tabs-overflow-hover-background`, `--rh-tabs-overflow-focus-background`, `--rh-tabs-overflow-focus-outline`, `--rh-tabs-overflow-focus-outline-offset`.

--- a/.changeset/lazy-pumas-enter.md
+++ b/.changeset/lazy-pumas-enter.md
@@ -1,0 +1,7 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-tab>`: add `wrapper` CSS part — the inner pill-shaped element wrapping the icon and label, enabling themed hover/focus backgrounds.
+
+`<rh-tabs>`: add `overflow-button`, `overflow-button previous`, and `overflow-button next` CSS parts on the overflow scroll buttons, enabling themed padding, sizing, and focus/hover styling.

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -46,9 +46,6 @@ rh-icon,
   position: relative;
   display: flex;
   flex: 1;
-
-  /** Gap between icon and label using rh-space-md */
-  gap: var(--rh-space-md, 8px);
   text-decoration: none;
   cursor: pointer;
   align-items: center;
@@ -156,7 +153,7 @@ rh-icon,
       background-color: transparent;
 
       &:before {
-        border-inline-color: var(--rh-color-border-subtle);
+        border-inline-color: var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
         border-inline-start-width: var(--rh-border-width-sm, 1px);
       }
 
@@ -167,14 +164,18 @@ rh-icon,
 
       &.first {
         &:before {
-          border-inline-start-color: var(--rh-color-border-subtle);
+          border-inline-start-color:
+            var(--_tab-box-side-border-color,
+              var(--rh-color-border-subtle));
           border-inline-start-width: var(--rh-border-width-sm, 1px);
         }
       }
 
       &.last {
         &:before {
-          border-inline-end-color: var(--rh-color-border-subtle);
+          border-inline-end-color:
+            var(--_tab-box-side-border-color,
+              var(--rh-color-border-subtle));
           border-inline-end-width: var(--rh-border-width-sm, 1px);
         }
       }
@@ -224,7 +225,9 @@ rh-icon,
         &.first {
           @container (min-width: 768px) {
             &:before {
-              border-inline-start-color: var(--rh-color-border-subtle);
+              border-inline-start-color:
+                var(--_tab-box-side-border-color,
+                  var(--rh-color-border-subtle));
               border-inline-start-width: var(--rh-border-width-sm, 1px);
             }
           }
@@ -233,7 +236,9 @@ rh-icon,
         &.last {
           @container (min-width: 768px) {
             &:before {
-              border-inline-end-color: var(--rh-color-border-subtle);
+              border-inline-end-color:
+                var(--_tab-box-side-border-color,
+                  var(--rh-color-border-subtle));
               border-inline-end-width: var(--rh-border-width-sm, 1px);
             }
           }
@@ -279,8 +284,7 @@ rh-icon,
   &:not(.active) {
     &.box {
       &:before {
-        /** Inactive box tab side border color */
-        border-inline-color: var(--rh-color-border-subtle);
+        border-inline-color: var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
 
         /** Inactive box tab side border width */
         border-inline-start-width: var(--rh-border-width-sm, 1px);
@@ -309,14 +313,12 @@ rh-icon,
               /** Vertical box tab trailing border width above sm breakpoint */
               var(--rh-border-width-sm, 1px)
               solid
-              /** Vertical box tab trailing border color above sm breakpoint */
-              var(--rh-color-border-subtle);
+              var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
             border-block-start:
               /** Vertical box tab top border width above sm breakpoint */
               var(--rh-border-width-sm, 1px)
               solid
-              /** Vertical box tab top border color above sm breakpoint */
-              var(--rh-color-border-subtle);
+              var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
           }
 
           &:after {
@@ -437,6 +439,16 @@ rh-icon,
   }
 }
 
+/* Inner wrapper for pill-shaped hover/focus backgrounds (unified theme) */
+#wrapper {
+  display: flex;
+  gap: var(--rh-space-md, 8px);
+  align-items: center;
+  border-radius: var(--_tab-wrapper-radius, 0);
+  padding: var(--_tab-wrapper-padding, 0);
+  justify-content: var(--_tab-wrapper-justify, initial);
+}
+
 :host(:disabled) {
   & #button {
     pointer-events: none;
@@ -453,9 +465,17 @@ rh-icon,
   outline: none;
 
   & #button {
-    /** Focus outline, adapts to color-palette */
-    border-radius: var(--rh-border-radius-default, 3px);
-    outline: var(--rh-border-width-lg, 3px) solid var(--rh-color-interactive-primary-default);
-    outline-offset: -7px;
+    outline: var(--_tab-focus-button-outline, 1px auto var(--rh-color-interactive-primary-default));
+    outline-offset: var(--_tab-focus-button-outline-offset, -3px);
   }
+
+  & #wrapper {
+    background-color: var(--_tab-focus-background, transparent);
+    outline: var(--_tab-focus-wrapper-outline, none);
+    outline-offset: var(--_tab-focus-wrapper-outline-offset, 0);
+  }
+}
+
+:host(:hover:not([disabled], [aria-disabled='true'])) #button:not(.active) #wrapper {
+  background-color: var(--_tab-hover-background, transparent);
 }

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -153,6 +153,7 @@ rh-icon,
       background-color: transparent;
 
       &:before {
+        /** Box tab side border color */
         border-inline-color: var(--rh-tabs-box-border-color, var(--rh-color-border-subtle));
         border-inline-start-width: var(--rh-border-width-sm, 1px);
       }
@@ -445,8 +446,14 @@ rh-icon,
   display: flex;
   gap: var(--rh-space-md, 8px);
   align-items: center;
+
+  /** Inner pill border radius */
   border-radius: var(--rh-tabs-link-inner-radius, 0);
+
+  /** Inner pill padding */
   padding: var(--rh-tabs-link-inner-padding, 0);
+
+  /** Inner pill content alignment */
   justify-content: var(--rh-tabs-link-inner-justify, initial);
 }
 
@@ -454,20 +461,29 @@ rh-icon,
   outline: none;
 
   & #button {
+    /** Focus outline on the outer button */
     outline:
       var(--rh-tabs-link-focus-outline,
         1px auto var(--rh-color-interactive-primary-default));
+
+    /** Focus outline offset on the outer button */
     outline-offset: var(--rh-tabs-link-focus-outline-offset, -3px);
   }
 
   & #wrapper {
+    /** Focus background on the inner pill */
     background-color: var(--rh-tabs-link-focus-background, transparent);
+
+    /** Focus outline on the inner pill */
     outline: var(--rh-tabs-link-focus-inner-outline, none);
+
+    /** Focus outline offset on the inner pill */
     outline-offset: var(--rh-tabs-link-focus-inner-outline-offset, 0);
   }
 }
 
 :host(:hover:not([disabled], [aria-disabled='true'])) #button:not(.active) #wrapper {
+  /** Hover background on the inner pill */
   background-color: var(--rh-tabs-link-hover-background, transparent);
 }
 /* stylelint-enable rhds/no-unknown-token-name */

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -153,7 +153,7 @@ rh-icon,
       background-color: transparent;
 
       &:before {
-        border-inline-color: var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
+        border-inline-color: var(--rh-tabs-box-border-color, var(--rh-color-border-subtle));
         border-inline-start-width: var(--rh-border-width-sm, 1px);
       }
 
@@ -165,7 +165,7 @@ rh-icon,
       &.first {
         &:before {
           border-inline-start-color:
-            var(--_tab-box-side-border-color,
+            var(--rh-tabs-box-border-color,
               var(--rh-color-border-subtle));
           border-inline-start-width: var(--rh-border-width-sm, 1px);
         }
@@ -174,7 +174,7 @@ rh-icon,
       &.last {
         &:before {
           border-inline-end-color:
-            var(--_tab-box-side-border-color,
+            var(--rh-tabs-box-border-color,
               var(--rh-color-border-subtle));
           border-inline-end-width: var(--rh-border-width-sm, 1px);
         }
@@ -226,7 +226,7 @@ rh-icon,
           @container (min-width: 768px) {
             &:before {
               border-inline-start-color:
-                var(--_tab-box-side-border-color,
+                var(--rh-tabs-box-border-color,
                   var(--rh-color-border-subtle));
               border-inline-start-width: var(--rh-border-width-sm, 1px);
             }
@@ -237,7 +237,7 @@ rh-icon,
           @container (min-width: 768px) {
             &:before {
               border-inline-end-color:
-                var(--_tab-box-side-border-color,
+                var(--rh-tabs-box-border-color,
                   var(--rh-color-border-subtle));
               border-inline-end-width: var(--rh-border-width-sm, 1px);
             }
@@ -284,7 +284,7 @@ rh-icon,
   &:not(.active) {
     &.box {
       &:before {
-        border-inline-color: var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
+        border-inline-color: var(--rh-tabs-box-border-color, var(--rh-color-border-subtle));
 
         /** Inactive box tab side border width */
         border-inline-start-width: var(--rh-border-width-sm, 1px);
@@ -313,12 +313,12 @@ rh-icon,
               /** Vertical box tab trailing border width above sm breakpoint */
               var(--rh-border-width-sm, 1px)
               solid
-              var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
+              var(--rh-tabs-box-border-color, var(--rh-color-border-subtle));
             border-block-start:
               /** Vertical box tab top border width above sm breakpoint */
               var(--rh-border-width-sm, 1px)
               solid
-              var(--_tab-box-side-border-color, var(--rh-color-border-subtle));
+              var(--rh-tabs-box-border-color, var(--rh-color-border-subtle));
           }
 
           &:after {
@@ -440,14 +440,37 @@ rh-icon,
 }
 
 /* Inner wrapper for pill-shaped hover/focus backgrounds (unified theme) */
+/* stylelint-disable rhds/no-unknown-token-name -- new component tokens, not yet in registry */
 #wrapper {
   display: flex;
   gap: var(--rh-space-md, 8px);
   align-items: center;
-  border-radius: var(--_tab-wrapper-radius, 0);
-  padding: var(--_tab-wrapper-padding, 0);
-  justify-content: var(--_tab-wrapper-justify, initial);
+  border-radius: var(--rh-tabs-link-inner-radius, 0);
+  padding: var(--rh-tabs-link-inner-padding, 0);
+  justify-content: var(--rh-tabs-link-inner-justify, initial);
 }
+
+:host(:is(:focus-visible)) {
+  outline: none;
+
+  & #button {
+    outline:
+      var(--rh-tabs-link-focus-outline,
+        1px auto var(--rh-color-interactive-primary-default));
+    outline-offset: var(--rh-tabs-link-focus-outline-offset, -3px);
+  }
+
+  & #wrapper {
+    background-color: var(--rh-tabs-link-focus-background, transparent);
+    outline: var(--rh-tabs-link-focus-inner-outline, none);
+    outline-offset: var(--rh-tabs-link-focus-inner-outline-offset, 0);
+  }
+}
+
+:host(:hover:not([disabled], [aria-disabled='true'])) #button:not(.active) #wrapper {
+  background-color: var(--rh-tabs-link-hover-background, transparent);
+}
+/* stylelint-enable rhds/no-unknown-token-name */
 
 :host(:disabled) {
   & #button {
@@ -459,23 +482,4 @@ rh-icon,
   & #button {
     cursor: default;
   }
-}
-
-:host(:is(:focus-visible)) {
-  outline: none;
-
-  & #button {
-    outline: var(--_tab-focus-button-outline, 1px auto var(--rh-color-interactive-primary-default));
-    outline-offset: var(--_tab-focus-button-outline-offset, -3px);
-  }
-
-  & #wrapper {
-    background-color: var(--_tab-focus-background, transparent);
-    outline: var(--_tab-focus-wrapper-outline, none);
-    outline-offset: var(--_tab-focus-wrapper-outline-offset, 0);
-  }
-}
-
-:host(:hover:not([disabled], [aria-disabled='true'])) #button:not(.active) #wrapper {
-  background-color: var(--_tab-hover-background, transparent);
 }

--- a/elements/rh-tabs/rh-tab.css
+++ b/elements/rh-tabs/rh-tab.css
@@ -461,13 +461,11 @@ rh-icon,
   outline: none;
 
   & #button {
-    /** Focus outline on the outer button */
+    border-radius: var(--rh-border-radius-default, 3px);
     outline:
       var(--rh-tabs-link-focus-outline,
-        1px auto var(--rh-color-interactive-primary-default));
-
-    /** Focus outline offset on the outer button */
-    outline-offset: var(--rh-tabs-link-focus-outline-offset, -3px);
+        var(--rh-border-width-lg, 3px) solid var(--rh-color-interactive-primary-default));
+    outline-offset: var(--rh-tabs-link-focus-outline-offset, -7px);
   }
 
   & #wrapper {

--- a/elements/rh-tabs/rh-tab.ts
+++ b/elements/rh-tabs/rh-tab.ts
@@ -66,6 +66,17 @@ export class TabExpandEvent extends Event {
  * @csspart icon - container for the icon slot
  * @csspart text - container for the default (text) slot
  *
+ * @cssprop {<length>} [--rh-tabs-link-inner-radius=0] - Border radius of the inner pill wrapper
+ * @cssprop {<length>+} [--rh-tabs-link-inner-padding=0] - Padding inside the inner pill wrapper
+ * @cssprop {<string>} [--rh-tabs-link-inner-justify=initial] - Justify-content for the inner pill wrapper
+ * @cssprop {<color>} [--rh-tabs-link-hover-background=transparent] - Background color of the inner pill on hover
+ * @cssprop {<color>} [--rh-tabs-link-focus-background=transparent] - Background color of the inner pill on focus
+ * @cssprop [--rh-tabs-link-focus-outline] - Outline shorthand for the button on focus
+ * @cssprop {<length>} [--rh-tabs-link-focus-outline-offset=-3px] - Outline offset for the button on focus
+ * @cssprop [--rh-tabs-link-focus-inner-outline=none] - Outline shorthand for the inner pill on focus
+ * @cssprop {<length>} [--rh-tabs-link-focus-inner-outline-offset=0] - Outline offset for the inner pill on focus
+ * @cssprop {<color>} [--rh-tabs-box-border-color] - Side border color for box-style tabs; defaults to `--rh-color-border-subtle`
+ *
  */
 @customElement('rh-tab')
 @themable
@@ -139,11 +150,18 @@ export class RhTab extends LitElement {
            ?disabled="${this.disabled}"
            class="${classMap({ active, box, vertical, first, last })}">
         <div id="wrapper">
+          <!-- summary: Icon
+               description: |
+                 Can contain an \`<svg>\` or \`<rh-icon>\` element
+                 displayed before the tab label text. -->
           <slot name="icon"
                 part="icon">
             <rh-icon ?hidden="${!this.icon}" icon="${ifDefined(this.icon)}" set="${ifDefined(this.iconSet)}"></rh-icon>
           </slot>
-          <!-- Tab title text -->
+          <!-- summary: Tab label
+               description: |
+                 Tab label text. Authors should keep labels short
+                 and descriptive. -->
           <slot part="text"></slot>
         </div>
       </div>

--- a/elements/rh-tabs/rh-tab.ts
+++ b/elements/rh-tabs/rh-tab.ts
@@ -138,19 +138,14 @@ export class RhTab extends LitElement {
            part="button"
            ?disabled="${this.disabled}"
            class="${classMap({ active, box, vertical, first, last })}">
-        <!-- summary: Icon
-             description: |
-               Can contain an \`<svg>\` or \`<rh-icon>\` element
-               displayed before the tab label text. -->
-        <slot name="icon"
-              part="icon">
-          <rh-icon ?hidden="${!this.icon}" icon="${ifDefined(this.icon)}" set="${ifDefined(this.iconSet)}"></rh-icon>
-        </slot>
-        <!-- summary: Tab label
-             description: |
-               Tab label text. Authors should keep labels short
-               and descriptive. -->
-        <slot part="text"></slot>
+        <div id="wrapper" part="wrapper">
+          <slot name="icon"
+                part="icon">
+            <rh-icon ?hidden="${!this.icon}" icon="${ifDefined(this.icon)}" set="${ifDefined(this.iconSet)}"></rh-icon>
+          </slot>
+          <!-- Tab title text -->
+          <slot part="text"></slot>
+        </div>
       </div>
     `;
   }

--- a/elements/rh-tabs/rh-tab.ts
+++ b/elements/rh-tabs/rh-tab.ts
@@ -138,7 +138,7 @@ export class RhTab extends LitElement {
            part="button"
            ?disabled="${this.disabled}"
            class="${classMap({ active, box, vertical, first, last })}">
-        <div id="wrapper" part="wrapper">
+        <div id="wrapper">
           <slot name="icon"
                 part="icon">
             <rh-icon ?hidden="${!this.icon}" icon="${ifDefined(this.icon)}" set="${ifDefined(this.iconSet)}"></rh-icon>

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -215,12 +215,12 @@ button {
 
 /* OVERFLOW BUTTONS */
 :is(#previous-tab, #next-tab) {
-  padding-block: 0;
-
-  /** Scroll button inline padding */
-  padding-inline: var(--rh-space-lg, 16px);
-
-  /** Scroll button background, adapts to color-palette */
+  padding-block: var(--_overflow-button-padding-block, 0);
+  padding-inline:
+    var(--_overflow-button-padding-inline,
+      var(--rh-space-lg, 16px));
+  border-radius: var(--_overflow-button-radius, 0);
+  min-width: var(--_overflow-button-min-size, auto);
   background-color: var(--rh-color-surface);
   color: var(--_overflow-button-text-color);
   position: relative;
@@ -228,21 +228,55 @@ button {
 
   &:before {
     border-block-start: var(--rh-border-width-sm, 1px) solid transparent;
-    border-block-end: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
-    border-inline: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+    border-block-end:
+      var(--rh-border-width-sm, 1px)
+      solid
+      var(--_overflow-border-color, var(--rh-color-border-subtle));
+    border-inline:
+      var(--rh-border-width-sm, 1px)
+      solid
+      var(--_overflow-border-color, var(--rh-color-border-subtle));
   }
 
   &:hover {
     color: var(--_overflow-button-hover-text-color, var(--rh-color-text-primary));
 
     &:before {
-      border-block-end: var(--rh-border-width-lg, 3px) solid var(--rh-color-border-subtle);
+      border-block-end:
+        var(--_overflow-hover-indicator,
+          var(--rh-border-width-lg, 3px)
+          solid
+          var(--rh-color-border-subtle));
     }
+  }
+
+  &:focus {
+    outline: none;
   }
 
   &:disabled {
     color: var(--_overflow-button-disabled-text-color);
   }
+}
+
+/* Inner wrapper for hover/focus pill on overflow buttons */
+.overflow-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--_overflow-icon-size, auto);
+  height: var(--_overflow-icon-size, auto);
+  border-radius: var(--_overflow-icon-radius, 0);
+}
+
+:is(#previous-tab, #next-tab):hover .overflow-icon {
+  background-color: var(--_overflow-hover-bg, transparent);
+}
+
+:is(#previous-tab, #next-tab):focus .overflow-icon {
+  background-color: var(--_overflow-focus-bg, transparent);
+  outline: var(--_overflow-focus-outline, none);
+  outline-offset: var(--_overflow-focus-outline-offset, 0);
 }
 
 #next-tab {

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -215,12 +215,12 @@ button {
 
 /* OVERFLOW BUTTONS */
 :is(#previous-tab, #next-tab) {
-  padding-block: var(--_overflow-button-padding-block, 0);
+  padding-block: var(--rh-tabs-overflow-button-padding-block, 0);
   padding-inline:
-    var(--_overflow-button-padding-inline,
+    var(--rh-tabs-overflow-button-padding-inline,
       var(--rh-space-lg, 16px));
-  border-radius: var(--_overflow-button-radius, 0);
-  min-width: var(--_overflow-button-min-size, auto);
+  border-radius: var(--rh-tabs-overflow-button-radius, 0);
+  min-width: var(--rh-tabs-overflow-button-min-size, auto);
   background-color: var(--rh-color-surface);
   color: var(--_overflow-button-text-color);
   position: relative;
@@ -231,11 +231,11 @@ button {
     border-block-end:
       var(--rh-border-width-sm, 1px)
       solid
-      var(--_overflow-border-color, var(--rh-color-border-subtle));
+      var(--rh-tabs-overflow-border-color, var(--rh-color-border-subtle));
     border-inline:
       var(--rh-border-width-sm, 1px)
       solid
-      var(--_overflow-border-color, var(--rh-color-border-subtle));
+      var(--rh-tabs-overflow-border-color, var(--rh-color-border-subtle));
   }
 
   &:hover {
@@ -243,7 +243,7 @@ button {
 
     &:before {
       border-block-end:
-        var(--_overflow-hover-indicator,
+        var(--rh-tabs-overflow-hover-indicator,
           var(--rh-border-width-lg, 3px)
           solid
           var(--rh-color-border-subtle));
@@ -264,19 +264,19 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--_overflow-icon-size, auto);
-  height: var(--_overflow-icon-size, auto);
-  border-radius: var(--_overflow-icon-radius, 0);
+  width: var(--rh-tabs-overflow-icon-size, auto);
+  height: var(--rh-tabs-overflow-icon-size, auto);
+  border-radius: var(--rh-tabs-overflow-icon-radius, 0);
 }
 
 :is(#previous-tab, #next-tab):hover .overflow-icon {
-  background-color: var(--_overflow-hover-bg, transparent);
+  background-color: var(--rh-tabs-overflow-hover-background, transparent);
 }
 
 :is(#previous-tab, #next-tab):focus .overflow-icon {
-  background-color: var(--_overflow-focus-bg, transparent);
-  outline: var(--_overflow-focus-outline, none);
-  outline-offset: var(--_overflow-focus-outline-offset, 0);
+  background-color: var(--rh-tabs-overflow-focus-background, transparent);
+  outline: var(--rh-tabs-overflow-focus-outline, none);
+  outline-offset: var(--rh-tabs-overflow-focus-outline-offset, 0);
 }
 
 #next-tab {

--- a/elements/rh-tabs/rh-tabs.css
+++ b/elements/rh-tabs/rh-tabs.css
@@ -214,13 +214,23 @@ button {
 }
 
 /* OVERFLOW BUTTONS */
+/* stylelint-disable rhds/no-unknown-token-name -- new component tokens, not yet in registry */
 :is(#previous-tab, #next-tab) {
+  /** Overflow button block padding */
   padding-block: var(--rh-tabs-overflow-button-padding-block, 0);
+
+  /** Overflow button inline padding */
   padding-inline:
     var(--rh-tabs-overflow-button-padding-inline,
       var(--rh-space-lg, 16px));
+
+  /** Overflow button border radius */
   border-radius: var(--rh-tabs-overflow-button-radius, 0);
+
+  /** Overflow button minimum width */
   min-width: var(--rh-tabs-overflow-button-min-size, auto);
+
+  /** Scroll button background, adapts to color-palette */
   background-color: var(--rh-color-surface);
   color: var(--_overflow-button-text-color);
   position: relative;
@@ -228,10 +238,14 @@ button {
 
   &:before {
     border-block-start: var(--rh-border-width-sm, 1px) solid transparent;
+
+    /** Overflow button bottom border color */
     border-block-end:
       var(--rh-border-width-sm, 1px)
       solid
       var(--rh-tabs-overflow-border-color, var(--rh-color-border-subtle));
+
+    /** Overflow button inline border color */
     border-inline:
       var(--rh-border-width-sm, 1px)
       solid
@@ -242,6 +256,7 @@ button {
     color: var(--_overflow-button-hover-text-color, var(--rh-color-text-primary));
 
     &:before {
+      /** Overflow button hover bottom indicator */
       border-block-end:
         var(--rh-tabs-overflow-hover-indicator,
           var(--rh-border-width-lg, 3px)
@@ -264,20 +279,31 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
+
+  /** Overflow icon pill width and height */
   width: var(--rh-tabs-overflow-icon-size, auto);
   height: var(--rh-tabs-overflow-icon-size, auto);
+
+  /** Overflow icon pill border radius */
   border-radius: var(--rh-tabs-overflow-icon-radius, 0);
 }
 
 :is(#previous-tab, #next-tab):hover .overflow-icon {
+  /** Overflow icon pill hover background */
   background-color: var(--rh-tabs-overflow-hover-background, transparent);
 }
 
 :is(#previous-tab, #next-tab):focus .overflow-icon {
+  /** Overflow icon pill focus background */
   background-color: var(--rh-tabs-overflow-focus-background, transparent);
+
+  /** Overflow icon pill focus outline */
   outline: var(--rh-tabs-overflow-focus-outline, none);
+
+  /** Overflow icon pill focus outline offset */
   outline-offset: var(--rh-tabs-overflow-focus-outline-offset, 0);
 }
+/* stylelint-enable rhds/no-unknown-token-name */
 
 #next-tab {
   inset-inline-start: -1px;

--- a/elements/rh-tabs/rh-tabs.ts
+++ b/elements/rh-tabs/rh-tabs.ts
@@ -205,11 +205,11 @@ export class RhTabs extends LitElement {
       <div id="container" part="container" class="${classMap({ vertical, box, inset, centered, overflow: this.#overflow.showScrollButtons })}">
         <!-- tabs container -->
         <div part="tabs-container">${!this.#overflow.showScrollButtons ? '' : html`
-          <button id="previous-tab" tabindex="-1"
+          <button id="previous-tab" part="overflow-button previous" tabindex="-1"
                   aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll left'}"
                   ?disabled="${!this.#overflow.overflowLeft}"
                   @click="${() => !this.matches(':dir(rtl)') ? this.#overflow.scrollLeft() : this.#overflow.scrollRight()}">
-            <rh-icon set="ui" icon="caret-left" loading="eager"></rh-icon>
+            <span class="overflow-icon"><rh-icon set="ui" icon="caret-left" loading="eager"></rh-icon></span>
           </button>`}
           <div id="tablist" role="tablist">
             <!-- summary: Tab elements
@@ -222,12 +222,12 @@ export class RhTabs extends LitElement {
                   part="tabs"
                   @slotchange="${this.#onSlotchange}"></slot>
           </div>${!this.#overflow.showScrollButtons ? '' : html`
-          <button id="next-tab"
+          <button id="next-tab" part="overflow-button next"
                   tabindex="-1"
                   aria-label="${this.getAttribute('label-scroll-right') ?? 'Scroll right'}"
                   ?disabled="${!this.#overflow.overflowRight}"
                   @click="${() => !this.matches(':dir(rtl)') ? this.#overflow.scrollRight() : this.#overflow.scrollLeft()}">
-             <rh-icon set="ui" icon="caret-right" loading="eager"></rh-icon>
+            <span class="overflow-icon"><rh-icon set="ui" icon="caret-right" loading="eager"></rh-icon></span>
           </button>`}
         </div>
         <!-- summary: Panel elements

--- a/elements/rh-tabs/rh-tabs.ts
+++ b/elements/rh-tabs/rh-tabs.ts
@@ -55,6 +55,22 @@ export { RhTab };
  * @csspart tabs-container - wrapper around the tab list and scroll buttons
  * @csspart tabs - the scrollable tab list (has `role="tablist"`)
  * @csspart panels - container for `rh-tab-panel` elements
+ * @csspart overflow-button - both overflow scroll buttons
+ * @csspart overflow-button previous - the scroll-left overflow button
+ * @csspart overflow-button next - the scroll-right overflow button
+ *
+ * @cssprop {<length>} [--rh-tabs-overflow-button-padding-block=0] - Block padding for overflow scroll buttons
+ * @cssprop {<length>} [--rh-tabs-overflow-button-padding-inline] - Inline padding for overflow scroll buttons; defaults to `--rh-space-lg`
+ * @cssprop {<length>} [--rh-tabs-overflow-button-radius=0] - Border radius for overflow scroll buttons
+ * @cssprop {<length>} [--rh-tabs-overflow-button-min-size=auto] - Minimum width for overflow scroll buttons
+ * @cssprop {<color>} [--rh-tabs-overflow-border-color] - Border color for overflow button edges; defaults to `--rh-color-border-subtle`
+ * @cssprop [--rh-tabs-overflow-hover-indicator] - Bottom border shorthand on overflow button hover
+ * @cssprop {<length>} [--rh-tabs-overflow-icon-size=auto] - Width and height of the overflow icon pill area
+ * @cssprop {<length>} [--rh-tabs-overflow-icon-radius=0] - Border radius of the overflow icon pill area
+ * @cssprop {<color>} [--rh-tabs-overflow-hover-background=transparent] - Background color of the overflow icon pill on hover
+ * @cssprop {<color>} [--rh-tabs-overflow-focus-background=transparent] - Background color of the overflow icon pill on focus
+ * @cssprop [--rh-tabs-overflow-focus-outline=none] - Outline shorthand for the overflow icon pill on focus
+ * @cssprop {<length>} [--rh-tabs-overflow-focus-outline-offset=0] - Outline offset for the overflow icon pill on focus
  *
  */
 @customElement('rh-tabs')


### PR DESCRIPTION
## What I did

`<rh-tab>`: add `wrapper` element plus CSS custom props — the inner pill-shaped element wrapping the icon and label, enabling themed hover/focus backgrounds.

`<rh-tabs>`: add `overflow-button`, `overflow-button previous`, and `overflow-button next` CSS parts on the overflow scroll buttons, enabling themed padding, sizing, and focus/hover styling.


## Testing Instructions

1. Double-check the changes match the changes in [Adam's original Unified Tabs PR](https://github.com/RedHat-UX/red-hat-design-system/pull/3002/changes#diff-36cb788fdca5f81e140abbf7eaf87c1dc03fc5ccc1aa10885c03acf9cac65c7e), which have been abstracted here. 

## Notes to Reviewers

Related to https://github.com/RedHat-UX/red-hat-design-system/pull/3002