### PR TITLE
fix(navigation-primary): accessibility improvement ensure hidden 

### DIFF
--- a/.changeset/nine-turtles-switch.md
+++ b/.changeset/nine-turtles-switch.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-primary>`: improved accessibility by ensuring event slot remains hidden when nothing is slotted
+  

--- a/elements/rh-navigation-primary/rh-navigation-primary.css
+++ b/elements/rh-navigation-primary/rh-navigation-primary.css
@@ -32,7 +32,7 @@
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .visually-hidden {


### PR DESCRIPTION
## What I did

1. Added `!important` to the `.hidden` class so it doesn't accidentally get overridden in container query breakpoints.

## Testing Instructions

1. View DP navigation-primary/demo/no-secondary-items demo, ensure #events remains `display: none` so it isn't reported as a role="list" in the AT

## Notes to Reviewers
