### PR TITLE
docs: update focus guidance with border-radius soft default

### DIFF
--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -55,7 +55,7 @@ In CSS terms, here is some minimal code that meets these requirements:
 
 ```css rh-code-block
 :is(*, :hover):focus-visible {
-  outline-color: light-dark(--rh-color-blue-50, --rh-color-blue-30);
+  outline-color: light-dark(var(--rh-color-blue-50), var(--rh-color-blue-30));
   outline-offset: 3px;
   outline-style: solid;
   outline-width: 3px;
@@ -107,7 +107,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 
 ```css rh-code-block
 :is(*, :hover):focus-visible {
-  outline-color: light-dark(--rh-color-blue-50, --rh-color-blue-30);
+  outline-color: light-dark(var(--rh-color-blue-50), var(--rh-color-blue-30));
   outline-offset: 3px;
   outline-style: solid;
   outline-width: 3px;
@@ -146,7 +146,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 ### Technical notes on the CSS
 
 - We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
-- The <code>:is(\*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
+- The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -65,7 +65,7 @@ In CSS terms, here is some minimal code that meets these requirements:
 }
 
 :where(:focus-visible) {
-  border-radius: 3px;
+  border-radius: var(--rh-border-width-lg, 3px);
 }
 ```
 
@@ -121,7 +121,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 }
 
 :where(:focus-visible) {
-  border-radius: 3px;
+  border-radius: var(--rh-border-width-lg, 3px);
 }
 
 /* Placeholder `.inset` class for inset focus. */

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -45,7 +45,7 @@ When focus is applied to an interactive element, we apply an outline that:
 - is solid (not dashed or dotted).
 - is 3px thick.
 - is offset from the element by 3px.
-- has a default border radius of 3px (unless the element already has a specified radius).
+- has a default border radius of 3px (which is overridden if the element already has a specified radius).
 - has 3:1 or greater contrast from the background colors just outside and inside of it.
 - temporarily disables any transition animations on the element (so entering or exiting the focus state is not distracting).
 

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -105,6 +105,8 @@ Note that there may be cases where a focus ring appears against a light backgrou
 
 ## Full example CSS
 
+This code includes the basic code above, plus options for inset indicators, indicators with no offset at all, and forced light or dark indicators.
+
 ```css rh-code-block
 :is(*, :hover):focus-visible {
   outline-color: light-dark(var(--rh-color-blue-50), var(--rh-color-blue-30));
@@ -146,7 +148,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 ### Technical notes on the CSS
 
 - We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
-- The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
+- The <code>:is(\*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -62,7 +62,7 @@ In CSS terms, here is some minimal code that meets these requirements:
   transition: none;
 }
 
-:where(*, :hover):focus-visible {
+:where(:focus-visible) {
   border-radius: 3px;
 }
 ```
@@ -114,7 +114,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
   transition: none;
 }
 
-:where(*, :hover):focus-visible {
+:where(:focus-visible) {
   border-radius: 3px;
 }
 

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -118,6 +118,10 @@ Note that there may be cases where a focus ring appears against a light backgrou
   border-radius: 3px;
 }
 
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
 /* Placeholder `.inset` class for inset focus. */
 .inset:is(*, :hover):focus-visible {
   outline-offset: -7px;
@@ -136,10 +140,6 @@ Note that there may be cases where a focus ring appears against a light backgrou
 /* Placeholder `.dark-bg` class for focus against dark backgrounds. */
 .dark-bg:is(*, :hover):focus-visible {
   outline-color: --rh-color-blue-30;
-}
-
-:focus:not(:focus-visible) {
-  outline: none;
 }
 ```
 

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -146,7 +146,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 ### Technical notes on the CSS
 
 - We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
-- The <code>:is(\*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
+- The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -107,7 +107,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 <img src="./focus-styling-considerations-demo.svg" alt="Demo of how inset ring colors should be set based on their background color and not the page theme" style="max-width: 100%;">
 
 
-## Example CSS
+## Full example CSS
 ```css rh-code-block
 :is(*, :hover):focus-visible {
   outline-color: light-dark(

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -148,7 +148,7 @@ This code includes the basic code above, plus options for inset indicators, indi
 ### Technical notes on the CSS
 
 - We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
-- The <code>:is(\*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
+- The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -28,7 +28,6 @@ subnav:
   import "@uxdot/elements/uxdot-pattern.js";
 </script>
 
-
 ## Focus indicator styles
 
 Focus styles visually indicate when interactive elements like links and buttons are selected (usually via keyboard) and ready to receive input. **All interactive elements are required** to have a [visible focus indicator](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html) to conform with the Web Content Accessibility Guidelines (WCAG).
@@ -46,9 +45,9 @@ When focus is applied to an interactive element, we apply an outline that:
 - is solid (not dashed or dotted).
 - is 3px thick.
 - is offset from the element by 3px.
+- has a default border radius of 3px (_unless the element already has a specified radius_).
 - has 3:1 or greater contrast from the background colors just outside and inside of it.
 - temporarily disables any transition animations on the element (so entering or exiting the focus state is not distracting).
-
 
 ### Basic CSS
 
@@ -60,7 +59,11 @@ In CSS terms, here is some minimal code that meets these requirements:
   outline-offset: 3px;
   outline-style: solid;
   outline-width: 3px;
-  transition: none; 
+  transition: none;
+}
+
+:where(*, :hover):focus-visible {
+  border-radius: 3px;
 }
 ```
 
@@ -94,22 +97,25 @@ We have designated focus ring colors that align with our brand standards for bot
   </table>
 </rh-table>
 
-
 #### Styling considerations
 
 Note that there may be cases where a focus ring appears against a light background in dark mode and vice versa. For example, an inset focus ring for a text field may appear against a white background, even in dark mode. In these cases, you may need to manually override the default dark scheme ring color (<code>--rh-color-blue-30</code>) with the light scheme color (<code>--rh-color-blue-50</code>).
 
 <img src="./focus-styling-considerations-demo.svg" alt="Demo of how inset ring colors should be set based on their background color and not the page theme" style="max-width: 100%;">
 
+## Full example CSS
 
-## Example CSS
 ```css rh-code-block
 :is(*, :hover):focus-visible {
   outline-color: light-dark(--rh-color-blue-50, --rh-color-blue-30);
   outline-offset: 3px;
   outline-style: solid;
   outline-width: 3px;
-  transition: none; 
+  transition: none;
+}
+
+:where(*, :hover):focus-visible {
+  border-radius: 3px;
 }
 
 /* Placeholder `.inset` class for inset focus. */
@@ -140,15 +146,13 @@ Note that there may be cases where a focus ring appears against a light backgrou
 ### Technical notes on the CSS
 
 - We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
-- The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
+- The <code>:is(\*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.
 - Note that we prefer <code>:focus-visible</code> to <code>:focus</code>. **Avoid using the latter**. In fact, our code above disables the latter.
 
-
 ## Best Practices
-
 
 ### Custom focus indicator styles
 

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -45,7 +45,7 @@ When focus is applied to an interactive element, we apply an outline that:
 - is solid (not dashed or dotted).
 - is 3px thick.
 - is offset from the element by 3px.
-- has a default border radius of 3px (_unless the element already has a specified radius_).
+- has a default border radius of 3px (unless the element already has a specified radius).
 - has 3:1 or greater contrast from the background colors just outside and inside of it.
 - temporarily disables any transition animations on the element (so entering or exiting the focus state is not distracting).
 

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -28,6 +28,7 @@ subnav:
   import "@uxdot/elements/uxdot-pattern.js";
 </script>
 
+
 ## Focus indicator styles
 
 Focus styles visually indicate when interactive elements like links and buttons are selected (usually via keyboard) and ready to receive input. **All interactive elements are required** to have a [visible focus indicator](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html) to conform with the Web Content Accessibility Guidelines (WCAG).
@@ -40,7 +41,7 @@ To view keyboard focus states on a computer, open a web page in your browser and
 
 Users who depend on focus indicators need styles that are **clear and consistent**, so they always know where they are in an experience. Our focus styles align with our [brand standards](https://www.redhat.com/en/about/brand/standards) and the latest [WCAG guidance](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance).
 
-When focus is applied to an interactive element, apply an outline that:
+When focus is applied to an interactive element, we apply an outline that:
 
 - is solid (not dashed or dotted).
 - is 3px thick.
@@ -49,16 +50,17 @@ When focus is applied to an interactive element, apply an outline that:
 - has 3:1 or greater contrast from the background colors just outside and inside of it.
 - temporarily disables any transition animations on the element (so entering or exiting the focus state is not distracting).
 
+
 ### Basic CSS
 
 In CSS terms, here is some minimal code that meets these requirements:
 
 ```css rh-code-block
 :is(*, :hover):focus-visible {
-  outline-color: light-dark(var(--rh-color-blue-50), var(--rh-color-blue-30));
-  outline-offset: 3px;
+  outline-color: var(--rh-color-border-interactive, #0066cc);
+  outline-offset: var(--rh-border-width-lg, 3px);
   outline-style: solid;
-  outline-width: 3px;
+  outline-width: var(--rh-border-width-lg, 3px);
   transition: none;
 }
 
@@ -97,31 +99,29 @@ We have designated focus ring colors that align with our brand standards for bot
   </table>
 </rh-table>
 
+
 #### Styling considerations
 
 Note that there may be cases where a focus ring appears against a light background in dark mode and vice versa. For example, an inset focus ring for a text field may appear against a white background, even in dark mode. In these cases, you may need to manually override the default dark scheme ring color (<code>--rh-color-border-interactive-on-dark</code>) with the light scheme color (<code>--rh-color-border-interactive-on-light</code>).
 
 <img src="./focus-styling-considerations-demo.svg" alt="Demo of how inset ring colors should be set based on their background color and not the page theme" style="max-width: 100%;">
 
-## Full example CSS
 
-This code includes the basic code above, plus options for inset indicators, indicators with no offset at all, and forced light or dark indicators.
-
+## Example CSS
 ```css rh-code-block
 :is(*, :hover):focus-visible {
-  outline-color: light-dark(var(--rh-color-blue-50), var(--rh-color-blue-30));
-  outline-offset: 3px;
+  outline-color: light-dark(
+    var(--rh-color-border-interactive-on-light, #0066cc),
+    var(--rh-color-border-interactive-on-dark, #92c5f9)
+  );
+  outline-offset: var(--rh-border-width-lg, 3px);
   outline-style: solid;
-  outline-width: 3px;
+  outline-width: var(--rh-border-width-lg, 3px);
   transition: none;
 }
 
 :where(:focus-visible) {
   border-radius: 3px;
-}
-
-:focus:not(:focus-visible) {
-  outline: none;
 }
 
 /* Placeholder `.inset` class for inset focus. */
@@ -143,6 +143,10 @@ This code includes the basic code above, plus options for inset indicators, indi
 .dark-bg:is(*, :hover):focus-visible {
   outline-color: var(--rh-color-border-interactive-on-dark, #92c5f9);
 }
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
 ```
 
 ### Technical notes on the CSS
@@ -154,7 +158,9 @@ This code includes the basic code above, plus options for inset indicators, indi
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.
 - Note that we prefer <code>:focus-visible</code> to <code>:focus</code>. **Avoid using the latter**. In fact, our code above disables the latter.
 
-## Best Practices
+
+## Best practices
+
 
 ### Custom focus indicator styles
 

--- a/docs/foundations/interactions/focus-indicators/index.md
+++ b/docs/foundations/interactions/focus-indicators/index.md
@@ -40,12 +40,12 @@ To view keyboard focus states on a computer, open a web page in your browser and
 
 Users who depend on focus indicators need styles that are **clear and consistent**, so they always know where they are in an experience. Our focus styles align with our [brand standards](https://www.redhat.com/en/about/brand/standards) and the latest [WCAG guidance](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance).
 
-When focus is applied to an interactive element, we apply an outline that:
+When focus is applied to an interactive element, apply an outline that:
 
 - is solid (not dashed or dotted).
 - is 3px thick.
 - is offset from the element by 3px.
-- has a default border radius of 3px (which is overridden if the element already has a specified radius).
+- has a border radius of 3px, unless the element already has a specified radius.
 - has 3:1 or greater contrast from the background colors just outside and inside of it.
 - temporarily disables any transition animations on the element (so entering or exiting the focus state is not distracting).
 
@@ -146,7 +146,7 @@ Note that there may be cases where a focus ring appears against a light backgrou
 ### Technical notes on the CSS
 
 - We use the <code>color-scheme</code> property on our websites, which allows us to use the <code>light-dark()</code> function. If your website does not use <code>color-scheme</code>, you can separate out the dark mode focus ring color into another selector or query. The good news is that, even if you do not have a <code>color-scheme</code> and you do not account for this, the fallback ring color of <code>--rh-color-blue-50</code> is **WCAG conformant** against both our dark and light backgrounds.
-- The <code>:is(*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
+- The <code>:is(\*, :hover)</code> pseudo-class prevents potential hover state style conflicts from making the focus outline disappear, for cases where an element has both keyboard focus and mouse cursor hover.
 - WCAG 2.2 requires 2px outlines for AAA conformance when focus is offset. However, **inset** focus must be greater than 2px. So, for the sake of consistency, we go with 3px in **all cases**.
 - We add a <code>transition: none</code> property to **temporarily remove any animations** that may be on the element, so the focus ring appearance does not animate.
 - Inset focus rings receive a negative <code>outline-offset</code> just large enough to leave some whitespace between the ring and the border of the element.


### PR DESCRIPTION
## What I did

1. Added text on supplying a default border radius.
2. Updated the CSS samples with `:where` selectors containing default `border-radius` property value of 3px.


## Testing Instructions

Go to the [deploy preview page](#) and...

1. Check that the following verbiage is accurate and has been added to the list in the "How we style focus" section:

> has a default border radius of 3px (which is overridden if the element already has a specified radius).

2. Verify that the "Basic CSS" and "Full example CSS" code blocks include the following CSS (updated to include token):

```
:where(:focus-visible) {
  border-radius: var(--rh-border-width-lg, 3px);
}
```

(Note: we use `:where` in order to remove specificity. That way, if an element already has a border-radius, the 3px radius should not be applied.)