### PR TITLE
docs: remove global and default-theme styles, apply fallbacks

### DIFF
--- a/docs/styles/grid.css
+++ b/docs/styles/grid.css
@@ -5,7 +5,7 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(var(--uxdot-grid-repeat, 1), 1fr);
-  gap: var(--rh-space-2xl);
+  gap: var(--rh-space-2xl, 32px);
 
   &.gapless {
     gap: 0;

--- a/docs/styles/not-defined.css
+++ b/docs/styles/not-defined.css
@@ -6,21 +6,21 @@ uxdot-hero:not(:defined) {
 }
 
 uxdot-hero:not(:defined) [slot='header'] {
-  color: var(--rh-color-text-brand-on-light);
+  color: var(--rh-color-text-brand-on-light, #ee0000);
   margin-block-end: 0;
-  font-weight: var(--rh-font-weight-code-medium);
-  font-size: var(--rh-font-size-code-lg) !important;
+  font-weight: var(--rh-font-weight-code-medium, 500);
+  font-size: var(--rh-font-size-code-lg, 1.125rem) !important;
 }
 
 uxdot-hero:not(:defined) [slot='tagline'] {
-  font-size: var(--rh-font-size-heading-2xl) !important;
-  margin-block: var(--rh-space-lg) !important;
+  font-size: var(--rh-font-size-heading-2xl, 3rem) !important;
+  margin-block: var(--rh-space-lg, 16px) !important;
   text-align: center;
 }
 
 uxdot-hero:not(:defined) [slot='image'] {
   width: 100%;
-  margin-block-start: var(--rh-space-4xl);
+  margin-block-start: var(--rh-space-4xl, 64px);
 }
 
 uxdot-example:not(:defined) img {
@@ -30,8 +30,8 @@ uxdot-example:not(:defined) img {
 rh-subnav:not(:defined) {
   display: flex;
   flex-direction: row;
-  gap: var(--rh-space-md);
-  margin-block-start: var(--rh-space-2xl);
+  gap: var(--rh-space-md, 8px);
+  margin-block-start: var(--rh-space-2xl, 32px);
   max-width: 100%;
   overflow-x: scroll;
 }
@@ -39,12 +39,12 @@ rh-subnav:not(:defined) {
 rh-subnav:not(:defined) a {
   display: block;
   white-space: nowrap;
-  padding: var(--rh-space-lg);
+  padding: var(--rh-space-lg, 16px);
   text-decoration: none;
-  color: var(--rh-color-text-secondary-on-light);
+  color: var(--rh-color-text-secondary-on-light, #4d4d4d);
   position: relative;
 }
 
 rh-subnav:not(:defined) a[active] {
-  border-block-end: 3px solid var(--rh-color-accent-brand-on-light);
+  border-block-end: 3px solid var(--rh-color-accent-brand-on-light, #ee0000);
 }

--- a/docs/styles/pages/ai-guidelines.css
+++ b/docs/styles/pages/ai-guidelines.css
@@ -73,8 +73,14 @@ figure[data-type='dont'] {
       content: 'Do';
       margin-inline-start: calc(var(--rh-size-icon-01, 16px) + var(--rh-space-md, 8px));
       margin-block-end: var(--rh-space-lg, 16px);
-      color: var(--rh-color-status-success, light-dark(var(--rh-color-status-success-on-light, #3d7317), var(--rh-color-status-success-on-dark, #87bb62)));
-      font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
+      color:
+        var(--rh-color-status-success,
+          light-dark(
+            var(--rh-color-status-success-on-light, #3d7317),
+            var(--rh-color-status-success-on-dark, #87bb62)));
+      font-family:
+        var(--rh-font-family-heading,
+          RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
       font-size: var(--rh-font-size-heading-xs, 1.25rem);
       font-weight: var(--rh-font-weight-heading-medium, 500);
     }
@@ -89,7 +95,11 @@ figure[data-type='dont'] {
       width: var(--rh-size-icon-01, 16px);
       height: var(--rh-size-icon-01, 16px);
       mask-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%20fill%3D%22var(--rh-color-gray-95)%22%3E%3Cpath%20d%3D%22M16%201C7.729%201%201%207.729%201%2016s6.729%2015%2015%2015%2015-6.729%2015-15S24.271%201%2016%201Zm7.795%2011.795-8.646%208.646c-.317.317-.733.475-1.149.475s-.832-.158-1.149-.475l-4.646-4.646a1.126%201.126%200%200%201%201.591-1.591l4.205%204.205%208.205-8.205a1.126%201.126%200%200%201%201.591%201.591Z%22%2F%3E%3C%2Fsvg%3E');
-      background-color: var(--rh-color-status-success, light-dark(var(--rh-color-status-success-on-light, #3d7317), var(--rh-color-status-success-on-dark, #87bb62)));
+      background-color:
+        var(--rh-color-status-success,
+          light-dark(
+            var(--rh-color-status-success-on-light, #3d7317),
+            var(--rh-color-status-success-on-dark, #87bb62)));
     }
   }
 }
@@ -98,12 +108,20 @@ figure:is([data-type='dont']) {
   figcaption {
     &:before {
       content: "Don't";
-      color: var(--rh-color-status-danger, light-dark(var(--rh-color-status-danger-on-light, #b1380b), var(--rh-color-status-danger-on-dark, #f0561d)));
+      color:
+        var(--rh-color-status-danger,
+          light-dark(
+            var(--rh-color-status-danger-on-light, #b1380b),
+            var(--rh-color-status-danger-on-dark, #f0561d)));
     }
 
     &:after {
       mask-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%20fill%3D%22var(--rh-color-gray-95)%22%3E%3Cpath%20d%3D%22M16%201C7.729%201%201%207.729%201%2016s6.729%2015%2015%2015%2015-6.729%2015-15S24.271%201%2016%201Zm6.796%2020.205A1.127%201.127%200%200%201%2022%2023.126c-.288%200-.576-.11-.796-.33L16%2017.592l-5.204%205.204a1.122%201.122%200%200%201-1.592%200%201.127%201.127%200%200%201%200-1.591L14.409%2016l-5.205-5.205a1.127%201.127%200%200%201%200-1.591%201.127%201.127%200%200%201%201.592%200L16%2014.408l5.204-5.204a1.127%201.127%200%200%201%201.592%200%201.127%201.127%200%200%201%200%201.591L17.591%2016l5.205%205.205Z%22%2F%3E%3C%2Fsvg%3E');
-      background-color: var(--rh-color-status-danger, light-dark(var(--rh-color-status-danger-on-light, #b1380b), var(--rh-color-status-danger-on-dark, #f0561d)));
+      background-color:
+        var(--rh-color-status-danger,
+          light-dark(
+            var(--rh-color-status-danger-on-light, #b1380b),
+            var(--rh-color-status-danger-on-dark, #f0561d)));
     }
   }
 }

--- a/docs/styles/pages/ai-guidelines.css
+++ b/docs/styles/pages/ai-guidelines.css
@@ -21,10 +21,10 @@ body {
 }
 
 figure[data-type*='example'] {
-  margin-block: var(--rh-space-3xl);
+  margin-block: var(--rh-space-3xl, 48px);
 
   figcaption {
-    margin-block-start: var(--rh-space-xl);
+    margin-block-start: var(--rh-space-xl, 24px);
 
     :is(p, ul, ol) {
       margin-block-start: 0;
@@ -34,7 +34,7 @@ figure[data-type*='example'] {
   &:is([data-type*='landscape']) {
     img {
       display: block;
-      margin-block-end: var(--rh-space-xl);
+      margin-block-end: var(--rh-space-xl, 24px);
     }
   }
 
@@ -43,7 +43,7 @@ figure[data-type*='example'] {
     &:has(> :nth-child(2):not(figcaption)) {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
-      gap: var(--rh-space-2xl);
+      gap: var(--rh-space-2xl, 32px);
     }
 
     /* has only 3 images or more than 5 */
@@ -61,7 +61,7 @@ figure[data-type*='example'] {
 /* Adds the "Do" & "Don't" tags with icons to the do/dont <figure> types */
 figure[data-type='do'],
 figure[data-type='dont'] {
-  margin-block: var(--rh-space-3xl);
+  margin-block: var(--rh-space-3xl, 48px);
 
   /* stylelint-disable-next-line no-descending-specificity */
   figcaption {
@@ -71,12 +71,12 @@ figure[data-type='dont'] {
     &:before {
       display: block;
       content: 'Do';
-      margin-inline-start: calc(var(--rh-size-icon-01) + var(--rh-space-md));
-      margin-block-end: var(--rh-space-lg);
-      color: var(--rh-color-status-success);
-      font-family: var(--rh-font-family-heading);
-      font-size: var(--rh-font-size-heading-xs);
-      font-weight: var(--rh-font-weight-heading-medium);
+      margin-inline-start: calc(var(--rh-size-icon-01, 16px) + var(--rh-space-md, 8px));
+      margin-block-end: var(--rh-space-lg, 16px);
+      color: var(--rh-color-status-success, light-dark(var(--rh-color-status-success-on-light, #3d7317), var(--rh-color-status-success-on-dark, #87bb62)));
+      font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
+      font-size: var(--rh-font-size-heading-xs, 1.25rem);
+      font-weight: var(--rh-font-weight-heading-medium, 500);
     }
 
     &:after {
@@ -86,10 +86,10 @@ figure[data-type='dont'] {
       transform: translateY(50%);
       display: block;
       content: '';
-      width: var(--rh-size-icon-01);
-      height: var(--rh-size-icon-01);
+      width: var(--rh-size-icon-01, 16px);
+      height: var(--rh-size-icon-01, 16px);
       mask-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%20fill%3D%22var(--rh-color-gray-95)%22%3E%3Cpath%20d%3D%22M16%201C7.729%201%201%207.729%201%2016s6.729%2015%2015%2015%2015-6.729%2015-15S24.271%201%2016%201Zm7.795%2011.795-8.646%208.646c-.317.317-.733.475-1.149.475s-.832-.158-1.149-.475l-4.646-4.646a1.126%201.126%200%200%201%201.591-1.591l4.205%204.205%208.205-8.205a1.126%201.126%200%200%201%201.591%201.591Z%22%2F%3E%3C%2Fsvg%3E');
-      background-color: var(--rh-color-status-success);
+      background-color: var(--rh-color-status-success, light-dark(var(--rh-color-status-success-on-light, #3d7317), var(--rh-color-status-success-on-dark, #87bb62)));
     }
   }
 }
@@ -98,12 +98,12 @@ figure:is([data-type='dont']) {
   figcaption {
     &:before {
       content: "Don't";
-      color: var(--rh-color-status-danger);
+      color: var(--rh-color-status-danger, light-dark(var(--rh-color-status-danger-on-light, #b1380b), var(--rh-color-status-danger-on-dark, #f0561d)));
     }
 
     &:after {
       mask-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%20fill%3D%22var(--rh-color-gray-95)%22%3E%3Cpath%20d%3D%22M16%201C7.729%201%201%207.729%201%2016s6.729%2015%2015%2015%2015-6.729%2015-15S24.271%201%2016%201Zm6.796%2020.205A1.127%201.127%200%200%201%2022%2023.126c-.288%200-.576-.11-.796-.33L16%2017.592l-5.204%205.204a1.122%201.122%200%200%201-1.592%200%201.127%201.127%200%200%201%200-1.591L14.409%2016l-5.205-5.205a1.127%201.127%200%200%201%200-1.591%201.127%201.127%200%200%201%201.592%200L16%2014.408l5.204-5.204a1.127%201.127%200%200%201%201.592%200%201.127%201.127%200%200%201%200%201.591L17.591%2016l5.205%205.205Z%22%2F%3E%3C%2Fsvg%3E');
-      background-color: var(--rh-color-status-danger);
+      background-color: var(--rh-color-status-danger, light-dark(var(--rh-color-status-danger-on-light, #b1380b), var(--rh-color-status-danger-on-dark, #f0561d)));
     }
   }
 }
@@ -112,7 +112,7 @@ figure:is([data-type='dont']) {
 ul:is([data-type='dos-donts'], [data-type='examples']) {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--rh-space-2xl);
+  gap: var(--rh-space-2xl, 32px);
   width: 100%;
   margin: 0;
   padding: 0;
@@ -136,7 +136,7 @@ ul:is([data-type='dos-donts'], [data-type='examples']) {
     flex-direction: column;
     flex: 1;
     width: 100%;
-    margin: 0 0 var(--rh-space-2xl);
+    margin: 0 0 var(--rh-space-2xl, 32px);
 
     /* stylelint-disable-next-line no-descending-specificity */
     & img {
@@ -146,7 +146,7 @@ ul:is([data-type='dos-donts'], [data-type='examples']) {
 
     /* stylelint-disable-next-line no-descending-specificity */
     figcaption {
-      margin-block-start: var(--rh-space-xl);
+      margin-block-start: var(--rh-space-xl, 24px);
 
       ul p:last-child {
         margin-block-end: 0;
@@ -176,8 +176,8 @@ ul:is([data-type='dos-donts'], [data-type='examples']) {
 ul:has(> li > img[src*='rh-ui-icon-']) {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--rh-space-2xl);
-  margin-block: var(--rh-space-2xl);
+  gap: var(--rh-space-2xl, 32px);
+  margin-block: var(--rh-space-2xl, 32px);
   margin-inline: 0;
   padding-inline: 0;
 
@@ -197,12 +197,12 @@ ul:has(> li > img[src*='rh-ui-icon-']) {
 img[src*='rh-ui-icon-'] {
   filter: var(--ui-icon-filter);
   transition: filter 0s ease;
-  margin-block-end: var(--rh-space-lg);
+  margin-block-end: var(--rh-space-lg, 16px);
   max-width: 48px;
 }
 
 rh-alert {
-  margin-block: var(--rh-space-3xl);
+  margin-block: var(--rh-space-3xl, 48px);
 }
 
 /**

--- a/docs/styles/pages/backpage.css
+++ b/docs/styles/pages/backpage.css
@@ -6,7 +6,7 @@
     grid-template-areas:
       'header'
       'content';
-    row-gap: var(--rh-space-4xl);
+    row-gap: var(--rh-space-4xl, 64px);
 
     &.has-toc {
       grid-template-areas:
@@ -19,7 +19,7 @@
       grid-area: aside;
 
       @container main (width >= 1440px) {
-        padding-inline: 0 var(--rh-space-2xl);
+        padding-inline: 0 var(--rh-space-2xl, 32px);
       }
     }
 
@@ -29,7 +29,7 @@
       container-name: container;
 
       & > section {
-        margin-block-start: var(--rh-space-6xl);
+        margin-block-start: var(--rh-space-6xl, 96px);
       }
 
       & > section:first-of-type {
@@ -38,17 +38,17 @@
 
       & h2,
       uxdot-copy-permalink h2 {
-        font-size: var(--rh-font-size-heading-md);  /* RHDS h4 heading font size */
+        font-size: var(--rh-font-size-heading-md, 1.75rem);  /* RHDS h4 heading font size */
       }
 
       & h3,
       uxdot-copy-permalink h3 {
-        font-size: var(--rh-font-size-heading-sm);  /* RHDS h5 heading font size */
+        font-size: var(--rh-font-size-heading-sm, 1.5rem);  /* RHDS h5 heading font size */
       }
 
       & h4,
       uxdot-copy-permalink h4 {
-        font-size: var(--rh-font-size-heading-xs);  /* RHDS h6 heading font size */
+        font-size: var(--rh-font-size-heading-xs, 1.25rem);  /* RHDS h6 heading font size */
       }
 
       & h5,
@@ -69,7 +69,7 @@
       & > :where(uxdot-copy-permalink.h2, h2),
       & > :not(section, uxdot-copy-permalink) > :where(uxdot-copy-permalink.h2, h2),
       & > section > :where(uxdot-copy-permalink.h2, h2) {
-        margin-block-start: var(--rh-space-6xl);
+        margin-block-start: var(--rh-space-6xl, 96px);
       }
 
       /**
@@ -94,7 +94,7 @@
       & > :where(uxdot-copy-permalink.h3, h3),
       & > :not(section, uxdot-copy-permalink) > :where(uxdot-copy-permalink.h3, h3),
       & > section > :where(uxdot-copy-permalink.h3, h3) {
-        margin-block-start: var(--rh-space-4xl);
+        margin-block-start: var(--rh-space-4xl, 64px);
       }
 
       /**
@@ -105,7 +105,7 @@
       & > :where(uxdot-copy-permalink.h4, h4),
       & > :not(section, uxdot-copy-permalink) > :where(uxdot-copy-permalink.h4, h4),
       & > section > :where(uxdot-copy-permalink.h4, h4) {
-        margin-block-start: var(--rh-space-3xl);
+        margin-block-start: var(--rh-space-3xl, 48px);
       }
     }
   }
@@ -124,19 +124,19 @@
 
   uxdot-toc {
     @container main (width < 576px) {
-      margin-inline: var(--rh-space-lg);
+      margin-inline: var(--rh-space-lg, 16px);
     }
 
     @container main (width >= 576px) {
-      padding-inline: var(--rh-space-2xl);
+      padding-inline: var(--rh-space-2xl, 32px);
     }
 
     @container main (width >= 768px) {
-      padding-inline: var(--rh-space-3xl);
+      padding-inline: var(--rh-space-3xl, 48px);
     }
 
     @container main (width >= 992px) {
-      padding-inline: var(--rh-space-6xl);
+      padding-inline: var(--rh-space-6xl, 96px);
     }
 
     @container main (width >= 1440px) {
@@ -146,7 +146,7 @@
 
   @container main (width >= 992px) {
     article {
-      row-gap: var(--rh-space-6xl);
+      row-gap: var(--rh-space-6xl, 96px);
     }
   }
 
@@ -170,7 +170,7 @@
           max-width: 320px;
           position: sticky;
           height: max-content;
-          top: calc(var(--uxdot-masthead-max-height) + var(--rh-space-2xl) * 3);
+          top: calc(var(--uxdot-masthead-max-height) + var(--rh-space-2xl, 32px) * 3);
         }
       }
     }

--- a/docs/styles/pages/code.css
+++ b/docs/styles/pages/code.css
@@ -8,7 +8,7 @@
 
     a {
       display: flex;
-      gap: var(--rh-space-sm);
+      gap: var(--rh-space-sm, 6px);
 
       rh-badge {
         display: inline-flex;
@@ -24,12 +24,12 @@
     th,
     td,
     td :is(p, ul, ol, code) {
-      margin-block-end: var(--rh-space-lg);
-      font-size: var(--rh-font-size-body-text-sm);
+      margin-block-end: var(--rh-space-lg, 16px);
+      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
     }
 
     td :is(h2, h3, h4) {
-      font-size: var(--rh-font-size-body-text-sm);
+      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
     }
 
     td {

--- a/docs/styles/pages/tokens.css
+++ b/docs/styles/pages/tokens.css
@@ -1,14 +1,14 @@
 .variants > td {
-  padding-block: var(--rh-space-md);
+  padding-block: var(--rh-space-md, 8px);
 }
 
 uxdot-copy-permalink ~ .token-category > uxdot-copy-permalink {
-  margin-block-start: var(--rh-space-2xl);
+  margin-block-start: var(--rh-space-2xl, 32px);
 }
 
 rh-card.swatches {
-  --rh-card-header-background-on-light: var(--rh-color-surface-light);
-  --rh-card-header-background-on-dark: var(--rh-color-surface-dark);
+  --rh-card-header-background-on-light: var(--rh-color-surface-light, #e0e0e0);
+  --rh-card-header-background-on-dark: var(--rh-color-surface-dark, #383838);
 
   display: block;
 
@@ -24,11 +24,11 @@ rh-card.swatches {
 
   &::part(header) {
     margin: 0;
-    padding: var(--rh-space-lg) var(--rh-space-2xl);
-    gap: var(--rh-space-lg);
-    font-weight: var(--rh-font-weight-heading-regular);
-    font-size: var(--rh-font-size-body-text-md);
-    font-family: var(--rh-font-family-body-text);
+    padding: var(--rh-space-lg, 16px) var(--rh-space-2xl, 32px);
+    gap: var(--rh-space-lg, 16px);
+    font-weight: var(--rh-font-weight-heading-regular, 400);
+    font-size: var(--rh-font-size-body-text-md, 1rem);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     align-items: center;
     flex-flow: row wrap;
   }
@@ -44,13 +44,13 @@ rh-card.swatches {
   &::part(body) {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--rh-space-md);
+    gap: var(--rh-space-md, 8px);
   }
 
   & label {
     margin-inline-start: auto;
-    font-size: var(--rh-font-size-body-text-md);
-    font-weight: var(--rh-font-weight-body-text-regular);
+    font-size: var(--rh-font-size-body-text-md, 1rem);
+    font-weight: var(--rh-font-weight-body-text-regular, 400);
   }
 
   & figure {
@@ -59,5 +59,5 @@ rh-card.swatches {
 }
 
 rh-disclosure.deprecated-tokens {
-  margin-block-end: var(--rh-space-6xl);
+  margin-block-end: var(--rh-space-6xl, 96px);
 }

--- a/docs/styles/samp.css
+++ b/docs/styles/samp.css
@@ -6,8 +6,7 @@ samp:not(.swatch) {
     background-color: var(--rh-color-surface-darkest, #151515);
 
     /* Linting rule issue */
-    /* stylelint-disable-next-line rhds/token-values */
-    opacity: var(--rh-opacity-60, 0.6);
+    opacity: var(--rh-opacity-60, 60%);
     display: block;
     border-bottom:
       2px solid

--- a/docs/styles/samp.css
+++ b/docs/styles/samp.css
@@ -9,7 +9,12 @@ samp:not(.swatch) {
     /* stylelint-disable-next-line rhds/token-values */
     opacity: var(--rh-opacity-60, 0.6);
     display: block;
-    border-bottom: 2px solid var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff)));
+    border-bottom:
+      2px solid
+      var(--rh-color-border-strong,
+        light-dark(
+          var(--rh-color-border-strong-on-light, #151515),
+          var(--rh-color-border-strong-on-dark, #ffffff)));
     position: relative;
 
     &:before,
@@ -22,7 +27,11 @@ samp:not(.swatch) {
       inset-block: calc(-1 * var(--rh-length-xs, 4px));
       border-style: solid;
       border-inline-width: var(--rh-border-width-md, 2px) 0;
-      border-color: var(--rh-color-border-interactive, light-dark(var(--rh-color-border-interactive-on-light, #0066cc), var(--rh-color-border-interactive-on-dark, #92c5f9)));
+      border-color:
+        var(--rh-color-border-interactive,
+          light-dark(
+            var(--rh-color-border-interactive-on-light, #0066cc),
+            var(--rh-color-border-interactive-on-dark, #92c5f9)));
     }
 
     &:before {
@@ -39,7 +48,12 @@ samp:not(.swatch) {
     aspect-ratio: 1;
     display: block;
     width: var(--samp-icon-size);
-    border: var(--rh-border-width-md, 2px) dotted var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff)));
+    border:
+      var(--rh-border-width-md, 2px) dotted
+      var(--rh-color-border-strong,
+        light-dark(
+          var(--rh-color-border-strong-on-light, #151515),
+          var(--rh-color-border-strong-on-dark, #ffffff)));
   }
 
   /* Fonts */
@@ -72,7 +86,11 @@ samp:not(.swatch) {
     }
 
     &:not(.border, .text, .dark) {
-      border-color: var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff)));
+      border-color:
+        var(--rh-color-border-strong,
+          light-dark(
+            var(--rh-color-border-strong-on-light, #151515),
+            var(--rh-color-border-strong-on-dark, #ffffff)));
     }
   }
 
@@ -97,7 +115,12 @@ samp:not(.swatch) {
     display: block;
     border-style: solid;
     border-width: var(--samp-space-size, var(--rh-border-width-md, 2px));
-    border-color: var(--samp-color, var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff))));
+    border-color:
+      var(--samp-color,
+        var(--rh-color-border-strong,
+        light-dark(
+          var(--rh-color-border-strong-on-light, #151515),
+          var(--rh-color-border-strong-on-dark, #ffffff))));
     border-radius: var(--samp-radius, var(--rh-border-radius-default, 3px));
 
     &.sm {

--- a/docs/styles/samp.css
+++ b/docs/styles/samp.css
@@ -3,13 +3,13 @@ samp:not(.swatch) {
   /* Lengths */
   &.length {
     width: var(--samp-length-size);
-    background-color: var(--rh-color-surface-darkest);
+    background-color: var(--rh-color-surface-darkest, #151515);
 
     /* Linting rule issue */
     /* stylelint-disable-next-line rhds/token-values */
-    opacity: var(--rh-opacity-60);
+    opacity: var(--rh-opacity-60, 0.6);
     display: block;
-    border-bottom: 2px solid var(--rh-color-border-strong);
+    border-bottom: 2px solid var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff)));
     position: relative;
 
     &:before,
@@ -17,12 +17,12 @@ samp:not(.swatch) {
       content: ' ';
       position: absolute;
       display: block;
-      height: var(--rh-length-xs);
+      height: var(--rh-length-xs, 4px);
       width: 0;
-      inset-block: calc(-1 * var(--rh-length-xs));
+      inset-block: calc(-1 * var(--rh-length-xs, 4px));
       border-style: solid;
-      border-inline-width: var(--rh-border-width-md) 0;
-      border-color: var(--rh-color-border-interactive);
+      border-inline-width: var(--rh-border-width-md, 2px) 0;
+      border-color: var(--rh-color-border-interactive, light-dark(var(--rh-color-border-interactive-on-light, #0066cc), var(--rh-color-border-interactive-on-dark, #92c5f9)));
     }
 
     &:before {
@@ -39,22 +39,22 @@ samp:not(.swatch) {
     aspect-ratio: 1;
     display: block;
     width: var(--samp-icon-size);
-    border: var(--rh-border-width-md) dotted var(--rh-color-border-strong);
+    border: var(--rh-border-width-md, 2px) dotted var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff)));
   }
 
   /* Fonts */
   &.font {
-    font-size: var(--samp-font-size, var(--rh-font-size-body-text-md));
-    font-family: var(--samp-font-family, var(--rh-font-family-body-text));
-    font-weight: var(--samp-font-weight, var(--rh-font-weight-body-text-regular));
+    font-size: var(--samp-font-size, var(--rh-font-size-body-text-md, 1rem));
+    font-family: var(--samp-font-family, var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif));
+    font-weight: var(--samp-font-weight, var(--rh-font-weight-body-text-regular, 400));
 
     &.heading {
-      font-size: var(--samp-font-size, var(--rh-font-size-heading-md));
-      font-family: var(--rh-font-family-heading);
+      font-size: var(--samp-font-size, var(--rh-font-size-heading-md, 1.75rem));
+      font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
     }
 
     &.code {
-      font-family: var(--rh-font-family-code);
+      font-family: var(--rh-font-family-code, RedHatMono, 'Red Hat Mono', 'Courier New', Courier, monospace);
     }
   }
 
@@ -64,7 +64,7 @@ samp:not(.swatch) {
 
     &:not(.border, .text) {
       aspect-ratio: 1;
-      height: var(--rh-length-xl);
+      height: var(--rh-length-xl, 24px);
       display: block;
       border-radius: 100%;
       border: 1px solid transparent;
@@ -72,7 +72,7 @@ samp:not(.swatch) {
     }
 
     &:not(.border, .text, .dark) {
-      border-color: var(--rh-color-border-strong);
+      border-color: var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff)));
     }
   }
 
@@ -83,33 +83,33 @@ samp:not(.swatch) {
 
   /* Box shadow */
   &.box-shadow {
-    height: var(--rh-length-2xl);
+    height: var(--rh-length-2xl, 32px);
     aspect-ratio: 1;
-    border-radius: var(--rh-border-radius-default);
+    border-radius: var(--rh-border-radius-default, 3px);
     box-shadow: var(--samp-box-shadow);
     display: block;
   }
 
   /* Border */
   &.border {
-    width: var(--rh-length-2xl);
+    width: var(--rh-length-2xl, 32px);
     aspect-ratio: 2;
     display: block;
     border-style: solid;
-    border-width: var(--samp-space-size, var(--rh-border-width-md));
-    border-color: var(--samp-color, var(--rh-color-border-strong));
-    border-radius: var(--samp-radius, var(--rh-border-radius-default));
+    border-width: var(--samp-space-size, var(--rh-border-width-md, 2px));
+    border-color: var(--samp-color, var(--rh-color-border-strong, light-dark(var(--rh-color-border-strong-on-light, #151515), var(--rh-color-border-strong-on-dark, #ffffff))));
+    border-radius: var(--samp-radius, var(--rh-border-radius-default, 3px));
 
     &.sm {
-      border-width: var(--samp-space-size, var(--rh-border-width-sm));
+      border-width: var(--samp-space-size, var(--rh-border-width-sm, 1px));
     }
 
     &.md {
-      border-width: var(--samp-space-size, var(--rh-border-width-md));
+      border-width: var(--samp-space-size, var(--rh-border-width-md, 2px));
     }
 
     &.lg {
-      border-width: var(--samp-space-size, var(--rh-border-width-lg));
+      border-width: var(--samp-space-size, var(--rh-border-width-lg, 3px));
     }
   }
 
@@ -118,23 +118,23 @@ samp:not(.swatch) {
     opacity: var(--samp-opacity);
     background-color: black;
     display: block;
-    width: var(--rh-length-xl);
+    width: var(--rh-length-xl, 24px);
     aspect-ratio: 1;
   }
 
   /* Breakpoints */
   &.breakpoint img {
-    max-height: var(--rh-length-3xl);
+    max-height: var(--rh-length-3xl, 48px);
   }
 }
 
 samp.swatch {
   width: max-content;
-  border-radius: var(--rh-border-radius-pill);
-  border-width: var(--rh-border-width-sm);
+  border-radius: var(--rh-border-radius-pill, 64px);
+  border-width: var(--rh-border-width-sm, 1px);
   border-style: solid;
   border-color: oklch(from var(--swatch-color) calc(l + var(--_offset)) c h);
-  padding: var(--rh-space-xs) var(--rh-space-md);
+  padding: var(--rh-space-xs, 4px) var(--rh-space-md, 8px);
   display: inline;
   position: relative;
 
@@ -148,43 +148,48 @@ samp.swatch {
 
   &.color {
     transition-property: background-color, border-color;
-    transition-duration: var(--rh-animation-speed);
-    transition-timing-function: var(--rh-animation-timing);
+    transition-duration: var(--rh-animation-speed, 0.3s);
+    transition-timing-function:
+      var(--rh-animation-timing,
+        cubic-bezier(0.465, 0.183, 0.153, 0.946));
     background-color: var(--swatch-color);
-    font-family: var(--rh-font-family-body-text);
-    font-size: var(--rh-font-size-body-text-sm);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+    font-size: var(--rh-font-size-body-text-sm, 0.875rem);
 
     &.isLight {
-      color: var(--rh-color-text-primary-on-light);
+      color: var(--rh-color-text-primary-on-light, #151515);
     }
 
     &.isDark {
-      color: var(--rh-color-text-primary-on-dark);
+      color: var(--rh-color-text-primary-on-dark, #ffffff);
     }
   }
 
   &.font {
     color: var(--swatch-color);
-    transition: color var(--rh-animation-speed) var(--rh-animation-timing);
-    font-size: var(--rh-font-size-heading-lg);
-    font-weight: var(--rh-font-weight-heading-bold);
-    border-radius: var(--rh-border-radius-default);
-    padding: var(--rh-space-sm) var(--rh-space-md);
+    transition:
+      color
+      var(--rh-animation-speed, 0.3s)
+      var(--rh-animation-timing, cubic-bezier(0.465, 0.183, 0.153, 0.946));
+    font-size: var(--rh-font-size-heading-lg, 2.25rem);
+    font-weight: var(--rh-font-weight-heading-bold, 700);
+    border-radius: var(--rh-border-radius-default, 3px);
+    padding: var(--rh-space-sm, 6px) var(--rh-space-md, 8px);
 
     & span:last-child {
-      font-size: var(--rh-font-size-body-text-md);
+      font-size: var(--rh-font-size-body-text-md, 1rem);
     }
   }
 
   &.border {
     border-color: var(--swatch-color);
-    border-width: var(--rh-border-width-lg);
+    border-width: var(--rh-border-width-lg, 3px);
   }
 
   &.icon {
     display: inline-flex;
     align-items: center;
-    gap: var(--rh-space-xs);
+    gap: var(--rh-space-xs, 4px);
 
     & rh-icon {
       color: var(--swatch-color);

--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -19,8 +19,6 @@
 @import url('not-defined.css') layer(not-defined);
 @import url('reset.css') layer(reset);
 @import url('fonts.css') layer(fonts);
-@import url('/assets/packages/@rhds/tokens/css/global.css') layer(tokens);
-@import url('/assets/packages/@rhds/tokens/css/default-theme.css') layer(tokens);
 @import url('typography.css') layer(typography);
 @import url('grid.css') layer(grid);
 @import url('lightdom.css') layer(lightdom);
@@ -34,32 +32,34 @@
   }
 
   body {
-    color: var(--rh-color-text-primary);
+    color: var(--rh-color-text-primary, light-dark(var(--rh-color-text-primary-on-light, #151515), var(--rh-color-text-primary-on-dark, #ffffff)));
   }
 
   a {
-    color: var(--rh-color-interactive-primary-default);
+    color: var(--rh-color-interactive-primary-default, light-dark(var(--rh-color-interactive-primary-default-on-light, #0066cc), var(--rh-color-interactive-primary-default-on-dark, #92c5f9)));
     text-decoration: underline dashed 1px;
-    text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+    text-decoration-color:
+      light-dark(var(--rh-color-gray-50, #707070),
+        var(--rh-color-gray-40, #a3a3a3));
     text-underline-offset: max(5px, 0.28em);
     transition: ease text-underline-offset 0.3s;
 
     &:hover {
-      color: var(--rh-color-interactive-primary-hover);
+      color: var(--rh-color-interactive-primary-hover, light-dark(var(--rh-color-interactive-primary-hover-on-light, #003366), var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)));
       text-decoration-color: inherit;
       text-underline-offset: max(6px, 0.33em);
     }
 
     &:focus-within {
-      color: var(--rh-color-interactive-primary-focus);
+      color: var(--rh-color-interactive-primary-focus, light-dark(var(--rh-color-interactive-primary-focus-on-light, #003366), var(--rh-color-interactive-primary-focus-on-dark, #b9dafc)));
       text-decoration-color: inherit;
       text-underline-offset: max(6px, 0.33em);
-      &:hover { color: var(--rh-color-interactive-primary-focus); }
+      &:hover { color: var(--rh-color-interactive-primary-focus, light-dark(var(--rh-color-interactive-primary-focus-on-light, #003366), var(--rh-color-interactive-primary-focus-on-dark, #b9dafc))); }
     }
 
     &:visited { /* stylelint-disable-line no-descending-specificity */
-      color: var(--rh-color-interactive-primary-visited-default);
-      &:hover { color: var(--rh-color-interactive-primary-visited-hover); }
+      color: var(--rh-color-interactive-primary-visited-default, light-dark(var(--rh-color-interactive-primary-visited-default-on-light, #5e40be), var(--rh-color-interactive-primary-visited-default-on-dark, #b6a6e9)));
+      &:hover { color: var(--rh-color-interactive-primary-visited-hover, light-dark(var(--rh-color-interactive-primary-visited-hover-on-light, #21134d), var(--rh-color-interactive-primary-visited-hover-on-dark, #ece6ff))); }
     }
 
     /* Denote VPN / RH Internal links */
@@ -69,7 +69,7 @@
       display: inline-block;
       width: 14px;
       height: 14px;
-      margin-left: var(--rh-space-sm);
+      margin-left: var(--rh-space-sm, 6px);
       vertical-align: baseline;
       text-indent: -99999em;
       background-color: currentcolor;
@@ -82,10 +82,10 @@
   }
 
   hr {
-    border-block-start: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
+    border-block-start: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
     border-inline: none;
     border-block-end: none;
-    margin-block-end: var(--rh-space-2xl);
+    margin-block-end: var(--rh-space-2xl, 32px);
   }
 
   :where(img, picture, video, canvas, svg) {
@@ -98,7 +98,7 @@
   }
 
   figcaption {
-    color: var(--rh-color-text-secondary);
+    color: var(--rh-color-text-secondary, light-dark(var(--rh-color-text-secondary-on-light, #4d4d4d), var(--rh-color-text-secondary-on-dark, #c7c7c7)));
   }
 
   .visually-hidden {
@@ -112,7 +112,7 @@
   }
 
   :is(*, :hover):focus-visible {
-    border-radius: var(--rh-border-radius-default);
+    border-radius: var(--rh-border-radius-default, 3px);
     outline-color:
       light-dark(
           --rh-color-border-interactive-on-light,
@@ -170,7 +170,7 @@
 
   :target {
     /* Set padding for #hash links */
-    scroll-margin-top: calc(var(--uxdot-masthead-max-height) + var(--rh-space-5xl));
+    scroll-margin-top: calc(var(--uxdot-masthead-max-height) + var(--rh-space-5xl, 80px));
   }
 
   body {
@@ -189,8 +189,8 @@
   #main,
   uxdot-sidenav {
     --rh-color-surface:
-      light-dark(var(--rh-color-surface-lightest),
-        var(--rh-color-surface-darker));
+      light-dark(var(--rh-color-surface-lightest, #ffffff),
+        var(--rh-color-surface-darker, #1f1f1f));
   }
 
   #main {
@@ -201,8 +201,8 @@
   }
 
   .container {
-    padding-inline: var(--rh-space-lg);
-    padding-block-end: var(--rh-space-lg);
+    padding-inline: var(--rh-space-lg, 16px);
+    padding-block-end: var(--rh-space-lg, 16px);
   }
 
   /**
@@ -220,7 +220,7 @@
     grid-area: nav;
 
     rh-tag {
-      margin-inline-start: var(--rh-space-md);
+      margin-inline-start: var(--rh-space-md, 8px);
     }
   }
 
@@ -249,23 +249,23 @@
 
   @container main (min-width: 576px) {
     .container {
-      padding-inline: var(--rh-space-2xl);
-      padding-block-end: var(--rh-space-2xl);
+      padding-inline: var(--rh-space-2xl, 32px);
+      padding-block-end: var(--rh-space-2xl, 32px);
     }
   }
 
   @container main (min-width: 768px) {
     .container {
-      padding-inline: var(--rh-space-3xl);
-      padding-block-end: var(--rh-space-3xl);
+      padding-inline: var(--rh-space-3xl, 48px);
+      padding-block-end: var(--rh-space-3xl, 48px);
     }
   }
 
   @container main (min-width: 992px) {
     .container {
       max-width: var(--container-max-width);
-      padding-inline: var(--rh-space-6xl);
-      padding-block: 0 var(--rh-space-6xl);
+      padding-inline: var(--rh-space-6xl, 96px);
+      padding-block: 0 var(--rh-space-6xl, 96px);
     }
   }
 }
@@ -276,25 +276,25 @@
   }
 
   :where(p, ul, ol, dl) {
-    margin-block: var(--rh-space-lg) var(--rh-space-2xl);
+    margin-block: var(--rh-space-lg, 16px) var(--rh-space-2xl, 32px);
   }
 
   :where(li) {
-    margin-block: var(--rh-space-md);
+    margin-block: var(--rh-space-md, 8px);
   }
 
   :where(h1, h2, h3, h4, h5, h6) {
-    margin-block-end: var(--rh-space-lg);
+    margin-block-end: var(--rh-space-lg, 16px);
   }
 
   :where(h1, h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6),
   :where(uxdot-copy-permalink + uxdot-copy-permalink) {
-    margin-block-start: var(--rh-space-2xl);
+    margin-block-start: var(--rh-space-2xl, 32px);
   }
 
   :where(uxdot-copy-permalink, h1, h2, h3 ,h4, h5 ,h6) + uxdot-example,
   :where(rh-alert) + uxdot-demo {
-    margin-block-start: var(--rh-space-lg);
+    margin-block-start: var(--rh-space-lg, 16px);
   }
 
   figure uxdot-example {
@@ -306,11 +306,11 @@
   rh-alert + rh-code-block,
   rh-code-block + rh-alert,
   rh-cta + uxdot-example {
-    margin-block-start: var(--rh-space-2xl);
+    margin-block-start: var(--rh-space-2xl, 32px);
   }
 
   rh-table {
-    margin-block: var(--rh-space-3xl);
+    margin-block: var(--rh-space-3xl, 48px);
   }
 
   /* TODO: look into this do we need this rule? */
@@ -319,17 +319,17 @@
   }
 
   rh-alert + rh-alert {
-    margin-block-start: var(--rh-space-xl);
+    margin-block-start: var(--rh-space-xl, 24px);
   }
 
   uxdot-example + figcaption,
   figcaption + uxdot-example {
-    margin-block: var(--rh-space-lg);
+    margin-block: var(--rh-space-lg, 16px);
   }
 
   uxdot-example + figcaption ol,
   uxdot-example + figcaption p {
-    color: var(--rh-color-text-secondary);
+    color: var(--rh-color-text-secondary, light-dark(var(--rh-color-text-secondary-on-light, #4d4d4d), var(--rh-color-text-secondary-on-dark, #c7c7c7)));
     font-size: var(--rh-font-size-body-text-sm, 0.875rem);
     line-height: var(--rh-line-height-body-text, 1.5);
   }
@@ -351,7 +351,7 @@
   }
 
   uxdot-demo + rh-cta {
-    margin-block: var(--rh-space-2xl);
+    margin-block: var(--rh-space-2xl, 32px);
   }
 
   p.aka {
@@ -377,13 +377,13 @@
      */
 
   :where(code:not([class^='language-'])) {
-    padding-inline: var(--rh-space-xs);
+    padding-inline: var(--rh-space-xs, 4px);
     background:
-      light-dark(oklch(from var(--rh-color-surface) calc(l - 0.05) c h),
-        oklch(from var(--rh-color-surface) calc(l + 0.1) c h));
-    border-radius: var(--rh-border-radius-default);
-    font-size: var(--rh-font-size-code-md);
-    font-weight: var(--rh-font-weight-code-regular);
+      light-dark(oklch(from var(--rh-color-surface, light-dark(var(--rh-color-surface-lightest, #ffffff), var(--rh-color-surface-darkest, #151515))) calc(l - 0.05) c h),
+        oklch(from var(--rh-color-surface, light-dark(var(--rh-color-surface-lightest, #ffffff), var(--rh-color-surface-darkest, #151515))) calc(l + 0.1) c h));
+    border-radius: var(--rh-border-radius-default, 3px);
+    font-size: var(--rh-font-size-code-md, 1rem);
+    font-weight: var(--rh-font-weight-code-regular, 400);
   }
 
   :where(code:empty) {
@@ -396,24 +396,24 @@
   }
 
   :where(kbd) {
-    --_uxdot-kbd-color-border: var(--rh-color-border-subtle);
+    --_uxdot-kbd-color-border: var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
 
     background-color:
       light-dark(
-          var(--rh-color-surface-lightest),
-          var(--rh-color-surface-darkest));
-    color: var(--rh-color-text-primary);
-    border-radius: var(--rh-border-radius-default);
-    border: var(--rh-border-width-sm) solid var(--_uxdot-kbd-color-border);
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515));
+    color: var(--rh-color-text-primary, light-dark(var(--rh-color-text-primary-on-light, #151515), var(--rh-color-text-primary-on-dark, #ffffff)));
+    border-radius: var(--rh-border-radius-default, 3px);
+    border: var(--rh-border-width-sm, 1px) solid var(--_uxdot-kbd-color-border);
     box-shadow: 0 2px 0 1px var(--_uxdot-kbd-color-border);
     cursor: default;
-    font-size: var(--rh-font-size-body-text-md);
+    font-size: var(--rh-font-size-body-text-md, 1rem);
     line-height: 1;
     min-width: 0.75rem;
     display: inline-block;
     text-align: center;
-    padding: 2px var(--rh-space-sm);
-    margin-inline: var(--rh-space-xs);
+    padding: 2px var(--rh-space-sm, 6px);
+    margin-inline: var(--rh-space-xs, 4px);
     position: relative;
     top: -1px;
   }
@@ -457,9 +457,9 @@
   }
 
   #edit-this-page {
-    border-block-start: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
-    margin-block-start: var(--rh-space-6xl);
-    padding-block-start: var(--rh-space-lg);
+    border-block-start: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+    margin-block-start: var(--rh-space-6xl, 96px);
+    padding-block-start: var(--rh-space-lg, 16px);
   }
 }
 
@@ -477,7 +477,7 @@
     & p {
       /* TODO: Document this bug shouldn't have to force the font size
       the component is trying to set internally on #description */
-      font-size: var(--rh-font-size-body-text-md) !important;
+      font-size: var(--rh-font-size-body-text-md, 1rem) !important;
     }
 
     & code {
@@ -494,8 +494,8 @@
       &:hover {
         --uxdot-copy-permalink-button-background:
           light-dark(
-              var(--rh-color-surface-light),
-              var(--rh-color-surface-darker)
+              var(--rh-color-surface-light, #e0e0e0),
+              var(--rh-color-surface-darker, #1f1f1f)
             );
       }
     }

--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -158,8 +158,8 @@
     border-radius: var(--rh-border-radius-default, 3px);
     outline-color:
       light-dark(
-          --rh-color-border-interactive-on-light,
-          --rh-color-border-interactive-on-dark);
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          var(--rh-color-border-interactive-on-dark, #92c5f9));
     outline-offset: var(--rh-border-width-lg, 3px);
     outline-style: solid;
     outline-width: var(--rh-border-width-lg, 3px);

--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -32,11 +32,19 @@
   }
 
   body {
-    color: var(--rh-color-text-primary, light-dark(var(--rh-color-text-primary-on-light, #151515), var(--rh-color-text-primary-on-dark, #ffffff)));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)));
   }
 
   a {
-    color: var(--rh-color-interactive-primary-default, light-dark(var(--rh-color-interactive-primary-default-on-light, #0066cc), var(--rh-color-interactive-primary-default-on-dark, #92c5f9)));
+    color:
+      var(--rh-color-interactive-primary-default,
+        light-dark(
+          var(--rh-color-interactive-primary-default-on-light, #0066cc),
+          var(--rh-color-interactive-primary-default-on-dark, #92c5f9)));
     text-decoration: underline dashed 1px;
     text-decoration-color:
       light-dark(var(--rh-color-gray-50, #707070),
@@ -45,21 +53,47 @@
     transition: ease text-underline-offset 0.3s;
 
     &:hover {
-      color: var(--rh-color-interactive-primary-hover, light-dark(var(--rh-color-interactive-primary-hover-on-light, #003366), var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)));
+      color:
+        var(--rh-color-interactive-primary-hover,
+          light-dark(
+            var(--rh-color-interactive-primary-hover-on-light, #003366),
+            var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)));
       text-decoration-color: inherit;
       text-underline-offset: max(6px, 0.33em);
     }
 
     &:focus-within {
-      color: var(--rh-color-interactive-primary-focus, light-dark(var(--rh-color-interactive-primary-focus-on-light, #003366), var(--rh-color-interactive-primary-focus-on-dark, #b9dafc)));
+      color:
+        var(--rh-color-interactive-primary-focus,
+          light-dark(
+            var(--rh-color-interactive-primary-focus-on-light, #003366),
+            var(--rh-color-interactive-primary-focus-on-dark, #b9dafc)));
       text-decoration-color: inherit;
       text-underline-offset: max(6px, 0.33em);
-      &:hover { color: var(--rh-color-interactive-primary-focus, light-dark(var(--rh-color-interactive-primary-focus-on-light, #003366), var(--rh-color-interactive-primary-focus-on-dark, #b9dafc))); }
+
+      &:hover {
+        color:
+          var(--rh-color-interactive-primary-focus,
+            light-dark(
+              var(--rh-color-interactive-primary-focus-on-light, #003366),
+              var(--rh-color-interactive-primary-focus-on-dark, #b9dafc)));
+      }
     }
 
     &:visited { /* stylelint-disable-line no-descending-specificity */
-      color: var(--rh-color-interactive-primary-visited-default, light-dark(var(--rh-color-interactive-primary-visited-default-on-light, #5e40be), var(--rh-color-interactive-primary-visited-default-on-dark, #b6a6e9)));
-      &:hover { color: var(--rh-color-interactive-primary-visited-hover, light-dark(var(--rh-color-interactive-primary-visited-hover-on-light, #21134d), var(--rh-color-interactive-primary-visited-hover-on-dark, #ece6ff))); }
+      color:
+        var(--rh-color-interactive-primary-visited-default,
+          light-dark(
+            var(--rh-color-interactive-primary-visited-default-on-light, #5e40be),
+            var(--rh-color-interactive-primary-visited-default-on-dark, #b6a6e9)));
+
+      &:hover {
+        color:
+          var(--rh-color-interactive-primary-visited-hover,
+            light-dark(
+              var(--rh-color-interactive-primary-visited-hover-on-light, #21134d),
+              var(--rh-color-interactive-primary-visited-hover-on-dark, #ece6ff)));
+      }
     }
 
     /* Denote VPN / RH Internal links */
@@ -82,7 +116,12 @@
   }
 
   hr {
-    border-block-start: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+    border-block-start:
+      var(--rh-border-width-sm, 1px) solid
+      var(--rh-color-border-subtle,
+        light-dark(
+          var(--rh-color-border-subtle-on-light, #c7c7c7),
+          var(--rh-color-border-subtle-on-dark, #707070)));
     border-inline: none;
     border-block-end: none;
     margin-block-end: var(--rh-space-2xl, 32px);
@@ -98,7 +137,11 @@
   }
 
   figcaption {
-    color: var(--rh-color-text-secondary, light-dark(var(--rh-color-text-secondary-on-light, #4d4d4d), var(--rh-color-text-secondary-on-dark, #c7c7c7)));
+    color:
+      var(--rh-color-text-secondary,
+        light-dark(
+          var(--rh-color-text-secondary-on-light, #4d4d4d),
+          var(--rh-color-text-secondary-on-dark, #c7c7c7)));
   }
 
   .visually-hidden {
@@ -329,7 +372,11 @@
 
   uxdot-example + figcaption ol,
   uxdot-example + figcaption p {
-    color: var(--rh-color-text-secondary, light-dark(var(--rh-color-text-secondary-on-light, #4d4d4d), var(--rh-color-text-secondary-on-dark, #c7c7c7)));
+    color:
+      var(--rh-color-text-secondary,
+        light-dark(
+          var(--rh-color-text-secondary-on-light, #4d4d4d),
+          var(--rh-color-text-secondary-on-dark, #c7c7c7)));
     font-size: var(--rh-font-size-body-text-sm, 0.875rem);
     line-height: var(--rh-line-height-body-text, 1.5);
   }
@@ -379,8 +426,19 @@
   :where(code:not([class^='language-'])) {
     padding-inline: var(--rh-space-xs, 4px);
     background:
-      light-dark(oklch(from var(--rh-color-surface, light-dark(var(--rh-color-surface-lightest, #ffffff), var(--rh-color-surface-darkest, #151515))) calc(l - 0.05) c h),
-        oklch(from var(--rh-color-surface, light-dark(var(--rh-color-surface-lightest, #ffffff), var(--rh-color-surface-darkest, #151515))) calc(l + 0.1) c h));
+      light-dark(
+          oklch(from
+          var(--rh-color-surface,
+          light-dark(
+            var(--rh-color-surface-lightest, #ffffff),
+            var(--rh-color-surface-darkest, #151515)))
+            calc(l - 0.05) c h),
+            oklch(from
+            var(--rh-color-surface,
+            light-dark(
+              var(--rh-color-surface-lightest, #ffffff),
+              var(--rh-color-surface-darkest, #151515)))
+              calc(l + 0.1) c h));
     border-radius: var(--rh-border-radius-default, 3px);
     font-size: var(--rh-font-size-code-md, 1rem);
     font-weight: var(--rh-font-weight-code-regular, 400);
@@ -396,13 +454,21 @@
   }
 
   :where(kbd) {
-    --_uxdot-kbd-color-border: var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+    --_uxdot-kbd-color-border:
+      var(--rh-color-border-subtle,
+        light-dark(
+          var(--rh-color-border-subtle-on-light, #c7c7c7),
+          var(--rh-color-border-subtle-on-dark, #707070)));
 
     background-color:
       light-dark(
           var(--rh-color-surface-lightest, #ffffff),
           var(--rh-color-surface-darkest, #151515));
-    color: var(--rh-color-text-primary, light-dark(var(--rh-color-text-primary-on-light, #151515), var(--rh-color-text-primary-on-dark, #ffffff)));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)));
     border-radius: var(--rh-border-radius-default, 3px);
     border: var(--rh-border-width-sm, 1px) solid var(--_uxdot-kbd-color-border);
     box-shadow: 0 2px 0 1px var(--_uxdot-kbd-color-border);
@@ -457,7 +523,12 @@
   }
 
   #edit-this-page {
-    border-block-start: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+    border-block-start:
+      var(--rh-border-width-sm, 1px) solid
+      var(--rh-color-border-subtle,
+        light-dark(
+          var(--rh-color-border-subtle-on-light, #c7c7c7),
+          var(--rh-color-border-subtle-on-dark, #707070)));
     margin-block-start: var(--rh-space-6xl, 96px);
     padding-block-start: var(--rh-space-lg, 16px);
   }

--- a/docs/styles/third-party/prism-rhds.css
+++ b/docs/styles/third-party/prism-rhds.css
@@ -12,10 +12,10 @@
 
 pre[class*='language-'],
 :not(pre) > code[class*='language-'] {
-  color: var(--rh-color-text-primary);
+  color: var(--rh-color-text-primary, light-dark(var(--rh-color-text-primary-on-light, #151515), var(--rh-color-text-primary-on-dark, #ffffff)));
   background:
-    light-dark(var(--rh-color-surface-lighter),
-      var(--rh-color-surface-dark));
+    light-dark(var(--rh-color-surface-lighter, #f2f2f2),
+      var(--rh-color-surface-dark, #383838));
   background: none;
   font-size: 1em;
   text-align: start;

--- a/docs/styles/third-party/prism-rhds.css
+++ b/docs/styles/third-party/prism-rhds.css
@@ -12,7 +12,11 @@
 
 pre[class*='language-'],
 :not(pre) > code[class*='language-'] {
-  color: var(--rh-color-text-primary, light-dark(var(--rh-color-text-primary-on-light, #151515), var(--rh-color-text-primary-on-dark, #ffffff)));
+  color:
+    var(--rh-color-text-primary,
+      light-dark(
+        var(--rh-color-text-primary-on-light, #151515),
+        var(--rh-color-text-primary-on-dark, #ffffff)));
   background:
     light-dark(var(--rh-color-surface-lighter, #f2f2f2),
       var(--rh-color-surface-dark, #383838));

--- a/docs/styles/third-party/prism-rhds.css
+++ b/docs/styles/third-party/prism-rhds.css
@@ -17,9 +17,6 @@ pre[class*='language-'],
       light-dark(
         var(--rh-color-text-primary-on-light, #151515),
         var(--rh-color-text-primary-on-dark, #ffffff)));
-  background:
-    light-dark(var(--rh-color-surface-lighter, #f2f2f2),
-      var(--rh-color-surface-dark, #383838));
   background: none;
   font-size: 1em;
   text-align: start;

--- a/docs/theming/color-palettes.css
+++ b/docs/theming/color-palettes.css
@@ -1,19 +1,19 @@
 dl {
-  margin: 0 0 var(--rh-space-2xl);
+  margin: 0 0 var(--rh-space-2xl, 32px);
 
   dt {
-    margin-block: var(--rh-space-lg);
+    margin-block: var(--rh-space-lg, 16px);
     font-weight: bold;
   }
 
   dd {
-    margin-block: var(--rh-space-lg);
-    padding-inline-start: var(--rh-space-2xl);
+    margin-block: var(--rh-space-lg, 16px);
+    padding-inline-start: var(--rh-space-2xl, 32px);
   }
 }
 
 rh-alert + rh-card {
-  margin-block-start: var(--rh-space-2xl);
+  margin-block-start: var(--rh-space-2xl, 32px);
 }
 
 .container > rh-alert {
@@ -35,14 +35,14 @@ rh-alert + rh-card {
   display: grid;
   padding: 0;
   list-style-type: none;
-  gap: var(--rh-space-xl);
+  gap: var(--rh-space-xl, 24px);
   grid-template-columns: 1fr 1fr 1fr;
   text-align: center;
 }
 
 .icon-card {
   &::part(header) {
-    margin-block: var(--rh-space-2xl) 1rem;
+    margin-block: var(--rh-space-2xl, 32px) 1rem;
     flex-direction: row;
     align-items: center;
     justify-content: center;
@@ -53,7 +53,7 @@ rh-alert + rh-card {
   }
 
   & rh-icon {
-    width: var(--rh-size-icon-04);
+    width: var(--rh-size-icon-04, 40px);
 
     --rh-icon-size: 100%;
   }
@@ -65,15 +65,15 @@ rh-alert + rh-card {
 
 .surface-grid {
   grid-template-columns: 1fr 1fr;
-  margin-block: var(--rh-space-lg) var(--rh-space-2xl);
+  margin-block: var(--rh-space-lg, 16px) var(--rh-space-2xl, 32px);
 
   rh-card {
     p {
-      margin-block-start: var(--rh-space-2xl);
-      font-size: var(--rh-font-size-body-text-sm);
+      margin-block-start: var(--rh-space-2xl, 32px);
+      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
 
       code {
-        font-size: var(--rh-font-size-code-sm);
+        font-size: var(--rh-font-size-code-sm, 0.875rem);
       }
     }
   }
@@ -81,13 +81,13 @@ rh-alert + rh-card {
 
 .color-palette-grid rh-surface {
   padding: 2rem;
-  border-radius: var(--rh-border-radius-default);
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
+  border-radius: var(--rh-border-radius-default, 3px);
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
 }
 
 .pullquote-card {
   min-width: 360px;
-  margin: var(--rh-space-2xl);
+  margin: var(--rh-space-2xl, 32px);
 
   &.right {
     float: right;
@@ -100,5 +100,5 @@ rh-audio-player::part(toolbar) {
 }
 
 label + rh-switch {
-  margin-inline-start: var(--rh-space-md);
+  margin-inline-start: var(--rh-space-md, 8px);
 }

--- a/docs/theming/color-palettes.css
+++ b/docs/theming/color-palettes.css
@@ -82,7 +82,12 @@ rh-alert + rh-card {
 .color-palette-grid rh-surface {
   padding: 2rem;
   border-radius: var(--rh-border-radius-default, 3px);
-  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+  border:
+    var(--rh-border-width-sm, 1px) solid
+    var(--rh-color-border-subtle,
+      light-dark(
+        var(--rh-color-border-subtle-on-light, #c7c7c7),
+        var(--rh-color-border-subtle-on-dark, #707070)));
 }
 
 .pullquote-card {

--- a/docs/theming/developers/developers.css
+++ b/docs/theming/developers/developers.css
@@ -1,6 +1,6 @@
 .code-tabs {
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
-  border-radius: var(--rh-border-radius-default);
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+  border-radius: var(--rh-border-radius-default, 3px);
   max-width: 56rem; /* warning: magic number */
   overflow: hidden;
 

--- a/docs/theming/developers/developers.css
+++ b/docs/theming/developers/developers.css
@@ -1,5 +1,10 @@
 .code-tabs {
-  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle, light-dark(var(--rh-color-border-subtle-on-light, #c7c7c7), var(--rh-color-border-subtle-on-dark, #707070)));
+  border:
+    var(--rh-border-width-sm, 1px) solid
+    var(--rh-color-border-subtle,
+      light-dark(
+        var(--rh-color-border-subtle-on-light, #c7c7c7),
+        var(--rh-color-border-subtle-on-dark, #707070)));
   border-radius: var(--rh-border-radius-default, 3px);
   max-width: 56rem; /* warning: magic number */
   overflow: hidden;


### PR DESCRIPTION
## What I did

Applied token fallbacks to docs stylesheets and fixed the resulting line-length violations.

1. Applied `stylelint --fix` across 11 CSS files in `docs/` to add missing `var()` fallback values for `--rh-*` design tokens. These are the shared docs stylesheets in `docs/styles/` and `docs/theming/` that previously lacked fallbacks. Now all require-token-fallback violations are resolved for these files.

2. Reformatted 6 files to fix max-line-length violations caused by long `light-dark(var(...), var(...))` fallback values. Broke them into multi-line format with proper indentation per the project's @stylistic/indentation config (indentInsideParens: 'once-at-root-twice-in-block').

Reference #3152
Closes #3163 

## Testing Instructions

1.

## Notes to Reviewers

This was the first step in correcting `docs/**/*.css` files.  Breaking apart changes up on the stack with the type of change made.  We still expect link errors on this branch.