### PR TITLE
feat(scheme toggle): add legend css vars to allow column alignment

### DIFF
--- a/.changeset/tender-mammals-joke.md
+++ b/.changeset/tender-mammals-joke.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-scheme-toggle>`: added new public CSS custom properties (`--rh-scheme-toggle-flex-flow`, `--rh-scheme-toggle-align-items`, `--rh-scheme-toggle-gap`) to control fieldset layout direction, alignment, and spacing. Set `--rh-scheme-toggle-flex-flow: column` to position the legend above the button group.
+  

--- a/elements/rh-scheme-toggle/demo/stacked-legend.html
+++ b/elements/rh-scheme-toggle/demo/stacked-legend.html
@@ -1,0 +1,26 @@
+---
+description: "Scheme toggle with a stacked legend (i.e., vertical orientation)."
+---
+<rh-scheme-toggle></rh-scheme-toggle>
+
+<script type="module">
+  import '@rhds/elements/rh-scheme-toggle/rh-scheme-toggle.js';
+</script>
+
+<style>
+  body {
+    color-scheme: light dark;
+    background-color: light-dark(var(--rh-color-surface-lightest, #ffffff),
+        var(--rh-color-surface-darkest, #151515));
+    color: light-dark(var(--rh-color-text-primary-default-on-light, #151515),
+        var(--rh-color-text-primary-default-on-dark, #ffffff));
+  }
+
+  rh-scheme-toggle {
+    --rh-scheme-toggle-flex-flow: column nowrap;
+    --rh-scheme-toggle-align-items: flex-start;
+    --rh-scheme-toggle-gap: var(--rh-space-md, 8px);
+
+    margin-block-start: var(--rh-space-md, 8px);
+  }
+</style>

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.css
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.css
@@ -3,13 +3,28 @@
 }
 
 fieldset {
-  align-items: center;
+  /**
+   * Fieldset flex layout direction.
+   * Set to `column` to position the legend above the button group.
+   * @cssprop --rh-scheme-toggle-flex-flow
+   */
+  flex-flow: var(--rh-scheme-toggle-flex-flow, row nowrap);
+
+  /**
+   * Cross-axis alignment of legend and button group.
+   * In row layout, this vertically centers the legend with the buttons.
+   * In column layout, controls horizontal alignment.
+   * @cssprop --rh-scheme-toggle-align-items
+   */
+  align-items: var(--rh-scheme-toggle-align-items, center);
+
+  /**
+   * Gap between the legend and the button group.
+   * @cssprop --rh-scheme-toggle-gap
+   */
+  gap: var(--rh-scheme-toggle-gap, var(--rh-space-lg, 16px));
   border: 0;
   display: flex;
-  flex-flow: row nowrap;
-
-  /** Fieldset legend-to-group gap */
-  gap: var(--rh-space-lg, 16px);
   margin: 0;
   padding: 0;
 

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.css
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.css
@@ -5,7 +5,7 @@
 fieldset {
   /**
    * Fieldset flex layout direction.
-   * Set to `column` to position the legend above the button group.
+   * Set to `column` to position the legend "stacked" above the button group.
    * @cssprop --rh-scheme-toggle-flex-flow
    */
   flex-flow: var(--rh-scheme-toggle-flex-flow, row nowrap);


### PR DESCRIPTION
## What I did

1. Added new public CSS custom properties (`--rh-scheme-toggle-flex-flow`, `--rh-scheme-toggle-align-items`, `--rh-scheme-toggle-gap`) to control fieldset layout direction, alignment, and spacing.


## Testing Instructions

1. Verify they work
2. Check code quality


Closes https://github.com/RedHat-UX/red-hat-design-system/issues/3011