### PR TITLE
docs(felt-demos): duplicated Felt theme demos into element doc demos

### DIFF
--- a/elements/rh-accordion/demo/felt-theme.html
+++ b/elements/rh-accordion/demo/felt-theme.html
@@ -1,0 +1,83 @@
+---
+description: "Accordion with the Project Felt preview theme — borderless, borderless large, bordered, and bordered large variants. Note: `class=\"bordered\"` is a Felt-specific CSS class, not part of the element API."
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Borderless (Default)</h3>
+  <div class="example-row">
+    <rh-accordion>
+      <rh-accordion-header>Accordion item one</rh-accordion-header>
+      <rh-accordion-panel>
+        <p>Panel content for item one. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </rh-accordion-panel>
+      <rh-accordion-header expanded>Accordion item two</rh-accordion-header>
+      <rh-accordion-panel expanded>
+        <p>Panel content for item two. Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+      </rh-accordion-panel>
+      <rh-accordion-header>Accordion item three</rh-accordion-header>
+      <rh-accordion-panel>
+        <p>Panel content for item three.</p>
+      </rh-accordion-panel>
+    </rh-accordion>
+  </div>
+
+  <h3>Borderless — Large</h3>
+  <div class="example-row">
+    <rh-accordion large>
+      <rh-accordion-header>Accordion item one</rh-accordion-header>
+      <rh-accordion-panel>
+        <p>Panel content for item one. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </rh-accordion-panel>
+      <rh-accordion-header expanded>Accordion item two</rh-accordion-header>
+      <rh-accordion-panel expanded>
+        <p>Panel content for item two. Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+      </rh-accordion-panel>
+    </rh-accordion>
+  </div>
+
+  <h3>Bordered</h3>
+  <div class="example-row">
+    <rh-accordion class="bordered">
+      <rh-accordion-header>Accordion item one</rh-accordion-header>
+      <rh-accordion-panel>
+        <p>Panel content for item one. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </rh-accordion-panel>
+      <rh-accordion-header expanded>Accordion item two</rh-accordion-header>
+      <rh-accordion-panel expanded>
+        <p>Panel content for item two. Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+      </rh-accordion-panel>
+      <rh-accordion-header>Accordion item three</rh-accordion-header>
+      <rh-accordion-panel>
+        <p>Panel content for item three.</p>
+      </rh-accordion-panel>
+    </rh-accordion>
+  </div>
+
+  <h3>Bordered — Large</h3>
+  <div class="example-row">
+    <rh-accordion large class="bordered">
+      <rh-accordion-header>Accordion item one</rh-accordion-header>
+      <rh-accordion-panel>
+        <p>Panel content for item one. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </rh-accordion-panel>
+      <rh-accordion-header expanded>Accordion item two</rh-accordion-header>
+      <rh-accordion-panel expanded>
+        <p>Panel content for item two. Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+      </rh-accordion-panel>
+    </rh-accordion>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-accordion/rh-accordion.js';
+</script>

--- a/elements/rh-accordion/demo/felt-theme.html
+++ b/elements/rh-accordion/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: "Accordion with the Project Felt preview theme — borderless, borderless large, bordered, and bordered large variants. Note: `class=\"bordered\"` is a Felt-specific CSS class, not part of the element API."
+description: "Accordion with the [Project Felt](/theming/themes/project-felt/) preview theme — borderless, borderless large, bordered, and bordered large variants. Note: `class=\"bordered\"` is a Felt-specific CSS class, not part of the element API."
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-alert/demo/felt-theme.html
+++ b/elements/rh-alert/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Inline, dismissable, and toast alerts with the Project Felt preview theme applied.
+description: Inline, dismissable, and toast alerts with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-alert/demo/felt-theme.html
+++ b/elements/rh-alert/demo/felt-theme.html
@@ -1,0 +1,89 @@
+---
+description: Inline, dismissable, and toast alerts with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .example-flex {
+    display: flex;
+    flex-direction: column;
+    gap: var(--rh-space-lg, 16px);
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Inline alerts</h3>
+  <div class="example-row example-flex">
+    <rh-alert>
+      <h4 slot="header">Default alert</h4>
+      <p>This is the default alert description.</p>
+    </rh-alert>
+    <rh-alert state="success">
+      <h4 slot="header">Success alert</h4>
+      <p>This is a success alert description.</p>
+    </rh-alert>
+    <rh-alert state="warning">
+      <h4 slot="header">Warning alert</h4>
+      <p>This is a warning alert description.</p>
+    </rh-alert>
+    <rh-alert state="danger">
+      <h4 slot="header">Danger alert</h4>
+      <p>This is a danger alert description.</p>
+    </rh-alert>
+    <rh-alert state="info">
+      <h4 slot="header">Info alert</h4>
+      <p>This is an info alert description.</p>
+    </rh-alert>
+  </div>
+
+  <h3>Dismissable alerts</h3>
+  <div class="example-row example-flex">
+    <rh-alert dismissable>
+      <h4 slot="header">Default alert</h4>
+      <p>This is the default alert description.</p>
+    </rh-alert>
+    <rh-alert state="success" dismissable>
+      <h4 slot="header">Success alert</h4>
+      <p>This is a success alert description.</p>
+    </rh-alert>
+    <rh-alert state="warning" dismissable>
+      <h4 slot="header">Warning alert</h4>
+      <p>This is a warning alert description.</p>
+    </rh-alert>
+    <rh-alert state="danger" dismissable>
+      <h4 slot="header">Danger alert</h4>
+      <p>This is a danger alert description.</p>
+    </rh-alert>
+    <rh-alert state="info" dismissable>
+      <h4 slot="header">Info alert</h4>
+      <p>This is an info alert description.</p>
+    </rh-alert>
+  </div>
+
+  <h3>Toast alerts</h3>
+  <div class="example-row example-flex">
+    <rh-alert variant="toast">
+      <h4 slot="header">Default toast</h4>
+      <p>This is a toast alert description.</p>
+    </rh-alert>
+    <rh-alert variant="toast" state="success">
+      <h4 slot="header">Success toast</h4>
+      <p>This is a success toast description.</p>
+    </rh-alert>
+    <rh-alert variant="toast" state="danger">
+      <h4 slot="header">Danger toast</h4>
+      <p>This is a danger toast description.</p>
+    </rh-alert>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-alert/rh-alert.js';
+</script>

--- a/elements/rh-badge/demo/felt-theme.html
+++ b/elements/rh-badge/demo/felt-theme.html
@@ -1,0 +1,31 @@
+---
+description: Badge states with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-flex {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-lg, 16px);
+    align-items: center;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <div class="example-flex">
+    <rh-badge number="7">7</rh-badge>
+    <rh-badge state="info" number="24">24</rh-badge>
+    <rh-badge state="success" number="12">12</rh-badge>
+    <rh-badge state="caution" number="3">3</rh-badge>
+    <rh-badge state="warning" number="5">5</rh-badge>
+    <rh-badge state="danger" number="99">99</rh-badge>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-badge/rh-badge.js';
+</script>

--- a/elements/rh-badge/demo/felt-theme.html
+++ b/elements/rh-badge/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Badge states with the Project Felt preview theme applied.
+description: Badge states with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-breadcrumb/demo/felt-theme.html
+++ b/elements/rh-breadcrumb/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Breadcrumb navigation with the Project Felt preview theme applied.
+description: Breadcrumb navigation with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 <link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css">

--- a/elements/rh-breadcrumb/demo/felt-theme.html
+++ b/elements/rh-breadcrumb/demo/felt-theme.html
@@ -1,0 +1,26 @@
+---
+description: Breadcrumb navigation with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+<link rel="stylesheet" href="/assets/packages/@rhds/elements/elements/rh-breadcrumb/rh-breadcrumb-lightdom.css">
+
+<style>
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <rh-breadcrumb>
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="#">Section</a></li>
+      <li><a href="#">Subsection</a></li>
+      <li><a href="#" aria-current="page">Current page</a></li>
+    </ol>
+  </rh-breadcrumb>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-breadcrumb/rh-breadcrumb.js';
+</script>

--- a/elements/rh-button/demo/felt-theme.html
+++ b/elements/rh-button/demo/felt-theme.html
@@ -1,0 +1,78 @@
+---
+description: All button variants, danger states, icon buttons, compact sizes, and disabled states with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .example-flex {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-lg, 16px);
+    align-items: center;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <div class="example-row example-flex">
+    <rh-button>Primary</rh-button>
+    <rh-button variant="secondary">Secondary</rh-button>
+    <rh-button variant="tertiary">Tertiary</rh-button>
+    <rh-button variant="link">Link</rh-button>
+    <rh-button icon="ellipsis-vertical-fill" variant="icon" aria-label="Menu"></rh-button>
+    <rh-button icon="close" icon-set="microns" variant="icon" aria-label="Close"></rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button danger>Primary danger</rh-button>
+    <rh-button variant="secondary" danger>Secondary danger</rh-button>
+    <rh-button variant="tertiary" danger>Tertiary danger</rh-button>
+    <rh-button variant="link" danger>Link danger</rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button icon="add-circle">Primary</rh-button>
+    <rh-button icon="add-circle" variant="secondary">Secondary</rh-button>
+    <rh-button icon="add-circle" variant="tertiary">Tertiary</rh-button>
+    <rh-button icon="add-circle" variant="link">Link</rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button icon="warning-fill" danger>Primary</rh-button>
+    <rh-button icon="warning-fill" variant="secondary" danger>Secondary</rh-button>
+    <rh-button icon="warning-fill" variant="tertiary" danger>Tertiary</rh-button>
+    <rh-button icon="warning-fill" variant="link" danger>Link</rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button disabled>Disabled</rh-button>
+    <rh-button disabled variant="secondary">Disabled</rh-button>
+    <rh-button disabled variant="tertiary">Disabled</rh-button>
+    <rh-button disabled variant="link">Disabled</rh-button>
+    <rh-button disabled icon="ellipsis-vertical-fill" variant="icon" aria-label="Menu"></rh-button>
+    <rh-button disabled icon="close" icon-set="microns" variant="icon" aria-label="Close"></rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button compact>Compact 1º</rh-button>
+    <rh-button compact variant="secondary">Compact 2º</rh-button>
+    <rh-button compact variant="tertiary">Compact 3º</rh-button>
+    <rh-button compact variant="link">Compact link</rh-button>
+    <rh-button compact icon="ellipsis-vertical-fill" variant="icon" aria-label="Menu"></rh-button>
+    <rh-button compact icon="close" icon-set="microns" variant="icon" aria-label="Close"></rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button compact danger>Compact 1º danger</rh-button>
+    <rh-button compact variant="secondary" danger>Compact 2º danger</rh-button>
+    <rh-button compact variant="link" danger>Compact link danger</rh-button>
+  </div>
+  <div class="example-row example-flex">
+    <rh-button variant="close" accessible-label="Close"></rh-button>
+    <rh-button variant="play">Play</rh-button>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-button/rh-button.js';
+</script>

--- a/elements/rh-button/demo/felt-theme.html
+++ b/elements/rh-button/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: All button variants, danger states, icon buttons, compact sizes, and disabled states with the Project Felt preview theme applied.
+description: All button variants, danger states, icon buttons, compact sizes, and disabled states with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-card/demo/felt-theme.html
+++ b/elements/rh-card/demo/felt-theme.html
@@ -1,0 +1,87 @@
+---
+description: "Card variants and sizes with the Project Felt preview theme applied. Note: `size` attribute (`compact`, `large`) and `variant` values (`plain`, `secondary`) are Felt-specific and not yet part of the element's public API."
+---
+<link rel="stylesheet" href="/styles/demo/styles.css" media="all">
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .card-grid {
+    display: flex;
+    gap: var(--rh-space-2xl, 32px);
+
+    rh-card {
+      height: auto;
+    }
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Default</h3>
+  <div class="card-grid example-row">
+    <rh-card>
+        <h4 slot="header">Example card - default</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue.</p>
+        <rh-cta href="#" slot="footer" variant="primary">Call to action</rh-cta>
+    </rh-card>
+    <rh-card variant="secondary">
+        <h4 slot="header">Example card - secondary</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue.</p>
+        <rh-cta href="#" slot="footer">Call to action</rh-cta>
+    </rh-card>
+    <rh-card variant="plain">
+        <h4 slot="header">Example card - plain</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue.</p>
+        <rh-cta href="#" slot="footer">Call to action</rh-cta>
+    </rh-card>
+  </div>
+
+  <h3>Compact</h3>
+  <div class="card-grid example-row">
+    <rh-card size="compact">
+        <h4 slot="header">Compact card - default</h4>
+        <p>Tighter padding for compact layouts.</p>
+        <rh-cta href="#" slot="footer">Call to action</rh-cta>
+    </rh-card>
+    <rh-card size="compact" variant="secondary">
+        <h4 slot="header">Compact card - secondary</h4>
+        <p>Tighter padding for compact layouts.</p>
+        <rh-cta href="#" slot="footer">Call to action</rh-cta>
+    </rh-card>
+    <rh-card size="compact" variant="plain">
+      <h4 slot="header">Compact card - plain</h4>
+      <p>Tighter padding for compact layouts.</p>
+      <rh-cta href="#" slot="footer">Call to action</rh-cta>
+  </rh-card>
+  </div>
+
+  <h3>Large</h3>
+  <div class="card-grid example-row">
+    <rh-card size="large">
+        <h4 slot="header">Large card - default</h4>
+        <p>Extra padding for spacious layouts. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <rh-cta href="#" slot="footer" variant="primary">Call to action</rh-cta>
+    </rh-card>
+    <rh-card size="large" variant="secondary">
+      <h4 slot="header">Large card - secondary</h4>
+      <p>Extra padding for spacious layouts. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <rh-cta href="#" slot="footer">Call to action</rh-cta>
+  </rh-card>
+  <rh-card size="large" variant="plain">
+    <h4 slot="header">Large card - plain</h4>
+    <p>Extra padding for spacious layouts. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <rh-cta href="#" slot="footer">Call to action</rh-cta>
+  </rh-card>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-card/rh-card.js';
+  import '@rhds/elements/rh-cta/rh-cta.js';
+</script>

--- a/elements/rh-card/demo/felt-theme.html
+++ b/elements/rh-card/demo/felt-theme.html
@@ -1,7 +1,6 @@
 ---
 description: "Card variants and sizes with the Project Felt preview theme applied. Note: `size` attribute (`compact`, `large`) and `variant` values (`plain`, `secondary`) are Felt-specific and not yet part of the element's public API."
 ---
-<link rel="stylesheet" href="/styles/demo/styles.css" media="all">
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 
 <style>

--- a/elements/rh-card/demo/felt-theme.html
+++ b/elements/rh-card/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: "Card variants and sizes with the Project Felt preview theme applied. Note: `size` attribute (`compact`, `large`) and `variant` values (`plain`, `secondary`) are Felt-specific and not yet part of the element's public API."
+description: "Card variants and sizes with the [Project Felt](/theming/themes/project-felt/) preview theme applied. Note: `size` attribute (`compact`, `large`) and `variant` values (`plain`, `secondary`) are Felt-specific and not yet part of the element's public API."
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-chip/demo/felt-theme.html
+++ b/elements/rh-chip/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Chip and chip group sizes with the Project Felt preview theme applied.
+description: Chip and chip group sizes with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-chip/demo/felt-theme.html
+++ b/elements/rh-chip/demo/felt-theme.html
@@ -1,0 +1,56 @@
+---
+description: Chip and chip group sizes with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .example-flex {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-lg, 16px);
+    align-items: center;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Default (large)</h3>
+  <div class="example-row example-flex">
+    <rh-chip>Chip</rh-chip>
+    <rh-chip>Another chip</rh-chip>
+    <rh-chip>Third chip</rh-chip>
+  </div>
+
+  <h3>Chip group large</h3>
+  <div class="example-row">
+    <rh-chip-group accessible-label="Chip group default">
+      <rh-chip>Small</rh-chip>
+      <rh-chip>Small</rh-chip>
+      <rh-chip>Small</rh-chip>
+    </rh-chip-group>
+  </div>
+
+  <h3>Chip group small</h3>
+  <div class="example-row">
+    <rh-chip-group size="sm" accessible-label="Chip group small">
+      <rh-chip>Small</rh-chip>
+      <rh-chip>Small</rh-chip>
+      <rh-chip>Small</rh-chip>
+    </rh-chip-group>
+  </div>
+
+  <h3>Disabled</h3>
+  <div class="example-row example-flex">
+    <rh-chip disabled>Disabled chip</rh-chip>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-chip/rh-chip.js';
+</script>

--- a/elements/rh-cta/demo/felt-theme.html
+++ b/elements/rh-cta/demo/felt-theme.html
@@ -1,0 +1,59 @@
+---
+description: "CTA variants and compact sizes with the Project Felt preview theme applied. Note: `variant=\"tertiary\"` and the `compact` attribute are Felt-specific and not yet part of the element's public API."
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .example-flex {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-lg, 16px);
+    align-items: center;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Default sizes</h3>
+  <div class="example-row example-flex">
+    <rh-cta variant="primary" href="#">Primary</rh-cta>
+    <rh-cta variant="secondary" href="#">Secondary</rh-cta>
+    <rh-cta variant="tertiary" href="#">Tertiary</rh-cta>
+    <rh-cta href="#">Default</rh-cta>
+    <rh-cta variant="brick" href="#">Brick</rh-cta>
+  </div>
+
+  <div class="example-row example-flex">
+    <rh-cta variant="primary" icon="play-circle" href="#">Primary</rh-cta>
+    <rh-cta variant="secondary" icon="play-circle" href="#">Secondary</rh-cta>
+    <rh-cta variant="tertiary" icon="play-circle" href="#">Tertiary</rh-cta>
+    <rh-cta icon="play-circle" href="#">Default</rh-cta>
+    <rh-cta icon="play-circle" variant="brick" href="#">Brick</rh-cta>
+  </div>
+
+  <h3>Compact</h3>
+  <div class="example-row example-flex">
+    <rh-cta variant="primary" compact href="#">Primary</rh-cta>
+    <rh-cta variant="secondary" compact href="#">Secondary</rh-cta>
+    <rh-cta variant="tertiary" compact href="#">Tertiary</rh-cta>
+    <rh-cta compact href="#">Default</rh-cta>
+  </div>
+
+  <div class="example-row example-flex">
+    <rh-cta variant="primary" compact icon="play-circle" href="#">Primary</rh-cta>
+    <rh-cta variant="secondary" compact icon="play-circle" href="#">Secondary</rh-cta>
+    <rh-cta variant="tertiary" compact icon="play-circle" href="#">Tertiary</rh-cta>
+    <rh-cta icon="play-circle" compact href="#">Default</rh-cta>
+    <rh-cta compact icon="play-circle" variant="brick" href="#">Brick</rh-cta>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-cta/rh-cta.js';
+</script>

--- a/elements/rh-cta/demo/felt-theme.html
+++ b/elements/rh-cta/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: "CTA variants and compact sizes with the Project Felt preview theme applied. Note: `variant=\"tertiary\"` and the `compact` attribute are Felt-specific and not yet part of the element's public API."
+description: "CTA variants and compact sizes with the [Project Felt](/theming/themes/project-felt/) preview theme applied. Note: `variant=\"tertiary\"` and the `compact` attribute are Felt-specific and not yet part of the element's public API."
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-dialog/demo/felt-theme.html
+++ b/elements/rh-dialog/demo/felt-theme.html
@@ -1,7 +1,6 @@
 ---
 description: Dialog size variants with the Project Felt preview theme applied.
 ---
-<link rel="stylesheet" href="/styles/demo/styles.css" media="all">
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 
 <style>

--- a/elements/rh-dialog/demo/felt-theme.html
+++ b/elements/rh-dialog/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Dialog size variants with the Project Felt preview theme applied.
+description: Dialog size variants with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-dialog/demo/felt-theme.html
+++ b/elements/rh-dialog/demo/felt-theme.html
@@ -1,0 +1,52 @@
+---
+description: Dialog size variants with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/styles/demo/styles.css" media="all">
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <div class="example-row">
+    <rh-button id="dialog-trigger-sm">Open small dialog</rh-button>
+    <rh-button id="dialog-trigger-md">Open medium dialog</rh-button>
+    <rh-button id="dialog-trigger-lg">Open large dialog</rh-button>
+    <rh-button id="dialog-trigger-nh">Open no-header dialog</rh-button>
+
+    <rh-dialog trigger="dialog-trigger-sm" variant="small">
+      <h3 slot="header">Modal title</h3>
+      <p>Content goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <rh-button slot="footer">Confirm</rh-button>
+      <rh-button slot="footer" variant="link">Cancel</rh-button>
+    </rh-dialog>
+    <rh-dialog trigger="dialog-trigger-md" variant="medium">
+      <h3 slot="header">Modal title</h3>
+      <p>Content goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <rh-button slot="footer">Confirm</rh-button>
+      <rh-button slot="footer" variant="link">Cancel</rh-button>
+    </rh-dialog>
+    <rh-dialog trigger="dialog-trigger-lg" variant="large">
+      <h3 slot="header">Modal title</h3>
+      <p>Content goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <rh-button slot="footer">Confirm</rh-button>
+      <rh-button slot="footer" variant="link">Cancel</rh-button>
+    </rh-dialog>
+    <rh-dialog trigger="dialog-trigger-nh">
+      <p>Content goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <rh-button slot="footer">Confirm</rh-button>
+      <rh-button slot="footer" variant="link">Cancel</rh-button>
+    </rh-dialog>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-dialog/rh-dialog.js';
+  import '@rhds/elements/rh-button/rh-button.js';
+</script>

--- a/elements/rh-jump-links/demo/felt-theme.html
+++ b/elements/rh-jump-links/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Vertical, nested, and horizontal jump links with the Project Felt preview theme applied.
+description: Vertical, nested, and horizontal jump links with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-jump-links/demo/felt-theme.html
+++ b/elements/rh-jump-links/demo/felt-theme.html
@@ -1,0 +1,85 @@
+---
+description: Vertical, nested, and horizontal jump links with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  #jump-links-demo-container {
+    display: grid;
+    grid-template-columns: max-content auto;
+    gap: var(--rh-space-2xl, 32px);
+    padding: var(--rh-space-lg, 16px);
+
+    aside {
+      h2 {
+        font-weight: var(--rh-font-weight-heading-medium);
+        font-family: var(--rh-font-family-body-text);
+        font-size: var(--rh-font-size-body-text-md);
+        line-height: var(--rh-line-height-body-text, 1.5);
+        margin-block-end: var(--rh-space-lg);
+      }
+    }
+  }
+
+  #horizontal-demo {
+    padding: var(--rh-space-lg, 16px);
+
+    h2 {
+      font-weight: var(--rh-font-weight-heading-medium);
+      font-family: var(--rh-font-family-body-text);
+      font-size: var(--rh-font-size-body-text-md);
+      line-height: var(--rh-line-height-body-text, 1.5);
+      margin-block-end: var(--rh-space-lg);
+    }
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <div id="jump-links-demo-container">
+    <aside>
+      <h2 id="sections">Vertical</h2>
+      <rh-jump-links aria-labelledby="sections">
+        <rh-jump-link href="#section-1">Section 1</rh-jump-link>
+        <rh-jump-link href="#section-2" active>Section 2</rh-jump-link>
+        <rh-jump-link href="#section-3">Section 3</rh-jump-link>
+        <rh-jump-link href="#section-4">Section 4</rh-jump-link>
+        <rh-jump-link href="#section-5">Section 5</rh-jump-link>
+      </rh-jump-links>
+
+      <h2 id="nested-sections">Nested</h2>
+      <rh-jump-links aria-labelledby="nested-sections">
+        <rh-jump-link href="#section-1">Jump link</rh-jump-link>
+        <rh-jump-links-list active>
+          <rh-jump-link slot="parent"
+                        href="#section-2">Jump link with active subsection</rh-jump-link>
+          <rh-jump-link href="#section-2a" active>Jump link subsection</rh-jump-link>
+          <rh-jump-link href="#section-2b">Jump link subsection</rh-jump-link>
+        </rh-jump-links-list>
+        <rh-jump-link href="#section-3">Jump link</rh-jump-link>
+        <rh-jump-link href="#section-4">Jump link</rh-jump-link>
+      </rh-jump-links>
+    </aside>
+  </div>
+
+  <div id="horizontal-demo">
+    <h2 id="horizontal-sections">Horizontal</h2>
+    <rh-jump-links orientation="horizontal"
+                   aria-labelledby="horizontal-sections">
+      <rh-jump-link href="#section-1">Jump link</rh-jump-link>
+      <rh-jump-link href="#section-2" active>Jump link</rh-jump-link>
+      <rh-jump-link href="#section-3">Jump link</rh-jump-link>
+      <rh-jump-link href="#section-4">Jump link</rh-jump-link>
+      <rh-jump-link href="#section-5">Jump link</rh-jump-link>
+      <rh-jump-link href="#section-6">Jump link</rh-jump-link>
+      <rh-jump-link href="#section-7">Jump link</rh-jump-link>
+      <rh-jump-link href="#section-8">Jump link</rh-jump-link>
+    </rh-jump-links>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-jump-links/rh-jump-links.js';
+</script>

--- a/elements/rh-menu-dropdown/demo/felt-theme.html
+++ b/elements/rh-menu-dropdown/demo/felt-theme.html
@@ -1,0 +1,59 @@
+---
+description: Basic, descriptive, and compact menu dropdowns with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  #menu-dropdown-container {
+    h3 {
+      margin-block: 1.5rem 0.5rem !important;
+    }
+
+    rh-menu-dropdown:not([layout="compact"]) {
+      width: 296px;
+    }
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <div id="menu-dropdown-container">
+    <h3>Basic</h3>
+    <rh-menu-dropdown>
+      <span slot="toggle-label">Basic toggle</span>
+      <rh-menu-item>Action one</rh-menu-item>
+      <rh-menu-item>Action two</rh-menu-item>
+      <rh-menu-item>Action three</rh-menu-item>
+      <rh-menu-item disabled>Disabled Action</rh-menu-item>
+      <hr/>
+      <rh-menu-item>Separated action</rh-menu-item>
+    </rh-menu-dropdown>
+
+    <h3>Items with descriptions</h3>
+    <rh-menu-dropdown>
+      <span slot="toggle-label">With descriptions</span>
+      <rh-menu-item>Action one <p slot="description">Description for the 1st action</p></rh-menu-item>
+      <rh-menu-item>Action two <p slot="description">Description for the 2nd action</p></rh-menu-item>
+      <rh-menu-item>Action three <p slot="description">Description for the 3rd action</p></rh-menu-item>
+      <rh-menu-item disabled>Disabled Action <p slot="description">Description for a disabled action</p></rh-menu-item>
+      <hr/>
+      <rh-menu-item>Separated action <p slot="description">Description for a separate action</p></rh-menu-item>
+    </rh-menu-dropdown>
+
+    <h3>Compact</h3>
+    <rh-menu-dropdown variant="borderless" layout="compact" accessible-label="Toggle menu">
+      <rh-menu-item>Action one</rh-menu-item>
+      <rh-menu-item>Action two</rh-menu-item>
+      <rh-menu-item>Action three</rh-menu-item>
+      <rh-menu-item disabled>Disabled Action</rh-menu-item>
+      <hr/>
+      <rh-menu-item>Separated action</rh-menu-item>
+    </rh-menu-dropdown>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-menu-dropdown/rh-menu-dropdown.js';
+</script>

--- a/elements/rh-menu-dropdown/demo/felt-theme.html
+++ b/elements/rh-menu-dropdown/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Basic, descriptive, and compact menu dropdowns with the Project Felt preview theme applied.
+description: Basic, descriptive, and compact menu dropdowns with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-navigation-vertical/demo/felt-theme.html
+++ b/elements/rh-navigation-vertical/demo/felt-theme.html
@@ -1,0 +1,32 @@
+---
+description: Vertical navigation with nested groups and the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+    max-width: 300px;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <div class="example-row">
+    <rh-navigation-vertical accessible-label="Example side nav">
+      <rh-navigation-link href="#">Nav item 1</rh-navigation-link>
+      <rh-navigation-link href="#" current-page>Nav item 2</rh-navigation-link>
+      <rh-navigation-vertical-list summary="Nav group">
+        <rh-navigation-link href="#">Sub item 1</rh-navigation-link>
+        <rh-navigation-link href="#">Sub item 2</rh-navigation-link>
+      </rh-navigation-vertical-list>
+      <rh-navigation-link href="#">Nav item 3</rh-navigation-link>
+    </rh-navigation-vertical>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-navigation-vertical/rh-navigation-vertical.js';
+</script>

--- a/elements/rh-navigation-vertical/demo/felt-theme.html
+++ b/elements/rh-navigation-vertical/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Vertical navigation with nested groups and the Project Felt preview theme applied.
+description: Vertical navigation with nested groups and the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-progress-stepper/demo/felt-theme.html
+++ b/elements/rh-progress-stepper/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Progress stepper states with the Project Felt preview theme applied.
+description: Progress stepper states with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-progress-stepper/demo/felt-theme.html
+++ b/elements/rh-progress-stepper/demo/felt-theme.html
@@ -1,0 +1,34 @@
+---
+description: Progress stepper states with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <rh-progress-stepper>
+    <rh-progress-step state="complete" description="This step has been completed successfully">
+      Complete Step
+    </rh-progress-step>
+    <rh-progress-step state="warn" description="This step has a warning that needs attention">
+      Warning Step
+    </rh-progress-step>
+    <rh-progress-step state="fail" description="This step has failed and needs to be retried">
+      Failed Step
+    </rh-progress-step>
+    <rh-progress-step state="active" description="Currently working on this step">
+      Active Step
+    </rh-progress-step>
+    <rh-progress-step description="This step is not yet started">
+      Inactive Step
+    </rh-progress-step>
+  </rh-progress-stepper>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-progress-stepper/rh-progress-stepper.js';
+</script>

--- a/elements/rh-spinner/demo/felt-theme.html
+++ b/elements/rh-spinner/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Spinner with Project Felt theme applied.
+description: Spinner with [Project Felt](/theming/themes/project-felt/) theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-spinner/demo/felt-theme.html
+++ b/elements/rh-spinner/demo/felt-theme.html
@@ -10,6 +10,9 @@ description: Spinner with Project Felt theme applied.
     gap: var(--rh-space-2xl, 32px);
     align-items: center;
   }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
 </style>
 
 <div class="felt-preview">

--- a/elements/rh-subnav/demo/felt-theme.html
+++ b/elements/rh-subnav/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Horizontal subnav with the Project Felt preview theme applied.
+description: Horizontal subnav with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-subnav/demo/felt-theme.html
+++ b/elements/rh-subnav/demo/felt-theme.html
@@ -1,0 +1,23 @@
+---
+description: Horizontal subnav with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <rh-subnav accessible-label="Example subnav">
+    <rh-navigation-link href="#">Nav item 1</rh-navigation-link>
+    <rh-navigation-link href="#" current-page>Nav item 2</rh-navigation-link>
+    <rh-navigation-link href="#">Nav item 3</rh-navigation-link>
+    <rh-navigation-link href="#">Nav item 4</rh-navigation-link>
+  </rh-subnav>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-subnav/rh-subnav.js';
+</script>

--- a/elements/rh-switch/demo/felt-theme.html
+++ b/elements/rh-switch/demo/felt-theme.html
@@ -1,0 +1,44 @@
+---
+description: Switch states and labels with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .example-flex {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-2xl, 32px);
+    align-items: center;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Default</h3>
+  <div class="example-row example-flex">
+    <rh-switch message-on="On" message-off="Off"></rh-switch>
+    <rh-switch checked message-on="On" message-off="Off"></rh-switch>
+  </div>
+
+  <h3>With labels</h3>
+  <div class="example-row example-flex">
+    <rh-switch message-on="Enabled" message-off="Disabled"></rh-switch>
+    <rh-switch checked message-on="Enabled" message-off="Disabled"></rh-switch>
+  </div>
+
+  <h3>Disabled</h3>
+  <div class="example-row example-flex">
+    <rh-switch disabled message-on="On" message-off="Off"></rh-switch>
+    <rh-switch disabled checked message-on="On" message-off="Off"></rh-switch>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-switch/rh-switch.js';
+</script>

--- a/elements/rh-switch/demo/felt-theme.html
+++ b/elements/rh-switch/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Switch states and labels with the Project Felt preview theme applied.
+description: Switch states and labels with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-tabs/demo/felt-theme.html
+++ b/elements/rh-tabs/demo/felt-theme.html
@@ -1,0 +1,133 @@
+---
+description: Horizontal, box inset, overflow, vertical, and vertical box tabs with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h2>Horizontal</h2>
+  <rh-tabs>
+    <rh-tab id="users"
+            slot="tab"
+            active>Users <rh-icon slot="icon"
+               icon="users"
+               set="ui"></rh-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers <rh-icon slot="icon"
+               icon="container"></rh-icon></rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database <rh-icon slot="icon"
+               icon="datacenter"></rh-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers <rh-icon slot="icon"
+               icon="server"></rh-icon></rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab" disabled>Cloud <rh-icon slot="icon"
+               icon="cloud"></rh-icon></rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
+
+  <h2>Box Inset</h2>
+  <rh-tabs box="inset">
+    <rh-tab slot="tab" active>Users <rh-icon slot="icon"
+               icon="users"
+               set="ui"></rh-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers <rh-icon slot="icon"
+               icon="container"></rh-icon></rh-tab>
+    <rh-tab-panel>Containers</rh-tab-panel>
+    <rh-tab slot="tab">Database <rh-icon slot="icon"
+               icon="datacenter"></rh-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers <rh-icon slot="icon"
+               icon="server"></rh-icon></rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab" disabled>Cloud <rh-icon slot="icon"
+               icon="cloud"></rh-icon></rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
+
+  <h2>Overflow</h2>
+  <rh-tabs>
+    <rh-tab slot="tab" active>Users <rh-icon slot="icon"
+               icon="users"
+               set="ui"></rh-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers <rh-icon slot="icon"
+               icon="container"></rh-icon></rh-tab>
+    <rh-tab-panel>Containers</rh-tab-panel>
+    <rh-tab slot="tab">Database <rh-icon slot="icon"
+               icon="datacenter"></rh-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers <rh-icon slot="icon"
+               icon="server"></rh-icon></rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab">Cloud</rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+    <rh-tab slot="tab">Network</rh-tab>
+    <rh-tab-panel>Network</rh-tab-panel>
+    <rh-tab slot="tab">Storage</rh-tab>
+    <rh-tab-panel>Storage</rh-tab-panel>
+    <rh-tab slot="tab">Security</rh-tab>
+    <rh-tab-panel>Security</rh-tab-panel>
+    <rh-tab slot="tab">Monitoring</rh-tab>
+    <rh-tab-panel>Monitoring</rh-tab-panel>
+    <rh-tab slot="tab">Logging</rh-tab>
+    <rh-tab-panel>Logging</rh-tab-panel>
+    <rh-tab slot="tab" disabled>Alerts <rh-icon slot="icon"
+               icon="bell"
+               set="ui"></rh-icon></rh-tab>
+    <rh-tab-panel>Alerts</rh-tab-panel>
+    <rh-tab slot="tab">Settings</rh-tab>
+    <rh-tab-panel>Settings</rh-tab-panel>
+  </rh-tabs>
+
+  <h2>Vertical</h2>
+  <rh-tabs vertical>
+    <rh-tab slot="tab" active>Users <rh-icon slot="icon"
+               icon="users"
+               set="ui"></rh-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers <rh-icon slot="icon"
+               icon="container"></rh-icon></rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database <rh-icon slot="icon"
+               icon="datacenter"></rh-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers <rh-icon slot="icon"
+               icon="server"></rh-icon></rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab" disabled>Cloud <rh-icon slot="icon"
+               icon="cloud"></rh-icon></rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
+
+  <h2>Vertical Box</h2>
+  <rh-tabs vertical box="box">
+    <rh-tab slot="tab" active>Users <rh-icon slot="icon"
+               icon="users"
+               set="ui"></rh-icon></rh-tab>
+    <rh-tab-panel>Users</rh-tab-panel>
+    <rh-tab slot="tab">Containers <rh-icon slot="icon"
+               icon="container"></rh-icon></rh-tab>
+    <rh-tab-panel>Containers <a href="#">Focusable element</a></rh-tab-panel>
+    <rh-tab slot="tab">Database <rh-icon slot="icon"
+               icon="datacenter"></rh-icon></rh-tab>
+    <rh-tab-panel>Database</rh-tab-panel>
+    <rh-tab slot="tab">Servers <rh-icon slot="icon"
+               icon="server"></rh-icon></rh-tab>
+    <rh-tab-panel>Servers</rh-tab-panel>
+    <rh-tab slot="tab" disabled>Cloud <rh-icon slot="icon"
+               icon="cloud"></rh-icon></rh-tab>
+    <rh-tab-panel>Cloud</rh-tab-panel>
+  </rh-tabs>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-tabs/rh-tabs.js';
+</script>

--- a/elements/rh-tabs/demo/felt-theme.html
+++ b/elements/rh-tabs/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Horizontal, box inset, overflow, vertical, and vertical box tabs with the Project Felt preview theme applied.
+description: Horizontal, box inset, overflow, vertical, and vertical box tabs with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-tag/demo/felt-theme.html
+++ b/elements/rh-tag/demo/felt-theme.html
@@ -1,5 +1,5 @@
 ---
-description: Filled, outlined, disabled, and linked tag variants in all colors with the Project Felt preview theme applied.
+description: Filled, outlined, disabled, and linked tag variants in all colors with the [Project Felt](/theming/themes/project-felt/) preview theme applied.
 ---
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 

--- a/elements/rh-tag/demo/felt-theme.html
+++ b/elements/rh-tag/demo/felt-theme.html
@@ -1,0 +1,154 @@
+---
+description: Filled, outlined, disabled, and linked tag variants in all colors with the Project Felt preview theme applied.
+---
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .example-flex {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-lg, 16px);
+    align-items: center;
+  }
+  .felt-preview {
+    padding: var(--rh-space-2xl, 32px);
+  }
+</style>
+
+<div class="felt-preview">
+  <h3>Filled</h3>
+  <div class="example-row example-flex">
+    <rh-tag>Gray</rh-tag>
+    <rh-tag icon="information-fill">Gray</rh-tag>
+    <rh-tag size="compact">Gray</rh-tag>
+    <rh-tag size="compact" icon="information-fill">Gray</rh-tag>
+    <rh-tag color="red">Red</rh-tag>
+    <rh-tag color="red" icon="information-fill">Red</rh-tag>
+    <rh-tag color="red" size="compact">Red</rh-tag>
+    <rh-tag color="red" size="compact" icon="information-fill">Red</rh-tag>
+    <rh-tag color="red-orange">Red Orange</rh-tag>
+    <rh-tag color="red-orange" icon="information-fill">Red Orange</rh-tag>
+    <rh-tag color="red-orange" size="compact">Red Orange</rh-tag>
+    <rh-tag color="red-orange" size="compact" icon="information-fill">Red Orange</rh-tag>
+    <rh-tag color="orange">Orange</rh-tag>
+    <rh-tag color="orange" icon="information-fill">Orange</rh-tag>
+    <rh-tag color="orange" size="compact">Orange</rh-tag>
+    <rh-tag color="orange" size="compact" icon="information-fill">Orange</rh-tag>
+    <rh-tag color="yellow">Yellow</rh-tag>
+    <rh-tag color="yellow" icon="information-fill">Yellow</rh-tag>
+    <rh-tag color="yellow" size="compact">Yellow</rh-tag>
+    <rh-tag color="yellow" size="compact" icon="information-fill">Yellow</rh-tag>
+    <rh-tag color="green">Green</rh-tag>
+    <rh-tag color="green" icon="information-fill">Green</rh-tag>
+    <rh-tag color="green" size="compact">Green</rh-tag>
+    <rh-tag color="green" size="compact" icon="information-fill">Green</rh-tag>
+    <rh-tag color="teal">Teal</rh-tag>
+    <rh-tag color="teal" icon="information-fill">Teal</rh-tag>
+    <rh-tag color="teal" size="compact">Teal</rh-tag>
+    <rh-tag color="teal" size="compact" icon="information-fill">Teal</rh-tag>
+    <rh-tag color="blue">Blue</rh-tag>
+    <rh-tag color="blue" icon="information-fill">Blue</rh-tag>
+    <rh-tag color="blue" size="compact">Blue</rh-tag>
+    <rh-tag color="blue" size="compact" icon="information-fill">Blue</rh-tag>
+    <rh-tag color="purple">Purple</rh-tag>
+    <rh-tag color="purple" icon="information-fill">Purple</rh-tag>
+    <rh-tag color="purple" size="compact">Purple</rh-tag>
+    <rh-tag color="purple" size="compact" icon="information-fill">Purple</rh-tag>
+  </div>
+
+  <h3>Outlined</h3>
+  <div class="example-row example-flex">
+    <rh-tag variant="outline">Gray</rh-tag>
+    <rh-tag variant="outline" icon="information-fill">Gray</rh-tag>
+    <rh-tag variant="outline" size="compact">Gray</rh-tag>
+    <rh-tag variant="outline" size="compact" icon="information-fill">Gray</rh-tag>
+    <rh-tag variant="outline" color="red">Red</rh-tag>
+    <rh-tag variant="outline" color="red" icon="information-fill">Red</rh-tag>
+    <rh-tag variant="outline" color="red" size="compact">Red</rh-tag>
+    <rh-tag variant="outline" color="red" size="compact" icon="information-fill">Red</rh-tag>
+    <rh-tag variant="outline" color="red-orange">Red Orange</rh-tag>
+    <rh-tag variant="outline" color="red-orange" icon="information-fill">Red Orange</rh-tag>
+    <rh-tag variant="outline" color="red-orange" size="compact">Red Orange</rh-tag>
+    <rh-tag variant="outline" color="red-orange" size="compact" icon="information-fill">Red Orange</rh-tag>
+    <rh-tag variant="outline" color="orange">Orange</rh-tag>
+    <rh-tag variant="outline" color="orange" icon="information-fill">Orange</rh-tag>
+    <rh-tag variant="outline" color="orange" size="compact">Orange</rh-tag>
+    <rh-tag variant="outline" color="orange" size="compact" icon="information-fill">Orange</rh-tag>
+    <rh-tag variant="outline" color="yellow">Yellow</rh-tag>
+    <rh-tag variant="outline" color="yellow" icon="information-fill">Yellow</rh-tag>
+    <rh-tag variant="outline" color="yellow" size="compact">Yellow</rh-tag>
+    <rh-tag variant="outline" color="yellow" size="compact" icon="information-fill">Yellow</rh-tag>
+    <rh-tag variant="outline" color="green">Green</rh-tag>
+    <rh-tag variant="outline" color="green" icon="information-fill">Green</rh-tag>
+    <rh-tag variant="outline" color="green" size="compact">Green</rh-tag>
+    <rh-tag variant="outline" color="green" size="compact" icon="information-fill">Green</rh-tag>
+    <rh-tag variant="outline" color="teal">Teal</rh-tag>
+    <rh-tag variant="outline" color="teal" icon="information-fill">Teal</rh-tag>
+    <rh-tag variant="outline" color="teal" size="compact">Teal</rh-tag>
+    <rh-tag variant="outline" color="teal" size="compact" icon="information-fill">Teal</rh-tag>
+    <rh-tag variant="outline" color="blue">Blue</rh-tag>
+    <rh-tag variant="outline" color="blue" icon="information-fill">Blue</rh-tag>
+    <rh-tag variant="outline" color="blue" size="compact">Blue</rh-tag>
+    <rh-tag variant="outline" color="blue" size="compact" icon="information-fill">Blue</rh-tag>
+    <rh-tag variant="outline" color="purple">Purple</rh-tag>
+    <rh-tag variant="outline" color="purple" icon="information-fill">Purple</rh-tag>
+    <rh-tag variant="outline" color="purple" size="compact">Purple</rh-tag>
+    <rh-tag variant="outline" color="purple" size="compact" icon="information-fill">Purple</rh-tag>
+  </div>
+
+  <h3>Disabled</h3>
+  <div class="example-row example-flex">
+    <rh-tag disabled href="#">Gray</rh-tag>
+    <rh-tag disabled color="red" href="#">Red</rh-tag>
+    <rh-tag disabled variant="outline" color="red" href="#">Red outline</rh-tag>
+    <rh-tag disabled variant="outline" color="blue" href="#">Blue outline</rh-tag>
+  </div>
+
+  <h3>Linked Filled</h3>
+  <div class="example-row example-flex">
+    <rh-tag href="#">Gray</rh-tag>
+    <rh-tag href="#" icon="information-fill">Gray</rh-tag>
+    <rh-tag href="#" size="compact">Gray</rh-tag>
+    <rh-tag href="#" size="compact" icon="information-fill">Gray</rh-tag>
+    <rh-tag href="#" color="red">Red</rh-tag>
+    <rh-tag href="#" color="red" icon="information-fill">Red</rh-tag>
+    <rh-tag href="#" color="red" size="compact">Red</rh-tag>
+    <rh-tag href="#" color="red" size="compact" icon="information-fill">Red</rh-tag>
+    <rh-tag href="#" color="blue">Blue</rh-tag>
+    <rh-tag href="#" color="blue" icon="information-fill">Blue</rh-tag>
+    <rh-tag href="#" color="blue" size="compact">Blue</rh-tag>
+    <rh-tag href="#" color="blue" size="compact" icon="information-fill">Blue</rh-tag>
+    <rh-tag href="#" color="purple">Purple</rh-tag>
+    <rh-tag href="#" color="purple" icon="information-fill">Purple</rh-tag>
+    <rh-tag href="#" color="purple" size="compact">Purple</rh-tag>
+    <rh-tag href="#" color="purple" size="compact" icon="information-fill">Purple</rh-tag>
+  </div>
+
+  <h3>Linked Outlined</h3>
+  <div class="example-row example-flex">
+    <rh-tag href="#" variant="outline">Gray</rh-tag>
+    <rh-tag href="#" variant="outline" icon="information-fill">Gray</rh-tag>
+    <rh-tag href="#" variant="outline" size="compact">Gray</rh-tag>
+    <rh-tag href="#" variant="outline" size="compact" icon="information-fill">Gray</rh-tag>
+    <rh-tag href="#" variant="outline" color="red">Red</rh-tag>
+    <rh-tag href="#" variant="outline" color="red" icon="information-fill">Red</rh-tag>
+    <rh-tag href="#" variant="outline" color="red" size="compact">Red</rh-tag>
+    <rh-tag href="#" variant="outline" color="red" size="compact" icon="information-fill">Red</rh-tag>
+    <rh-tag href="#" variant="outline" color="blue">Blue</rh-tag>
+    <rh-tag href="#" variant="outline" color="blue" icon="information-fill">Blue</rh-tag>
+    <rh-tag href="#" variant="outline" color="blue" size="compact">Blue</rh-tag>
+    <rh-tag href="#" variant="outline" color="blue" size="compact" icon="information-fill">Blue</rh-tag>
+    <rh-tag href="#" variant="outline" color="purple">Purple</rh-tag>
+    <rh-tag href="#" variant="outline" color="purple" icon="information-fill">Purple</rh-tag>
+    <rh-tag href="#" variant="outline" color="purple" size="compact">Purple</rh-tag>
+    <rh-tag href="#" variant="outline" color="purple" size="compact" icon="information-fill">Purple</rh-tag>
+  </div>
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-tag/rh-tag.js';
+</script>


### PR DESCRIPTION
## What I did

1. Duplicated all Project Felt preview theme demos into their respective element doc demos
2. Named each "Felt theme"
3. Added descriptions which include any "aspirational" Felt-specific CSS classes and attributes.

## Testing Instructions

1. Verify consistency of each
2. Vibe check docs/descriptions