### PR TITLE
fix: patch @rhds/tokens, no-unknown, light-dark() support

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -83,9 +83,14 @@ rules:
 
   rhds/deprecated: true
 
-  rhds/no-unknown-token-name: true
+  rhds/no-unknown-token-name:
+    - true
+    - cem: ./custom-elements.json
 
   rhds/require-token-fallback: true
+
+  rhds/token-values: true
+
 overrides:
   - files:
       - docs/**/*.scss

--- a/patches/@rhds+tokens+3.1.0.patch
+++ b/patches/@rhds+tokens+3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js b/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js
-index 5c51f5f..86fc42b 100644
+index 5c51f5f..0a61471 100644
 --- a/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js
 +++ b/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js
 @@ -1,4 +1,5 @@
@@ -9,7 +9,35 @@ index 5c51f5f..86fc42b 100644
  import { tokens } from '@rhds/tokens';
  import stylelint from 'stylelint';
  import parser from 'postcss-value-parser';
-@@ -13,15 +14,34 @@ const meta = {
+@@ -10,18 +11,48 @@ const meta = {
+     url: 'https://github.com/RedHat-UX/red-hat-design-tokens/tree/main/plugins/stylelint/rules/no-unknown-token-name.ts',
+     fixable: true,
+ };
++const cemCache = new Map();
++function getCemAllowed(cemPath) {
++    if (cemCache.has(cemPath)) {
++        return cemCache.get(cemPath);
++    }
++    const allowed = new Set();
++    try {
++        const cem = JSON.parse(readFileSync(cemPath, 'utf8'));
++        for (const mod of cem?.modules ?? []) {
++            for (const decl of mod.declarations ?? []) {
++                if (decl.customElement) {
++                    for (const cssProp of decl.cssProperties ?? []) {
++                        if (cssProp.name.startsWith('--rh')) {
++                            allowed.add(cssProp.name);
++                        }
++                    }
++                }
++            }
++        }
++    } catch {
++        // CEM file not found at provided path
++    }
++    cemCache.set(cemPath, allowed);
++    return allowed;
++}
  const ruleFunction = (_, opts) => {
      return (root, result) => {
          // here we assume a file structure of */rh-tagname/rh-tagname.css
@@ -26,29 +54,15 @@ index 5c51f5f..86fc42b 100644
          const migrations = new Map(Object.entries(opts?.migrations ?? {}));
          const allowed = new Set(opts?.allowed ?? []);
 +        if (opts?.cem) {
-+          try {
-+            const cemPath = join(process.cwd(), opts.cem);
-+            const cem = JSON.parse(readFileSync(cemPath, 'utf8'));
-+            for (const mod of cem?.modules ?? []) {
-+              for (const decl of mod.declarations ?? []) {
-+                if (decl.customElement) {
-+                  for (const cssProp of decl.cssProperties ?? []) {
-+                    if (cssProp.name.startsWith('--rh')) {
-+                      allowed.add(cssProp.name);
-+                    }
-+                  }
-+                }
-+              }
++            for (const name of getCemAllowed(join(process.cwd(), opts.cem))) {
++                allowed.add(name);
 +            }
-+          } catch {
-+            // CEM file not found at provided path
-+          }
 +        }
          root.walk(node => {
              if (node.type === 'decl') {
                  const parsedValue = parser(node.value);
 diff --git a/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js b/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js
-index bf431df..861702e 100644
+index bf431df..81cf845 100644
 --- a/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js
 +++ b/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js
 @@ -14,6 +14,24 @@ function isVarCall(parsedNode) {
@@ -99,8 +113,8 @@ index bf431df..861702e 100644
 +                                            node.value = `${prefix}${infix}${suffix}`;
 +                                        },
 +                                    });
++                                    return;
 +                                }
-+                                return;
 +                            }
                              if (expected === null && actual == null) {
                                  return;

--- a/patches/@rhds+tokens+3.1.0.patch
+++ b/patches/@rhds+tokens+3.1.0.patch
@@ -1,25 +1,35 @@
 diff --git a/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js b/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js
-index 5c51f5f..6395960 100644
+index 5c51f5f..86fc42b 100644
 --- a/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js
 +++ b/node_modules/@rhds/tokens/plugins/stylelint/rules/no-unknown-token-name.js
-@@ -11,7 +11,7 @@ const meta = {
-     fixable: true,
- };
+@@ -1,4 +1,5 @@
+-import { dirname, sep } from 'node:path';
++import { readFileSync } from 'node:fs';
++import { dirname, join, sep } from 'node:path';
+ import { tokens } from '@rhds/tokens';
+ import stylelint from 'stylelint';
+ import parser from 'postcss-value-parser';
+@@ -13,15 +14,34 @@ const meta = {
  const ruleFunction = (_, opts) => {
--    return (root, result) => {
-+    return async (root, result) => {
+     return (root, result) => {
          // here we assume a file structure of */rh-tagname/rh-tagname.css
-         const tagName = dirname(root.source.input.file)
-             .split(sep)
-@@ -22,6 +22,25 @@ const ruleFunction = (_, opts) => {
+-        const tagName = dirname(root.source.input.file)
+-            .split(sep)
+-            .findLast(x => x.startsWith('rh-'));
++        const tagName = root.source?.input?.file
++            ? dirname(root.source.input.file).split(sep).findLast(x => x.startsWith('rh-'))
++            : undefined;
+         const validOptions = stylelint.utils.validateOptions(result, ruleName);
+         if (!validOptions) {
+             return;
          }
          const migrations = new Map(Object.entries(opts?.migrations ?? {}));
          const allowed = new Set(opts?.allowed ?? []);
-+        try {
-+          const pkgjson = await import('../../../../../../package.json', { with: { type: 'json' } })
-+          if (pkgjson?.default.name === '@rhds/elements') {
-+            const cem = await import('../../../../../../custom-elements.json', { with: { type: 'json' } })
-+            for (const mod of cem.default?.modules) {
++        if (opts?.cem) {
++          try {
++            const cemPath = join(process.cwd(), opts.cem);
++            const cem = JSON.parse(readFileSync(cemPath, 'utf8'));
++            for (const mod of cem?.modules ?? []) {
 +              for (const decl of mod.declarations ?? []) {
 +                if (decl.customElement) {
 +                  for (const cssProp of decl.cssProperties ?? []) {
@@ -30,10 +40,68 @@ index 5c51f5f..6395960 100644
 +                }
 +              }
 +            }
++          } catch {
++            // CEM file not found at provided path
 +          }
-+        } catch (e) {
-+          console.log(e);
 +        }
          root.walk(node => {
              if (node.type === 'decl') {
                  const parsedValue = parser(node.value);
+diff --git a/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js b/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js
+index bf431df..861702e 100644
+--- a/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js
++++ b/node_modules/@rhds/tokens/plugins/stylelint/rules/token-values.js
+@@ -14,6 +14,24 @@ function isVarCall(parsedNode) {
+         && parsedNode.value === 'var'
+         && parsedNode.nodes.length > 1;
+ }
++function extractLightDarkParts(parsed) {
++    const ld = parsed.nodes?.find(n => n.type === 'function' && n.value === 'light-dark');
++    if (!ld) return null;
++    const varNodes = ld.nodes.filter(n => n.type === 'function' && n.value === 'var');
++    if (varNodes.length !== 2) return null;
++    return varNodes.map(v => {
++        const [nameNode, , ...fallbackNodes] = v.nodes;
++        return { name: nameNode.value, fallback: parser.stringify(fallbackNodes) };
++    });
++}
++function lightDarkMatches(actual, expected) {
++    const expectedParts = extractLightDarkParts(parser(expected));
++    if (!expectedParts) return null;
++    const actualParts = extractLightDarkParts(parser(actual));
++    if (!actualParts) return false;
++    return expectedParts.every((exp, i) =>
++        actualParts[i]?.name === exp.name && actualParts[i]?.fallback === exp.fallback);
++}
+ const ruleFunction = () => {
+     return (root, result) => {
+         const validOptions = stylelint.utils.validateOptions(result, ruleName);
+@@ -30,6 +48,28 @@ const ruleFunction = () => {
+                         if (tokens.has(name)) {
+                             const actual = parser.stringify(values);
+                             const expected = tokens.get(name);
++                            if (typeof expected === 'string' && expected.startsWith('light-dark(')) {
++                                const match = lightDarkMatches(actual, expected);
++                                if (match === true) return;
++                                if (match === false) {
++                                    stylelint.utils.report({
++                                        node,
++                                        message: `Expected ${name} fallback to be ${expected}`,
++                                        ruleName,
++                                        result,
++                                        word: name,
++                                        index: value.sourceIndex,
++                                        endIndex: value.sourceEndIndex,
++                                        fix() {
++                                            const prefix = node.value.slice(0, parsedNode.sourceIndex);
++                                            const infix = `var(${name}, ${expected})`;
++                                            const suffix = node.value.slice(parsedNode.sourceEndIndex);
++                                            node.value = `${prefix}${infix}${suffix}`;
++                                        },
++                                    });
++                                }
++                                return;
++                            }
+                             if (expected === null && actual == null) {
+                                 return;
+                             }


### PR DESCRIPTION
## What I did

Updated the @rhds/tokens patch to fix two stylelint plugin issues and configured the no-unknown-token-name rule to use the custom elements manifest.

1. token-values rule — added light-dark() support: The upstream rule doesn't know how to validate light-dark() fallback values. Added extractLightDarkParts() and lightDarkMatches() functions to structurally compare light-dark(var(...), var(...)) fallbacks against the canonical token values, with an auto-fixer that replaces incorrect fallbacks.
2. no-unknown-token-name rule — added opt-in cem option: The rule flags any --rh-* custom property not in the system token map, but component CSS custom properties (like --rh-tabs-link-color) are intentional API. Added a cem config option that reads custom-elements.json from the project root to discover and allow these properties. Also fixed null safety for root.source.input.file.
3. Configured cem location in .stylelintrc.yml:
```yaml
rhds/no-unknown-token-name:
  - true
  - cem: ./custom-elements.json
```

Closes #3121

## Testing Instructions

1.

## Notes to Reviewers

We expect additional lint failures. This PR stack contains many changes across the stack, and the lint failures should decrease with each level of fixes.