### PR TITLE
docs: use theme tokens for focus indicators and link focus

### DIFF
--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -56,11 +56,11 @@ In CSS terms, here is some minimal code that meets these requirements:
 
 ```css rh-code-block
 :is(*, :hover):focus-visible {
-  outline-color: light-dark(--rh-color-blue-50, --rh-color-blue-30);
-  outline-offset: 3px;
+  outline-color: var(--rh-color-border-interactive, #0066cc);
+  outline-offset: var(--rh-border-width-lg, 3px);
   outline-style: solid;
-  outline-width: 3px;
-  transition: none; 
+  outline-width: var(--rh-border-width-lg, 3px);
+  transition: none;
 }
 ```
 
@@ -68,7 +68,7 @@ In CSS terms, here is some minimal code that meets these requirements:
 
 Adjust the offset as needed. If an offset risks overflowing the focus ring outside the boundary of a page or the visible edge of a region, that offset can be removed or even made inset (see the example CSS below).
 
-We have designated focus ring colors that align with our brand standards for both light and dark schemes.
+We have designated focus ring colors that align with our brand standards for both light and dark schemes. Prefer the theming token <code>--rh-color-border-interactive</code>, which resolves to the correct on-light or on-dark value via <code>light-dark()</code>. Use the on-light and on-dark tokens when you need to override based on the background behind the focus ring.
 
 <rh-table>
   <table>
@@ -87,8 +87,8 @@ We have designated focus ring colors that align with our brand standards for bot
     <tbody>
       <tr>
         <td>Focus ring color</td>
-        <td><code>--rh-color-blue-50</code></td>
-        <td><code>--rh-color-blue-30</code></td>
+        <td><code>--rh-color-border-interactive-on-light</code></td>
+        <td><code>--rh-color-border-interactive-on-dark</code></td>
       </tr>
     </tbody>
   </table>
@@ -97,7 +97,7 @@ We have designated focus ring colors that align with our brand standards for bot
 
 #### Styling considerations
 
-Note that there may be cases where a focus ring appears against a light background in dark mode and vice versa. For example, an inset focus ring for a text field may appear against a white background, even in dark mode. In these cases, you may need to manually override the default dark scheme ring color (<code>--rh-color-blue-30</code>) with the light scheme color (<code>--rh-color-blue-50</code>).
+Note that there may be cases where a focus ring appears against a light background in dark mode and vice versa. For example, an inset focus ring for a text field may appear against a white background, even in dark mode. In these cases, you may need to manually override the default dark scheme ring color (<code>--rh-color-border-interactive-on-dark</code>) with the light scheme color (<code>--rh-color-border-interactive-on-light</code>).
 
 <img src="./focus-styling-considerations-demo.svg" alt="Demo of how inset ring colors should be set based on their background color and not the page theme" style="max-width: 100%;">
 
@@ -105,11 +105,14 @@ Note that there may be cases where a focus ring appears against a light backgrou
 ## Example CSS
 ```css rh-code-block
 :is(*, :hover):focus-visible {
-  outline-color: light-dark(--rh-color-blue-50, --rh-color-blue-30);
-  outline-offset: 3px;
+  outline-color: light-dark(
+    var(--rh-color-border-interactive-on-light, #0066cc),
+    var(--rh-color-border-interactive-on-dark, #92c5f9)
+  );
+  outline-offset: var(--rh-border-width-lg, 3px);
   outline-style: solid;
-  outline-width: 3px;
-  transition: none; 
+  outline-width: var(--rh-border-width-lg, 3px);
+  transition: none;
 }
 
 /* Placeholder `.inset` class for inset focus. */
@@ -124,12 +127,12 @@ Note that there may be cases where a focus ring appears against a light backgrou
 
 /* Placeholder `.light-bg` class for focus against light backgrounds. */
 .light-bg:is(*, :hover):focus-visible {
-  outline-color: --rh-color-blue-50;
+  outline-color: var(--rh-color-border-interactive-on-light, #0066cc);
 }
 
 /* Placeholder `.dark-bg` class for focus against dark backgrounds. */
 .dark-bg:is(*, :hover):focus-visible {
-  outline-color: --rh-color-blue-30;
+  outline-color: var(--rh-color-border-interactive-on-dark, #92c5f9);
 }
 
 :focus:not(:focus-visible) {
@@ -139,7 +142,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 
 ### Technical notes on the CSS
 
-- We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
+- We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-border-interactive-on-light</code> (<code>#0066cc</code>) is **WCAG conformant** against both our dark and light backgrounds.
 - The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
@@ -147,7 +150,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 - Note that we prefer <code>:focus-visible</code> to <code>:focus</code>. **Avoid using the latter**. In fact, our code above disables the latter.
 
 
-## Best Practices
+## Best practices
 
 
 ### Custom focus indicator styles

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -23,7 +23,6 @@ subnav:
   import '@rhds/elements/rh-alert/rh-alert.js';
   import '@rhds/elements/rh-code-block/rh-code-block.js';
   import '@rhds/elements/lib/elements/rh-context-picker/rh-context-picker.js';
-  import '@rhds/elements/rh-cta/rh-cta.js';
   import '@rhds/elements/rh-table/rh-table.js';
   import "@uxdot/elements/uxdot-pattern.js";
 </script>
@@ -373,7 +372,7 @@ When the Tab key is pressed repeatedly, focus moves through links in order, from
   </uxdot-best-practice>
 </div>
 
-<rh-cta href="/accessibility/content/#link-text">Writing accessible link text</rh-cta>
+For more guidance, see [Writing accessible link text][accessiblelinktext].
 
 ### Long links
 
@@ -426,5 +425,6 @@ When the Tab key is pressed repeatedly, focus moves through links in order, from
 [linkwithicon]: /patterns/link-with-icon/
 [ctas]: /elements/call-to-action/
 [focusindicators]: /foundations/interactions/focus-indicators/
+[accessiblelinktext]: /accessibility/content/#link-text
 [interactivevisitedtokens]: /tokens/color/#color-interactive-primary-visited
 [redhat]: https://www.redhat.com

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -156,6 +156,54 @@ When these links receive a mouse cursor hover, link colors and underline styles 
   </table>
 </rh-table>
 
+### Focus
+
+When a link receives keyboard focus, it should show both:
+
+1. The standard [focus indicator][focusindicators] (outline)
+2. The same text and underline styles as [hover](#hover)
+
+Use the focus interactive tokens for the text and underline. Those values match hover, so focused and hovered links look the same aside from the focus ring.
+
+<rh-table>
+  <table>
+    <colgroup>
+      <col>
+      <col>
+      <col>
+    </colgroup>
+    <thead>
+      <tr>
+        <th scope="col">Property</th>
+        <th scope="col">Light scheme</th>
+        <th scope="col">Dark scheme</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Focus ring color</td>
+        <td><code>--rh-color-border-interactive</code></td>
+        <td><code>--rh-color-border-interactive</code></td>
+      </tr>
+      <tr>
+        <td>Color - text</td>
+        <td><code>--rh-color-interactive-primary-focus</code></td>
+        <td><code>--rh-color-interactive-primary-focus</code></td>
+      </tr>
+      <tr>
+        <td>Underline - color</td>
+        <td><code>--rh-color-interactive-primary-focus</code></td>
+        <td><code>--rh-color-interactive-primary-focus</code></td>
+      </tr>
+      <tr>
+        <td>Underline - offset</td>
+        <td>6px</td>
+        <td>6px</td>
+      </tr>
+    </tbody>
+  </table>
+</rh-table>
+
 ### Visited state
 
 Visited links will change colors to one of our [interactive visited tokens][interactivevisitedtokens].
@@ -283,7 +331,7 @@ A user should have the ability to navigate to and interact with links using thei
 
 ### Tab order
 
-When the Tab key is pressed repeatedly, the focus highlights links in order, from left to right and top to bottom.
+When the Tab key is pressed repeatedly, focus moves through links in order, from left to right and top to bottom. Each focused link shows the [focus indicator][focusindicators] and [hover styles](#hover).
 
 <uxdot-example color-palette="lightest" width-adjustment="606px" slot="image">
   <img src="./a11y-tab-order-A.svg"
@@ -377,5 +425,6 @@ When the Tab key is pressed repeatedly, the focus highlights links in order, fro
 
 [linkwithicon]: /patterns/link-with-icon/
 [ctas]: /elements/call-to-action/
+[focusindicators]: /foundations/interactions/focus-indicators/
 [interactivevisitedtokens]: /tokens/color/#color-interactive-primary-visited
 [redhat]: https://www.redhat.com

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -246,7 +246,7 @@ Developers can use the following CSS as a starting point for link underlining:
       transition-timing-function: ease;
       transition-property: text-underline-offset, color, text-decoration-color;
       transition-duration: 0.3s;
-      &:hover {
+      &:is(:hover, :focus-within) {
         text-decoration-color: inherit;
         text-underline-offset: max(6px, 0.33em);
       }

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -27,24 +27,6 @@ subnav:
   import "@uxdot/elements/uxdot-pattern.js";
 </script>
 
-<style>
-.underline-exception {
-    display: block;
-    margin-block: var(--rh-space-2xl);
-    & span {
-        font-family: var(--rh-font-family-heading);
-        font-size: var(--rh-font-size-heading-xs);
-        font-weight: var(--rh-font-weight-heading-medium);
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        gap: var(--rh-space-md);
-        color: var(--rh-color-status-danger);
-        margin-block: var(--rh-space-2xl) var(--rh-space-lg);
-    }
-}
-</style>
-
 ## Types of links
 
 Links are interactive elements that connect users to another page or page section. Outside of navigation elements, most links will appear as one of the following types:
@@ -214,45 +196,35 @@ The following elements are exempt from underlining requirements and should not h
 ### Exceptions
 
 <div class="grid sm-two-columns">
-
-  <figure class="underline-exception">
+  <uxdot-best-practice variant="dont">
     <uxdot-example color-palette="lighter" width-adjustment="482px" slot="image">
       <img src="./underlining-exceptions-1.svg"
             alt="Recommendations menu with list of links that aren't underlined"
             width="482"
             height="342">
     </uxdot-example>
-    <figcaption>
-        <span><rh-icon set="ui" size="md" icon="close-circle-fill" defer-hydration=""></rh-icon>Don't underline</span>
-        <p>Do not underline links within visually distinct navigation groupings like menus and breadcrumbs.</p>
-    </figcaption>
-  </figure>
+    <p>Do not underline links within visually distinct navigation groupings like menus and breadcrumbs.</p>
+  </uxdot-best-practice>
 
-  <figure class="underline-exception">
+  <uxdot-best-practice variant="dont">
     <uxdot-example color-palette="lightest" width-adjustment="482px" slot="image">
       <img src="./underlining-exceptions-2.svg"
             alt="Heading, body copy, and call to action with an arrow but without an underline"
             width="482"
             height="342">
     </uxdot-example>
-    <figcaption>
-        <span><rh-icon set="ui" size="md" icon="close-circle-fill" defer-hydration=""></rh-icon>Don't underline</span>
-      <p>Do not underline links accompanied by visual cues (e.g., call to action arrows) that indicate their interactivity.</p>
-    </figcaption>
-  </figure>
+    <p>Do not underline links accompanied by visual cues (e.g., call to action arrows) that indicate their interactivity.</p>
+  </uxdot-best-practice>
 
-  <figure class="underline-exception">
+  <uxdot-best-practice variant="dont">
     <uxdot-example color-palette="lightest" width-adjustment="482px" slot="image">
       <img src="./underlining-exceptions-3.svg"
             alt="List of links "
             width="482"
             height="268">
     </uxdot-example>
-    <figcaption>
-        <span><rh-icon set="ui" size="md" icon="close-circle-fill" defer-hydration=""></rh-icon>Don't underline</span>
-      <p>Do not underline links that will not appear alongside non-link text like a list of links within a card.</p>
-    </figcpation>
-  </figure>
+    <p>Do not underline links that will not appear alongside non-link text like a list of links within a card.</p>
+  </uxdot-best-practice>
 </div>
 
 ### Example CSS
@@ -372,8 +344,6 @@ When the Tab key is pressed repeatedly, focus moves through links in order, from
   </uxdot-best-practice>
 </div>
 
-For more guidance, see [Writing accessible link text][accessiblelinktext].
-
 ### Long links
 
 <div class="grid sm-two-columns">
@@ -425,6 +395,5 @@ For more guidance, see [Writing accessible link text][accessiblelinktext].
 [linkwithicon]: /patterns/link-with-icon/
 [ctas]: /elements/call-to-action/
 [focusindicators]: /foundations/interactions/focus-indicators/
-[accessiblelinktext]: /accessibility/content/#link-text
 [interactivevisitedtokens]: /tokens/color/#color-interactive-primary-visited
 [redhat]: https://www.redhat.com

--- a/docs/foundations/interactions/links/inline-link-demo.html
+++ b/docs/foundations/interactions/links/inline-link-demo.html
@@ -9,7 +9,7 @@
         text-decoration-thickness: 1px;
         text-underline-offset: max(5px, 0.28em);
         transition: ease all 0.3s;
-        &:hover {
+        &:is(:hover, :focus-within) {
           text-decoration-color: inherit;
           text-underline-offset: max(6px, 0.33em);
         }

--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -115,8 +115,8 @@
     border-radius: var(--rh-border-radius-default);
     outline-color:
       light-dark(
-          --rh-color-border-interactive-on-light,
-          --rh-color-border-interactive-on-dark);
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          var(--rh-color-border-interactive-on-dark, #92c5f9));
     outline-offset: var(--rh-border-width-lg, 3px);
     outline-style: solid;
     outline-width: var(--rh-border-width-lg, 3px);

--- a/uxdot/uxdot-feedback.css
+++ b/uxdot/uxdot-feedback.css
@@ -17,8 +17,8 @@
     border-radius: var(--rh-border-radius-default);
     outline-color:
       light-dark(
-          --rh-color-border-interactive-on-light,
-          --rh-color-border-interactive-on-dark);
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          var(--rh-color-border-interactive-on-dark, #92c5f9));
     outline-offset: var(--rh-border-width-lg, 3px);
     outline-style: solid;
     outline-width: var(--rh-border-width-lg, 3px);

--- a/uxdot/uxdot-masthead.css
+++ b/uxdot/uxdot-masthead.css
@@ -33,8 +33,8 @@
     border-radius: var(--rh-border-radius-default);
     outline-color:
       light-dark(
-          --rh-color-border-interactive-on-light,
-          --rh-color-border-interactive-on-dark);
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          var(--rh-color-border-interactive-on-dark, #92c5f9));
     outline-offset: var(--rh-border-width-lg, 3px);
     outline-style: solid;
     outline-width: var(--rh-border-width-lg, 3px);


### PR DESCRIPTION
## Summary
- Replace crayon color tokens with `--rh-color-border-interactive` (and on-light/on-dark) in the focus indicators docs, and fix invalid `light-dark()` / `var()` CSS examples
- Document that focused links show both the focus ring and hover text/underline styles
- Fix the same invalid `light-dark()` pattern in site focus CSS (`styles.css`, masthead, feedback)

Closes #2975

## Test plan
- [x] Review [Focus indicators](https://ux.redhat.com/foundations/interactions/focus-indicators/) preview: tokens, CSS snippets, and “Best practices” heading
- [x] Review [Links](https://ux.redhat.com/foundations/interactions/links/) preview: new Focus section and tab-order note
- [x] Tab through the inline link demo and confirm underline hover styles apply on focus
- [x] Spot-check keyboard focus rings on the docs site (masthead, feedback, page content) in light and dark schemes


Made with [Cursor](https://cursor.com)