### PR TITLE
poc(card): implement dave ruperts workaround for :host(:has) using @s…

### DIFF
--- a/elements/rh-card/rh-card.css
+++ b/elements/rh-card/rh-card.css
@@ -6,31 +6,6 @@
   height: max-content;
 }
 
-/* :host(:has()) can query light DOM children from shadow CSS in Safari and
- * Firefox but fails in Chromium. The @scope block below duplicates the rule
- * using :scope (which resolves to the shadow host inside a bare @scope) so
- * Chromium can evaluate the same condition.
- * https://daverupert.com/2026/06/fix-for-host-has-slot/ */
-:host(:has(> [slot="header"])) #header { display: flex; }
-:host(:has(> [slot="image"])) #image { display: block; }
-:host(:has(> [slot="footer"])) #footer { display: flex; }
-:host(:has(> :not([slot]))) #body { display: block; }
-
-:host(:not(:has(> [slot="footer"]))) #body {
-  margin-block-end: var(--rh-space-2xl, 32px);
-}
-
-@scope {
-  :scope:has(> [slot="header"]) #header { display: flex; }
-  :scope:has(> [slot="image"]) #image { display: block; }
-  :scope:has(> [slot="footer"]) #footer { display: flex; }
-  :scope:has(> :not([slot])) #body { display: block; }
-
-  :scope:not(:has(> [slot="footer"])) #body {
-    margin-block-end: var(--rh-space-2xl, 32px);
-  }
-}
-
 ::slotted(*) {
   line-height: inherit;
 }
@@ -299,63 +274,9 @@
   height: auto;
 }
 
-:host([variant='promo']:not(:has(> [slot='image']))) #container.promo:not(.standard) {
-  grid-template-columns: auto;
-}
-
-@scope {
-  :scope[variant='promo']:not(:has(> [slot='image'])) #container.promo:not(.standard) {
-    grid-template-columns: auto;
-  }
-}
-
 .promo #body {
   /** Promo body margin */
   margin: var(--rh-space-2xl, 32px);
-}
-
-:host([variant='promo']:has(> [slot='image'])) #body {
-  order: -5;
-}
-
-@scope {
-  :scope[variant='promo']:has(> [slot='image']) #body {
-    order: -5;
-  }
-}
-
-:host([variant='promo']:has(> [slot='header'])) #header {
-  margin: 0;
-
-  /** Promo header margin-block-end */
-  margin-block-end: var(--rh-space-lg, 16px);
-}
-
-@scope {
-  :scope[variant='promo']:has(> [slot='header']) #header {
-    margin: 0;
-
-    /** Promo header margin-block-end */
-    margin-block-end: var(--rh-space-lg, 16px);
-  }
-}
-
-:host([variant='promo']:has(> [slot='footer'])) #footer {
-  margin-block:
-    /** Promo footer margin-block-start */
-    var(--rh-space-xl, 24px)
-    0;
-  margin-inline: 0;
-}
-
-@scope {
-  :scope[variant='promo']:has(> [slot='footer']) #footer {
-    margin-block:
-      /** Promo footer margin-block-start */
-      var(--rh-space-xl, 24px)
-      0;
-    margin-inline: 0;
-  }
 }
 
 .promo #header ::slotted(*) {
@@ -369,18 +290,6 @@
   margin-block: 0 var(--_promo-heading-margin-block-end) !important;
 }
 
-:host([variant='promo']:has(> [slot='image'], > [slot='header'])) #body ::slotted(p) {
-  font-size: var(--_promo-paragraph-font-size) !important;
-  margin-block-end: var(--_promo-paragraph-margin-block-end) !important;
-}
-
-@scope {
-  :scope[variant='promo']:has(> [slot='image'], > [slot='header']) #body ::slotted(p) {
-    font-size: var(--_promo-paragraph-font-size) !important;
-    margin-block-end: var(--_promo-paragraph-margin-block-end) !important;
-  }
-}
-
 #container.promo.standard {
   background-color:
     light-dark(
@@ -392,10 +301,6 @@
   display: flex;
   padding: var(--_promo-standard-inline-padding);
   width: auto;
-}
-
-.promo.standard #body {
-  display: contents;
 }
 
 .promo.standard #body ::slotted(:not([slot])) {
@@ -426,10 +331,6 @@
   width: auto;
 }
 
-:host([variant='promo'][full-width]) #body {
-  margin: 0;
-}
-
 :host([variant='promo'][full-width]) #body ::slotted(p) {
   /** Full-width promo paragraph font size */
   --_promo-paragraph-font-size: var(--rh-font-size-body-text-md, 1rem);
@@ -441,18 +342,6 @@
     var(--rh-card-heading-font-size,
       /** Full-width promo heading size */
       var(--rh-font-size-body-text-2xl, 1.5rem));
-}
-
-:host([variant='promo'][full-width]:has(> [slot='image'])) #footer {
-  /** Full-width promo image footer margin-block-end */
-  margin-block-end: var(--rh-space-2xl, 32px);
-}
-
-@scope {
-  :scope[variant='promo'][full-width]:has(> [slot='image']) #footer {
-    /** Full-width promo image footer margin-block-end */
-    margin-block-end: var(--rh-space-2xl, 32px);
-  }
 }
 
 @container promo (min-width: 768px) {
@@ -518,10 +407,123 @@
         /** Full-width promo heading size at containers >= md */
         var(--rh-font-size-heading-md, 1.75rem));
   }
+}
 
+@container promo (min-width: 1200px) {
+  :host([variant='promo'][full-width]) #container {
+    /** Full-width promo padding inline at containers >= xl */
+    padding-inline: var(--rh-space-7xl, 128px);
+  }
+}
+
+/* :host(:has()) can query light DOM children from shadow CSS in Safari and
+ * Firefox but fails in Chromium. The @scope block below duplicates the rule
+ * using :scope (which resolves to the shadow host inside a bare @scope) so
+ * Chromium can evaluate the same condition.
+ * https://daverupert.com/2026/06/fix-for-host-has-slot/ */
+
+:host(:has(> [slot='header'])) #header { display: flex; }
+:host(:has(> [slot='image'])) #image { display: block; }
+:host(:has(> [slot='footer'])) #footer { display: flex; }
+:host(:has(> :not([slot]))) #body { display: block; }
+
+:host(:not(:has(> [slot='footer']), [variant='promo'])) #body {
+  margin-block-end: var(--rh-space-2xl, 32px);
+}
+
+.promo.standard #body {
+  display: contents;
+}
+
+:host([variant='promo']:not(:has(> [slot='image']))) #container.promo:not(.standard) {
+  grid-template-columns: auto;
+}
+
+:host([variant='promo']:has(> [slot='image'])) #body {
+  order: -5;
+}
+
+:host([variant='promo']:has(> [slot='header'])) #header {
+  margin: 0;
+
+  /** Promo header margin-block-end */
+  margin-block-end: var(--rh-space-lg, 16px);
+}
+
+:host([variant='promo']:has(> [slot='footer'])) #footer {
+  margin-block:
+    /** Promo footer margin-block-start */
+    var(--rh-space-xl, 24px)
+    0;
+  margin-inline: 0;
+}
+
+:host([variant='promo']:has(> [slot='image'], > [slot='header'])) #body ::slotted(p) {
+  font-size: var(--_promo-paragraph-font-size) !important;
+  margin-block-end: var(--_promo-paragraph-margin-block-end) !important;
+}
+
+:host([variant='promo'][full-width]:has(> [slot='image'])) #footer {
+  /** Full-width promo image footer margin-block-end */
+  margin-block-end: var(--rh-space-2xl, 32px);
+}
+
+@container promo (min-width: 768px) {
   :host([variant='promo'][full-width]:has(> [slot='image'])) #footer {
     margin-block-end: 0;
   }
+}
+
+@scope {
+  :scope:has(> [slot='header']) #header { display: flex; }
+  :scope:has(> [slot='image']) #image { display: block; }
+  :scope:has(> [slot='footer']) #footer { display: flex; }
+  :scope:has(> :not([slot])) #body { display: block; }
+
+  :scope:not(:has(> [slot='footer']), [variant='promo']) #body {
+    margin-block-end: var(--rh-space-2xl, 32px);
+  }
+
+  .promo.standard #body {
+    display: contents;
+  }
+
+  :scope[variant='promo']:not(:has(> [slot='image'])) #container.promo:not(.standard) {
+    grid-template-columns: auto;
+  }
+
+  :scope[variant='promo']:has(> [slot='image']) #body {
+    order: -5;
+  }
+
+  :scope[variant='promo']:has(> [slot='header']) #header {
+    margin: 0;
+
+    /** Promo header margin-block-end */
+    margin-block-end: var(--rh-space-lg, 16px);
+  }
+
+  :scope[variant='promo']:has(> [slot='footer']) #footer {
+    margin-block:
+      /** Promo footer margin-block-start */
+      var(--rh-space-xl, 24px)
+      0;
+    margin-inline: 0;
+  }
+
+  :scope[variant='promo']:has(> [slot='image'], > [slot='header']) #body ::slotted(p) {
+    font-size: var(--_promo-paragraph-font-size) !important;
+    margin-block-end: var(--_promo-paragraph-margin-block-end) !important;
+  }
+
+  :scope[variant='promo'][full-width]:has(> [slot='image']) #footer {
+    /** Full-width promo image footer margin-block-end */
+    margin-block-end: var(--rh-space-2xl, 32px);
+  }
+}
+
+:host([variant='promo'][full-width]) #body {
+  margin: 0;
 }
 
 @container promo (min-width: 768px) {
@@ -529,12 +531,5 @@
     :scope[variant='promo'][full-width]:has(> [slot='image']) #footer {
       margin-block-end: 0;
     }
-  }
-}
-
-@container promo (min-width: 1200px) {
-  :host([variant='promo'][full-width]) #container {
-    /** Full-width promo padding inline at containers >= xl */
-    padding-inline: var(--rh-space-7xl, 128px);
   }
 }

--- a/elements/rh-card/rh-card.css
+++ b/elements/rh-card/rh-card.css
@@ -6,11 +6,29 @@
   height: max-content;
 }
 
-#header.empty,
-#image.empty,
-#footer.empty,
-#body.empty {
-  display: none !important;
+/* :host(:has()) can query light DOM children from shadow CSS in Safari and
+ * Firefox but fails in Chromium. The @scope block below duplicates the rule
+ * using :scope (which resolves to the shadow host inside a bare @scope) so
+ * Chromium can evaluate the same condition.
+ * https://daverupert.com/2026/06/fix-for-host-has-slot/ */
+:host(:has(> [slot="header"])) #header { display: flex; }
+:host(:has(> [slot="image"])) #image { display: block; }
+:host(:has(> [slot="footer"])) #footer { display: flex; }
+:host(:has(> :not([slot]))) #body { display: block; }
+
+:host(:not(:has(> [slot="footer"]))) #body {
+  margin-block-end: var(--rh-space-2xl, 32px);
+}
+
+@scope {
+  :scope:has(> [slot="header"]) #header { display: flex; }
+  :scope:has(> [slot="image"]) #image { display: block; }
+  :scope:has(> [slot="footer"]) #footer { display: flex; }
+  :scope:has(> :not([slot])) #body { display: block; }
+
+  :scope:not(:has(> [slot="footer"])) #body {
+    margin-block-end: var(--rh-space-2xl, 32px);
+  }
 }
 
 ::slotted(*) {
@@ -132,13 +150,17 @@
   font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
 }
 
+#image {
+  display: none;
+}
+
 #image ::slotted(*) {
   display: block;
   max-width: 100%;
 }
 
 #header {
-  display: flex;
+  display: none;
   flex-direction: column;
 
   /** Header content gap */
@@ -166,6 +188,7 @@
 }
 
 #body {
+  display: none;
   margin-block:
     /** Body margin-block-start */
     var(--rh-space-2xl, 32px)
@@ -173,13 +196,8 @@
     var(--rh-space-xl, 24px);
 }
 
-#body:has(+ .empty) {
-  /** Body margin-block-end */
-  margin-block-end: var(--rh-space-2xl, 32px);
-}
-
 #footer {
-  display: flex;
+  display: none;
   gap: 0.5em;
   margin-block:
     auto
@@ -281,8 +299,14 @@
   height: auto;
 }
 
-#container.promo:not(.standard, .image) {
+:host([variant='promo']:not(:has(> [slot='image']))) #container.promo:not(.standard) {
   grid-template-columns: auto;
+}
+
+@scope {
+  :scope[variant='promo']:not(:has(> [slot='image'])) #container.promo:not(.standard) {
+    grid-template-columns: auto;
+  }
 }
 
 .promo #body {
@@ -290,23 +314,48 @@
   margin: var(--rh-space-2xl, 32px);
 }
 
-.promo.image #body {
+:host([variant='promo']:has(> [slot='image'])) #body {
   order: -5;
 }
 
-.promo.header #header {
+@scope {
+  :scope[variant='promo']:has(> [slot='image']) #body {
+    order: -5;
+  }
+}
+
+:host([variant='promo']:has(> [slot='header'])) #header {
   margin: 0;
 
   /** Promo header margin-block-end */
   margin-block-end: var(--rh-space-lg, 16px);
 }
 
-.promo.footer #footer {
+@scope {
+  :scope[variant='promo']:has(> [slot='header']) #header {
+    margin: 0;
+
+    /** Promo header margin-block-end */
+    margin-block-end: var(--rh-space-lg, 16px);
+  }
+}
+
+:host([variant='promo']:has(> [slot='footer'])) #footer {
   margin-block:
     /** Promo footer margin-block-start */
     var(--rh-space-xl, 24px)
     0;
   margin-inline: 0;
+}
+
+@scope {
+  :scope[variant='promo']:has(> [slot='footer']) #footer {
+    margin-block:
+      /** Promo footer margin-block-start */
+      var(--rh-space-xl, 24px)
+      0;
+    margin-inline: 0;
+  }
 }
 
 .promo #header ::slotted(*) {
@@ -320,9 +369,16 @@
   margin-block: 0 var(--_promo-heading-margin-block-end) !important;
 }
 
-.promo:is(.image, .header) #body ::slotted(p) {
+:host([variant='promo']:has(> [slot='image'], > [slot='header'])) #body ::slotted(p) {
   font-size: var(--_promo-paragraph-font-size) !important;
   margin-block-end: var(--_promo-paragraph-margin-block-end) !important;
+}
+
+@scope {
+  :scope[variant='promo']:has(> [slot='image'], > [slot='header']) #body ::slotted(p) {
+    font-size: var(--_promo-paragraph-font-size) !important;
+    margin-block-end: var(--_promo-paragraph-margin-block-end) !important;
+  }
 }
 
 #container.promo.standard {
@@ -387,9 +443,16 @@
       var(--rh-font-size-body-text-2xl, 1.5rem));
 }
 
-:host([variant='promo'][full-width]) .image #footer {
+:host([variant='promo'][full-width]:has(> [slot='image'])) #footer {
   /** Full-width promo image footer margin-block-end */
   margin-block-end: var(--rh-space-2xl, 32px);
+}
+
+@scope {
+  :scope[variant='promo'][full-width]:has(> [slot='image']) #footer {
+    /** Full-width promo image footer margin-block-end */
+    margin-block-end: var(--rh-space-2xl, 32px);
+  }
 }
 
 @container promo (min-width: 768px) {
@@ -456,8 +519,16 @@
         var(--rh-font-size-heading-md, 1.75rem));
   }
 
-  :host([variant='promo'][full-width]) .image #footer {
+  :host([variant='promo'][full-width]:has(> [slot='image'])) #footer {
     margin-block-end: 0;
+  }
+}
+
+@container promo (min-width: 768px) {
+  @scope {
+    :scope[variant='promo'][full-width]:has(> [slot='image']) #footer {
+      margin-block-end: 0;
+    }
   }
 }
 

--- a/elements/rh-card/rh-card.ts
+++ b/elements/rh-card/rh-card.ts
@@ -53,7 +53,7 @@ export class RhCard extends LitElement {
    */
   @property({ reflect: true, attribute: 'full-width', type: Boolean }) fullWidth? = false;
 
-  #slots = new SlotController(this, 'header', 'image', null, 'footer');
+  #slots = new SlotController(this, 'header', 'image', null);
 
   override render() {
     const isPromo = this.variant === 'promo';
@@ -75,15 +75,10 @@ export class RhCard extends LitElement {
     const promo = this.variant === 'promo';
     const standard = isStandardPromo;
     const { variant = '' } = this;
-    const hasHeader = this.#slots.hasSlotted('header');
-    const hasFooter = this.#slots.hasSlotted('footer');
-    const hasImage = this.#slots.hasSlotted('image');
-    const hasBody = this.#slots.hasSlotted(null);
     const header = html`
       <!-- The header for the card. Contains the header slot. -->
       <div id="header"
-           part="header"
-           class="${classMap({ empty: !hasHeader })}">
+           part="header">
         <!--
           summary: Card header content
           description: |
@@ -96,8 +91,7 @@ export class RhCard extends LitElement {
     const footer = html`
       <!-- The footer for the card. Contains the footer slot. -->
       <div id="footer"
-           part="footer"
-           class="${classMap({ empty: !hasFooter })}">
+           part="footer">
         <!--
           summary: Card footer content
           description: |
@@ -113,17 +107,12 @@ export class RhCard extends LitElement {
           part="container"
           class="${classMap({
             standard,
-            body: hasBody,
-            header: hasHeader,
-            footer: hasFooter,
-            image: hasImage,
             [variant]: !!variant,
             [computedPalette ?? '']: !!computedPalette,
           })}">${promo ? '' : header}
         <!-- The image for the promo variant for the card. Contains the image slot. -->
         <div id="image"
-             part="image"
-             class="${classMap({ empty: !hasImage })}">
+             part="image">
           <!--
             summary: Promo variant image content
             description: |
@@ -135,8 +124,7 @@ export class RhCard extends LitElement {
         </div>
         <!-- The body for the card. Contains the default slot. -->
         <div id="body"
-             part="body"
-             class="${classMap({ empty: !hasBody })}">
+             part="body">
           ${!promo ? '' : header}
           <!--
             summary: Card body content (default slot)


### PR DESCRIPTION
# THIS IS A PROOF OF CONCEPT - DO NOT MERGE

## What I did

Replaces JavaScript-driven `.empty` class toggling on `rh-card` slot wrappers with pure CSS slot detection using `:host(:has())` + `@scope {}`. This eliminates the SSR flash caused by `MutationObserver`/`SlotController` not running server-side — slot wrappers now hide/show immediately on parse with no JS required.

Uses [Dave Rupert's `@scope` workaround](https://daverupert.com/2026/06/fix-for-host-has-slot/) to make `:host(:has())` work cross-browser: Safari and Firefox support `:host(:has())` natively, while Chromium needs a bare `@scope {}` block where `:scope` resolves to the shadow host.

## What changed

### CSS (`rh-card.css`)
- **Removed** `#header.empty, #image.empty, #footer.empty, #body.empty { display: none !important }` rule
- **Removed** `#body:has(+ .empty)` margin adjustment
- **Set** `#header`, `#image`, `#footer`, `#body` to `display: none` by default
- **Added** `:host(:has())` + `@scope` rules that conditionally show each wrapper when its corresponding slot has content (e.g. `:host(:has(> [slot="header"])) #header { display: flex }`)
- **Replaced** container layout classes (`.promo.image`, `.promo.header`, `.promo.footer`) with `:host(:has())` + `@scope` equivalents

### JS (`rh-card.ts`)
- **Removed** `hasHeader`, `hasFooter`, `hasImage`, `hasBody` variables
- **Removed** `classMap({ empty: !has* })` from all four wrapper divs
- **Removed** `body`, `header`, `footer`, `image` entries from container `classMap`
- **Removed** `'footer'` from `SlotController` registration
- **Kept** `SlotController` for `isStandardPromo` palette computation (requires JS string manipulation — can't be expressed in CSS)

## Why

The previous approach used `SlotController` (a `MutationObserver`-based Lit controller) to detect slot content, trigger a re-render, and toggle `.empty` classes via `classMap`. This is problematic for SSR because:
1. `MutationObserver` doesn't run server-side
2. `.empty` classes aren't applied until JS hydrates
3. Empty slot wrappers flash visible before being hidden

The CSS-only approach works immediately when the browser parses the HTML — no JS hydration needed.

## References

- [Dave Rupert — A workaround for hiding empty slots in Chromium](https://daverupert.com/2026/06/fix-for-host-has-slot/)
- [Adobe — Modern CSS Feature Support for Shadow DOM](http://shadow-dom-css.adobe.com/)
- [CSSWG #6867 — `:has-slotted` proposal](https://github.com/w3c/csswg-drafts/issues/6867)

## Testing Instructions

- [x] All 6 existing `rh-card` tests pass
- [ ] Visual check: default card, promo, standard promo, full-width promo — slots hide/show correctly
- [ ] Verify in Chrome, Safari, Firefox
- [ ] Confirm no layout flash on initial render with empty slots


## Notes to Reviewers

This can be ported to other places we've done this .empty class processing such as primary navigation.