### PR TITLE
docs: correct missing fallbacks in uxdot elements, apply @themeable

### DIFF
--- a/uxdot/uxdot-best-practice.css
+++ b/uxdot/uxdot-best-practice.css
@@ -1,23 +1,23 @@
 :host {
   display: block;
-  margin-block: var(--rh-space-2xl);
+  margin-block: var(--rh-space-2xl, 32px);
 }
 
 #container {
   display: flex;
   flex-direction: column;
-  gap: var(--rh-space-2xl);
-  margin-block: var(--rh-space-2xl);
+  gap: var(--rh-space-2xl, 32px);
+  margin-block: var(--rh-space-2xl, 32px);
 }
 
 span {
-  font-family: var(--rh-font-family-heading);
-  font-size: var(--rh-font-size-heading-xs);
-  font-weight: var(--rh-font-weight-heading-medium);
+  font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
+  font-size: var(--rh-font-size-heading-xs, 1.25rem);
+  font-weight: var(--rh-font-weight-heading-medium, 500);
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--rh-space-md);
+  gap: var(--rh-space-md, 8px);
 }
 
 #do span {
@@ -30,7 +30,10 @@ span {
 
 #caution {
   span {
-    color: light-dark(var(--rh-color-yellow-60), var(--rh-color-status-warning-on-dark));
+    color:
+      light-dark(
+          var(--rh-color-yellow-60, #96640f),
+          var(--rh-color-status-warning-on-dark, #ffcc17));
   }
 
   rh-icon {

--- a/uxdot/uxdot-best-practice.ts
+++ b/uxdot/uxdot-best-practice.ts
@@ -3,8 +3,11 @@ import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './uxdot-best-practice.css';
 
+@themable
 @customElement('uxdot-best-practice')
 export class UxdotBestPractice extends LitElement {
   static styles = [styles];

--- a/uxdot/uxdot-copy-button.css
+++ b/uxdot/uxdot-copy-button.css
@@ -1,21 +1,24 @@
 button {
   color: inherit;
-  border-radius: var(--rh-border-radius-default);
+  border-radius: var(--rh-border-radius-default, 3px);
   border-width: 0;
   background: none;
   display: inline-flex;
   align-items: center;
-  gap: var(--rh-space-xs);
-  padding-inline: var(--rh-space-xs);
+  gap: var(--rh-space-xs, 4px);
+  padding-inline: var(--rh-space-xs, 4px);
 }
 
 code {
-  padding: var(--rh-space-xs) var(--rh-space-md);
-  background: light-dark(var(--rh-color-surface-light), var(--rh-color-surface-dark));
-  font-size: var(--rh-font-size-code-md);
-  font-weight: var(--rh-font-weight-code-regular);
-  font-family: var(--rh-font-family-code);
-  line-height: var(--rh-line-height-code);
+  padding: var(--rh-space-xs, 4px) var(--rh-space-md, 8px);
+  background:
+    light-dark(
+        var(--rh-color-surface-light, #e0e0e0),
+        var(--rh-color-surface-dark, #383838));
+  font-size: var(--rh-font-size-code-md, 1rem);
+  font-weight: var(--rh-font-weight-code-regular, 400);
+  font-family: var(--rh-font-family-code, RedHatMono, 'Red Hat Mono', 'Courier New', Courier, monospace);
+  line-height: var(--rh-line-height-code, 1.5);
 }
 
 :host(.icon-only) code,
@@ -30,7 +33,7 @@ code {
 :host(:state(--rendered)) button:is(:focus, :active, :hover),
 :host(:state(--rendered)) button:is(:focus, :active, :hover) code {
   color: var(--rh-color-text-primary);
-  background: light-dark(var(--rh-color-blue-20), var(--rh-color-blue-70));
+  background: light-dark(var(--rh-color-blue-20, #b9dafc), var(--rh-color-blue-70, #003366));
   opacity: 1;
 }
 

--- a/uxdot/uxdot-copy-button.ts
+++ b/uxdot/uxdot-copy-button.ts
@@ -10,9 +10,12 @@ import { RhAlert } from '@rhds/elements/rh-alert/rh-alert.js';
 import '@rhds/elements/rh-tooltip/rh-tooltip.js';
 import '@rhds/elements/rh-icon/rh-icon.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './uxdot-copy-button.css';
 import visuallyHidden from './visually-hidden.css';
 
+@themable
 @customElement('uxdot-copy-button')
 export class UxdotCopyButton extends LitElement {
   static styles = [styles, visuallyHidden];

--- a/uxdot/uxdot-copy-permalink.css
+++ b/uxdot/uxdot-copy-permalink.css
@@ -1,6 +1,6 @@
 :host {
   display: flex;
-  margin-block-end: var(--rh-space-lg);
+  margin-block-end: var(--rh-space-lg, 16px);
   align-items: center;
 }
 
@@ -12,7 +12,7 @@
   height: 1.75rem;
   background: none;
   border: none;
-  border-radius: var(--rh-border-radius-default);
+  border-radius: var(--rh-border-radius-default, 3px);
   display: none;
   align-items: center;
 }
@@ -21,8 +21,8 @@
   background:
     var(--uxdot-copy-permalink-button-background,
       light-dark(
-        var(--rh-color-surface-light),
-        var(--rh-color-surface-dark)
+        var(--rh-color-surface-light, #e0e0e0),
+        var(--rh-color-surface-dark, #383838)
       )
     );
   color: var(--rh-color-text-primary);

--- a/uxdot/uxdot-copy-permalink.ts
+++ b/uxdot/uxdot-copy-permalink.ts
@@ -6,8 +6,11 @@ import { property } from 'lit/decorators/property.js';
 import { RhAlert } from '@rhds/elements/rh-alert/rh-alert.js';
 import '@rhds/elements/rh-icon/rh-icon.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './uxdot-copy-permalink.css';
 
+@themable
 @customElement('uxdot-copy-permalink')
 export class UxdotCopyPermalink extends LitElement {
   static styles = [styles];

--- a/uxdot/uxdot-demo.css
+++ b/uxdot/uxdot-demo.css
@@ -3,7 +3,7 @@
 }
 
 iframe {
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
   block-size: 400px;
   max-block-size: var(--height);
   inline-size: 100%;
@@ -15,7 +15,7 @@ iframe {
 
   display: flex;
   flex-direction: column;
-  gap: var(--rh-space-2xl);
+  gap: var(--rh-space-2xl, 32px);
 
   &:not(:defined) {
     opacity: 0;
@@ -35,19 +35,19 @@ iframe {
   &::part(body) {
     margin: 0;
     border-block-end:
-      var(--rh-border-width-sm) solid
+      var(--rh-border-width-sm, 1px) solid
       var(--rh-color-border-subtle);
   }
 
   &::part(footer) {
     margin: 0;
     flex-flow: row wrap;
-    gap: var(--rh-space-md);
-    padding: var(--rh-space-md);
+    gap: var(--rh-space-md, 8px);
+    padding: var(--rh-space-md, 8px);
 
     @container (min-width: 992px) {
-      gap: var(--rh-space-lg);
-      padding: var(--rh-space-lg);
+      gap: var(--rh-space-lg, 16px);
+      padding: var(--rh-space-lg, 16px);
     }
   }
 
@@ -63,9 +63,9 @@ iframe {
     display: inline-flex;
     align-items: center;
     white-space: nowrap;
-    gap: var(--rh-space-sm);
-    padding-inline: calc(var(--rh-space-lg) * 0.75) var(--rh-space-lg);
-    padding-block: var(--rh-space-sm);
+    gap: var(--rh-space-sm, 6px);
+    padding-inline: calc(var(--rh-space-lg, 16px) * 0.75) var(--rh-space-lg, 16px);
+    padding-block: var(--rh-space-sm, 6px);
     text-decoration: none;
 
     &:focus-visible {
@@ -98,14 +98,14 @@ iframe {
     position: relative;
     display: block;
     margin-block-start: -1px;
-    border-end-start-radius: var(--rh-border-radius-default);
-    border-end-end-radius: var(--rh-border-radius-default);
+    border-end-start-radius: var(--rh-border-radius-default, 3px);
+    border-end-end-radius: var(--rh-border-radius-default, 3px);
   }
 
   & #knobs {
     display: grid;
     grid-template-columns: 1fr;
-    gap: var(--rh-space-2xl);
+    gap: var(--rh-space-2xl, 32px);
 
     /* var(--rh-breakpoint-sm, 768px) */
     @media (min-width: 768px) {
@@ -132,12 +132,12 @@ iframe {
 
     & .code-tabs {
       border: 0;
-      border-radius: var(--rh-border-radius-default);
+      border-radius: var(--rh-border-radius-default, 3px);
 
       &::part(tabs-container) {
         background:
-          light-dark(var(--rh-color-surface-lightest),
-            var(--rh-color-surface-darker));
+          light-dark(var(--rh-color-surface-lightest, #ffffff),
+            var(--rh-color-surface-darker, #1f1f1f));
       }
 
       & rh-tab-panel {

--- a/uxdot/uxdot-demo.ts
+++ b/uxdot/uxdot-demo.ts
@@ -2,10 +2,13 @@ import { LitElement, html, isServer } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './uxdot-demo.css';
 
 import type { RhCodeBlock } from 'elements/rh-code-block/rh-code-block.js';
 
+@themable
 @customElement('uxdot-demo')
 export class UxdotDemo extends LitElement {
   static styles = [styles];

--- a/uxdot/uxdot-example.css
+++ b/uxdot/uxdot-example.css
@@ -2,7 +2,7 @@
   display: block;
   container-type: inline-size;
   container-name: host;
-  margin-block-end: var(--rh-space-2xl);
+  margin-block-end: var(--rh-space-2xl, 32px);
 }
 
 :host([transparent]) {
@@ -10,15 +10,15 @@
 }
 
 #container {
-  padding: var(--rh-space-2xl);
+  padding: var(--rh-space-2xl, 32px);
   display: flex;
   flex-direction: column;
   align-items: var(--_alignment, center);
   justify-content: center;
-  border-width: var(--rh-border-width-sm);
+  border-width: var(--rh-border-width-sm, 1px);
   border-style: solid;
   border-color: var(--rh-color-border-subtle);
-  border-radius: var(--rh-border-radius-default);
+  border-radius: var(--rh-border-radius-default, 3px);
   background-color: var(--rh-color-surface);
   color: var(--rh-color-text-primary);
 }
@@ -55,12 +55,12 @@
 
 @container host (min-width: 576px) {
   #container {
-    padding: var(--rh-space-3xl);
+    padding: var(--rh-space-3xl, 48px);
   }
 }
 
 @container host (min-width: 768px) {
   #container {
-    padding: var(--rh-space-4xl);
+    padding: var(--rh-space-4xl, 64px);
   }
 }

--- a/uxdot/uxdot-feedback.css
+++ b/uxdot/uxdot-feedback.css
@@ -4,17 +4,17 @@
   display: block;
   container-type: inline-size;
   container-name: host;
-  margin-block-start: var(--rh-space-5xl);
+  margin-block-start: var(--rh-space-5xl, 80px);
 }
 
 #container {
   display: grid;
   grid-template-columns: 1fr;
-  grid-gap: var(--rh-space-3xl);
-  margin-block-end: var(--rh-space-3xl);
+  grid-gap: var(--rh-space-3xl, 48px);
+  margin-block-end: var(--rh-space-3xl, 48px);
 
   :is(*, :hover):focus-visible {
-    border-radius: var(--rh-border-radius-default);
+    border-radius: var(--rh-border-radius-default, 3px);
     outline-color:
       light-dark(
           --rh-color-border-interactive-on-light,
@@ -32,15 +32,15 @@
 
 h2,
 ::slotted(h2) {
-  font-family: var(--rh-font-family-heading);
-  font-size: var(--rh-font-size-heading-md) !important;
-  font-weight: var(--rh-font-weight-heading-medium);
-  line-height: var(--rh-line-height-heading);
-  margin: var(--rh-space-2xl) 0 !important;
+  font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
+  font-size: var(--rh-font-size-heading-md, 1.75rem) !important;
+  font-weight: var(--rh-font-weight-heading-medium, 500);
+  line-height: var(--rh-line-height-heading, 1.3);
+  margin: var(--rh-space-2xl, 32px) 0 !important;
 }
 
 p {
-  font-size: var(--rh-font-size-body-text-lg);
+  font-size: var(--rh-font-size-body-text-lg, 1.125rem);
 }
 
 a {
@@ -48,7 +48,10 @@ a {
     light-dark(var(--rh-color-interactive-primary-default-on-light, #0066cc),
       var(--rh-color-interactive-primary-default-on-dark, #92c5f9));
   text-decoration: underline dashed 1px;
-  text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+  text-decoration-color:
+    light-dark(
+        var(--rh-color-gray-50, #707070),
+        var(--rh-color-gray-40, #a3a3a3));
   text-underline-offset: max(5px, 0.28em);
   transition: ease all 0.3s;
 

--- a/uxdot/uxdot-header.css
+++ b/uxdot/uxdot-header.css
@@ -1,19 +1,19 @@
 :host {
-  --_uxdot-header-padding: var(--rh-space-2xl);
+  --_uxdot-header-padding: var(--rh-space-2xl, 32px);
 
   display: block;
   container-type: inline-size;
   container-name: header;
   background-color:
-    light-dark(var(--rh-color-surface-lighter),
-      oklch(from var(--rh-color-surface-dark) calc(l * 0.82) c h));
+    light-dark(var(--rh-color-surface-lighter, #f2f2f2),
+      oklch(from var(--rh-color-surface-dark, #383838) calc(l * 0.82) c h));
 
   @container (min-width: 768px) {
-    --_uxdot-header-padding: var(--rh-space-3xl);
+    --_uxdot-header-padding: var(--rh-space-3xl, 48px);
   }
 
   @container (min-width: 992px) {
-    --_uxdot-header-padding: var(--rh-space-6xl);
+    --_uxdot-header-padding: var(--rh-space-6xl, 96px);
   }
 }
 
@@ -33,17 +33,19 @@
 }
 
 ::slotted(h1) {
-  font-family: var(--uxdot-heading-font-family, var(--rh-font-family-heading)) !important;
-  font-size: var(--uxdot-heading-heading-size, var(--rh-font-size-heading-2xl)) !important;
-  font-weight: var(--uxdot-heading-font-weight, var(--rh-font-weight-heading-regular)) !important;
-  line-height: var(--uxdot-heading-line-height, var(--rh-line-height-heading)) !important;
+  font-family: var(--uxdot-heading-font-family, var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif)) !important;
+  font-size: var(--uxdot-heading-heading-size, var(--rh-font-size-heading-2xl, 3rem)) !important;
+  font-weight:
+    var(--uxdot-heading-font-weight,
+      var(--rh-font-weight-heading-regular, 400)) !important;
+  line-height: var(--uxdot-heading-line-height, var(--rh-line-height-heading, 1.3)) !important;
   margin: 0 !important;
 }
 
 ::slotted([slot='subnav']) {
-  margin-block-start: var(--rh-space-2xl);
+  margin-block-start: var(--rh-space-2xl, 32px);
 
   /* take the header padding and minus the default padding (2xl), for mobile it should maximize
   soace for the subnav, but for larger viewports it will align the first button text with header */
-  padding-inline: calc(var(--_uxdot-header-padding) - var(--rh-space-2xl));
+  padding-inline: calc(var(--_uxdot-header-padding) - var(--rh-space-2xl, 32px));
 }

--- a/uxdot/uxdot-knob-attribute.css
+++ b/uxdot/uxdot-knob-attribute.css
@@ -17,7 +17,7 @@
   }
 
   rh-tooltip {
-    --rh-color-interactive-primary-default: var(--rh-color-icon-subtle);
+    --rh-color-interactive-primary-default: var(--rh-color-icon-subtle, #707070);
 
     margin-block-start: var(--rh-space-sm, 6px);
   }
@@ -58,7 +58,7 @@
 }
 
 pf-option {
-  --rh-icon-size: var(--rh-size-icon-03);
+  --rh-icon-size: var(--rh-size-icon-03, 32px);
 }
 
 button.toggletip {

--- a/uxdot/uxdot-knob-attribute.ts
+++ b/uxdot/uxdot-knob-attribute.ts
@@ -13,6 +13,8 @@ import '@rhds/elements/rh-switch/rh-switch.js';
 import '@rhds/elements/rh-tabs/rh-tabs.js';
 import '@rhds/elements/lib/elements/rh-context-picker/rh-context-picker.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
 
 import { observes } from '@patternfly/pfe-core/decorators.js';
@@ -22,6 +24,7 @@ const dequote = (x: string) =>
 
 const ARRAY_OF_PAREN_TYPE_RE = /^\((.*)\)\[\]$/;
 
+@themable
 @customElement('uxdot-knob-attribute')
 export class UxdotKnobAttribute extends LitElement {
   static styles = [styles];

--- a/uxdot/uxdot-masthead.css
+++ b/uxdot/uxdot-masthead.css
@@ -3,8 +3,8 @@
 :host {
   color-scheme: only dark;
   display: block;
-  background-color: var(--rh-color-surface-darkest);
-  color: var(--rh-color-text-primary-on-dark);
+  background-color: var(--rh-color-surface-darkest, #151515);
+  color: var(--rh-color-text-primary-on-dark, #ffffff);
   height: max-content;
   container-type: inline-size;
   container-name: uxdot-masthead;
@@ -12,16 +12,16 @@
 
 #container {
   display: grid;
-  column-gap: var(--rh-space-lg);
+  column-gap: var(--rh-space-lg, 16px);
   grid-template-columns: max-content 1fr 1fr;
   max-height: var(--uxdot-masthead-max-height, 72px);
-  margin-inline: var(--rh-space-md);
-  margin-block: var(--rh-space-lg);
+  margin-inline: var(--rh-space-md, 8px);
+  margin-block: var(--rh-space-lg, 16px);
   #scheme { display: none; }
 
   @container (min-width: 576px) {
-    gap: var(--rh-space-2xl);
-    margin: var(--rh-space-lg);
+    gap: var(--rh-space-2xl, 32px);
+    margin: var(--rh-space-lg, 16px);
   }
 
   @container (min-width: 992px) {
@@ -30,7 +30,7 @@
   }
 
   :is(*, :hover):focus-visible {
-    border-radius: var(--rh-border-radius-default);
+    border-radius: var(--rh-border-radius-default, 3px);
     outline-color:
       light-dark(
           --rh-color-border-interactive-on-light,
@@ -50,7 +50,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--rh-space-md);
+  gap: var(--rh-space-md, 8px);
   justify-content: center;
 
   @container (min-width: 992px) {
@@ -58,11 +58,11 @@
   }
 
   &::slotted(button) {
-    color: var(--rh-color-text-primary-on-dark);
+    color: var(--rh-color-text-primary-on-dark, #ffffff);
     background-color: transparent;
     border: none;
     margin: 0;
-    padding: var(--rh-space-md);
+    padding: var(--rh-space-md, 8px);
     line-height: 0 !important;
   }
 
@@ -70,12 +70,14 @@
   &::slotted(button:hover),
   &::slotted(button:active),
   &::slotted(button:focus) {
-    color: var(--rh-color-icon-subtle-hover);
+    color: var(--rh-color-icon-subtle-hover, #a3a3a3);
   }
 
   &::slotted(button:focus) {
-    outline: var(--rh-border-width-md) solid var(--rh-color-border-interactive-on-dark);
-    border-radius: var(--rh-border-radius-default);
+    outline:
+      var(--rh-border-width-md, 2px) solid
+      var(--rh-color-border-interactive-on-dark, #92c5f9);
+    border-radius: var(--rh-border-radius-default, 3px);
   }
 }
 
@@ -84,10 +86,10 @@
   flex-direction: row;
   align-items: center;
   justify-self: flex-start;
-  gap: var(--rh-space-md);
+  gap: var(--rh-space-md, 8px);
 
   @container (min-width: 992px) {
-    margin-inline-start: var(--rh-space-lg);
+    margin-inline-start: var(--rh-space-lg, 16px);
   }
 }
 
@@ -97,16 +99,19 @@
   display: flex;
   flex-direction: row;
   justify-self: end;
-  column-gap: var(--rh-space-lg);
+  column-gap: var(--rh-space-lg, 16px);
 
   a {
     display: flex;
     flex-direction: row;
-    gap: var(--rh-space-lg);
+    gap: var(--rh-space-lg, 16px);
     align-items: center;
     color: var(--rh-color-text-primary-on-dark, #ffffff) !important;
     text-decoration: underline dashed 1px;
-    text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+    text-decoration-color:
+      light-dark(
+          var(--rh-color-gray-50, #707070),
+          var(--rh-color-gray-40, #a3a3a3));
     text-underline-offset: max(5px, 0.28em);
     transition: ease all 0.3s;
 

--- a/uxdot/uxdot-pattern.css
+++ b/uxdot/uxdot-pattern.css
@@ -3,7 +3,7 @@
 :host {
   container: host / inline-size;
   display: block;
-  margin-block-start: var(--rh-space-2xl);
+  margin-block-start: var(--rh-space-2xl, 32px);
   max-width: 56rem; /* warning: magic number */
 }
 
@@ -15,7 +15,7 @@
   display: grid;
   grid-template-columns: auto;
   grid-template-areas: 'heading' 'controls' 'description' 'content' 'code';
-  gap: var(--rh-space-2xl) var(--rh-space-4xl);
+  gap: var(--rh-space-2xl, 32px) var(--rh-space-4xl, 64px);
 
   @container host (width >= 530px) {
     grid-template-columns: auto auto;
@@ -57,7 +57,7 @@ h3,
 ::slotted(h5),
 ::slotted(h6) {
   margin-block: 0 !important;
-  font-size: var(--rh-font-size-body-text-lg) !important;
+  font-size: var(--rh-font-size-body-text-lg, 1.125rem) !important;
 }
 
 #content {
@@ -65,16 +65,16 @@ h3,
   resize: vertical;
   overflow: auto;
   grid-area: content;
-  padding: var(--rh-space-lg);
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
-  border-radius: var(--rh-border-radius-default);
+  padding: var(--rh-space-lg, 16px);
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+  border-radius: var(--rh-border-radius-default, 3px);
   background-color: var(--rh-color-surface);
   color: var(--rh-color-text-primary);
   border-color: var(--rh-color-border-subtle);
 
-  @container host (width > 300px) { padding: var(--rh-space-xl); }
+  @container host (width > 300px) { padding: var(--rh-space-xl, 24px); }
 
-  @container host (width > 540px) { padding: var(--rh-space-4xl); }
+  @container host (width > 540px) { padding: var(--rh-space-4xl, 64px); }
 
   & > * {
     margin-inline: auto;
@@ -90,8 +90,8 @@ h3,
 }
 
 #code-tabs {
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
-  border-radius: var(--rh-border-radius-default);
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+  border-radius: var(--rh-border-radius-default, 3px);
   grid-area: code;
   background-color: var(--rh-color-surface);
 

--- a/uxdot/uxdot-repo-status-list.css
+++ b/uxdot/uxdot-repo-status-list.css
@@ -9,9 +9,9 @@
 }
 
 #inner-container {
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
-  border-radius: var(--rh-border-radius-default);
-  margin-block-start: var(--rh-space-lg);
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
+  border-radius: var(--rh-border-radius-default, 3px);
+  margin-block-start: var(--rh-space-lg, 16px);
 }
 
 #header-container {
@@ -21,7 +21,7 @@
 }
 
 .checklist {
-  font-size: var(--rh-font-size-body-text-sm);
+  font-size: var(--rh-font-size-body-text-sm, 0.875rem);
   position: absolute;
   inset-inline-end: 0;
   translate: 0 -4em;
@@ -46,27 +46,27 @@ dl {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--rh-space-lg);
-  margin-block: var(--rh-space-lg) !important;
-  margin-inline: var(--rh-space-xl) !important;
+  gap: var(--rh-space-lg, 16px);
+  margin-block: var(--rh-space-lg, 16px) !important;
+  margin-inline: var(--rh-space-xl, 24px) !important;
 
   @container host (width >= 768px) {
     flex-direction: row;
-    column-gap: var(--rh-space-lg);
+    column-gap: var(--rh-space-lg, 16px);
   }
 
   @container host (width >= 992px) {
-    column-gap: var(--rh-space-2xl);
+    column-gap: var(--rh-space-2xl, 32px);
   }
 
   & > div {
     display: flex;
-    column-gap: var(--rh-space-md);
+    column-gap: var(--rh-space-md, 8px);
     align-items: center;
 
     & > dt {
-      font-family: var(--rh-font-family-body-text);
-      font-size: var(--rh-font-size-body-text-md);
+      font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+      font-size: var(--rh-font-size-body-text-md, 1rem);
     }
 
     & dd {

--- a/uxdot/uxdot-repo-status-list.ts
+++ b/uxdot/uxdot-repo-status-list.ts
@@ -2,11 +2,14 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import { legend } from './uxdot-repo.js';
 import type { RepoStatus } from '../docs/_plugins/types.js';
 
 import style from './uxdot-repo-status-list.css';
 
+@themable
 @customElement('uxdot-repo-status-list')
 export class UxdotRepoStatusList extends LitElement {
   static styles = [style];

--- a/uxdot/uxdot-sidenav.css
+++ b/uxdot/uxdot-sidenav.css
@@ -1,6 +1,6 @@
 :host {
-  --_padding-start: var(--uxdot-sidenav-padding-start, var(--rh-space-2xl));
-  --_padding-end: var(--uxdot-sidenav-padding-end, var(--rh-space-2xl));
+  --_padding-start: var(--uxdot-sidenav-padding-start, var(--rh-space-2xl, 32px));
+  --_padding-end: var(--uxdot-sidenav-padding-end, var(--rh-space-2xl, 32px));
   --_max-height: 100dvh;
   --_sidenav_width: var(--uxdot-sidenav-width, 320px);
 
@@ -25,12 +25,12 @@
   background-color: transparent;
   border: none;
   margin: 0;
-  padding: var(--rh-space-md);
+  padding: var(--rh-space-md, 8px);
   line-height: 0 !important;
 }
 
 #content {
-  padding: var(--rh-space-lg);
+  padding: var(--rh-space-lg, 16px);
 }
 
 #container {
@@ -43,13 +43,13 @@
 }
 
 #close-button-container {
-  padding-inline: var(--rh-space-md);
-  padding-block: var(--rh-space-lg);
+  padding-inline: var(--rh-space-md, 8px);
+  padding-block: var(--rh-space-lg, 16px);
   max-block-size: var(--uxdot-masthead-max-height, 72px);
 }
 
 #close-button:focus {
-  outline: var(--rh-border-width-md) solid var(--rh-color-border-interactive);
+  outline: var(--rh-border-width-md, 2px) solid var(--rh-color-border-interactive);
   border-radius: var(--rh-border-radius-default, 3px);
 }
 
@@ -67,7 +67,7 @@
 
 [part='overlay'] {
   display: none;
-  background-color: rgb(from var(---rh-color-gray-90) / var(--rh-opacity-60));
+  background-color: rgb(from var(---rh-color-gray-90) / var(--rh-opacity-60, 60%));
   position: fixed;
   inset-block-start: 0;
   block-size: 100dvh;
@@ -82,14 +82,16 @@
 @media (min-width: 320px) {
   :host {
     inline-size: var(--_sidenav_width);
-    box-shadow: var(--rh-box-shadow-lg);
+    box-shadow: var(--rh-box-shadow-lg, 0 6px 8px 2px rgba(21, 21, 21, 0.3));
   }
 }
 
 @media (min-width: 576px) {
   #close-button-container {
-    padding-block: calc(var(--rh-space-lg) + var(--rh-space-xs)) var(--rh-space-lg);
-    padding-inline: var(--rh-space-lg);
+    padding-block:
+      calc(var(--rh-space-lg, 16px) + var(--rh-space-xs, 4px))
+      var(--rh-space-lg, 16px);
+    padding-inline: var(--rh-space-lg, 16px);
   }
 }
 
@@ -100,7 +102,7 @@
     position: fixed;
     inset-block-start: var(--uxdot-masthead-max-height, 72px);
     block-size: calc(var(--_max-height) - var(--uxdot-masthead-max-height, 72px));
-    border-inline-end: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
+    border-inline-end: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
     box-shadow: unset;
   }
 

--- a/uxdot/uxdot-spacer-tokens-table.css
+++ b/uxdot/uxdot-spacer-tokens-table.css
@@ -4,15 +4,15 @@ samp:not(.swatch) {
     width: var(--samp-space-size);
     aspect-ratio: 1/1;
     outline:
-      var(--rh-border-width-sm)
+      var(--rh-border-width-sm, 1px)
       dashed
-      var(--samp-space-color, var(--rh-color-surface-darkest));
-    color: var(--samp-space-color, var(--rh-color-text-primary-on-light));
+      var(--samp-space-color, var(--rh-color-surface-darkest, #151515));
+    color: var(--samp-space-color, var(--rh-color-text-primary-on-light, #151515));
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
-    font-size: var(--rh-font-size-body-text-xs);
+    font-size: var(--rh-font-size-body-text-xs, 0.75rem);
 
     & span {
       display: flex;
@@ -26,7 +26,7 @@ samp:not(.swatch) {
       content: '';
       width: var(--samp-space-size);
       aspect-ratio: 1/1;
-      background-color: var(--samp-space-color, var(--rh-color-surface-darkest));
+      background-color: var(--samp-space-color, var(--rh-color-surface-darkest, #151515));
       opacity: 0.125;
       z-index: -1;
       position: absolute;
@@ -57,13 +57,13 @@ samp:not(.swatch) {
   /* Lengths */
   &.length {
     width: var(--samp-length-size);
-    background-color: var(--rh-color-surface-darkest);
+    background-color: var(--rh-color-surface-darkest, #151515);
 
     /* Linting rule issue */
     /* stylelint-disable-next-line rhds/token-values */
-    opacity: var(--rh-opacity-60);
+    opacity: var(--rh-opacity-60, 0.6);
     display: block;
-    border-bottom: 2px solid var(--rh-color-border-strong-on-light);
+    border-bottom: 2px solid var(--rh-color-border-strong-on-light, #151515);
     position: relative;
 
     &:before,
@@ -71,12 +71,12 @@ samp:not(.swatch) {
       content: ' ';
       position: absolute;
       display: block;
-      height: var(--rh-length-xs);
+      height: var(--rh-length-xs, 4px);
       width: 0;
-      inset-block: calc(-1 * var(--rh-length-xs));
+      inset-block: calc(-1 * var(--rh-length-xs, 4px));
       border-style: solid;
-      border-inline-width: var(--rh-border-width-md) 0;
-      border-color: var(--rh-color-border-interactive-on-light);
+      border-inline-width: var(--rh-border-width-md, 2px) 0;
+      border-color: var(--rh-color-border-interactive-on-light, #0066cc);
     }
 
     &:before {
@@ -93,22 +93,22 @@ samp:not(.swatch) {
     aspect-ratio: 1;
     display: block;
     width: var(--samp-icon-size);
-    border: var(--rh-border-width-md) dotted var(--rh-color-border-strong);
+    border: var(--rh-border-width-md, 2px) dotted var(--rh-color-border-strong);
   }
 
   /* Fonts */
   &.font {
-    font-size: var(--samp-font-size, var(--rh-font-size-body-text-md));
-    font-family: var(--samp-font-family, var(--rh-font-family-body-text));
-    font-weight: var(--samp-font-weight, var(--rh-font-weight-body-text-regular));
+    font-size: var(--samp-font-size, var(--rh-font-size-body-text-md, 1rem));
+    font-family: var(--samp-font-family, var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif));
+    font-weight: var(--samp-font-weight, var(--rh-font-weight-body-text-regular, 400));
 
     &.heading {
-      font-size: var(--samp-font-size, var(--rh-font-size-heading-md));
-      font-family: var(--rh-font-family-heading);
+      font-size: var(--samp-font-size, var(--rh-font-size-heading-md, 1.75rem));
+      font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
     }
 
     &.code {
-      font-family: var(--rh-font-family-code);
+      font-family: var(--rh-font-family-code, RedHatMono, 'Red Hat Mono', 'Courier New', Courier, monospace);
     }
   }
 
@@ -118,7 +118,7 @@ samp:not(.swatch) {
 
     &:not(.border, .text) {
       aspect-ratio: 1;
-      height: var(--rh-length-xl);
+      height: var(--rh-length-xl, 24px);
       display: block;
       border-radius: 100%;
       border: 1px solid transparent;
@@ -126,7 +126,7 @@ samp:not(.swatch) {
     }
 
     &:not(.border, .text, .dark) {
-      border-color: var(--rh-color-border-strong-on-light);
+      border-color: var(--rh-color-border-strong-on-light, #151515);
     }
   }
 
@@ -137,33 +137,33 @@ samp:not(.swatch) {
 
   /* Box shadow */
   &.box-shadow {
-    height: var(--rh-length-2xl);
+    height: var(--rh-length-2xl, 32px);
     aspect-ratio: 1;
-    border-radius: var(--rh-border-radius-default);
+    border-radius: var(--rh-border-radius-default, 3px);
     box-shadow: var(--samp-box-shadow);
     display: block;
   }
 
   /* Border */
   &.border {
-    width: var(--rh-length-2xl);
+    width: var(--rh-length-2xl, 32px);
     aspect-ratio: 2;
     display: block;
     border-style: solid;
-    border-width: var(--samp-space-size, var(--rh-border-width-md));
-    border-color: var(--samp-color, var(--rh-color-border-strong-on-light));
-    border-radius: var(--samp-radius, var(--rh-border-radius-default));
+    border-width: var(--samp-space-size, var(--rh-border-width-md, 2px));
+    border-color: var(--samp-color, var(--rh-color-border-strong-on-light, #151515));
+    border-radius: var(--samp-radius, var(--rh-border-radius-default, 3px));
 
     &.sm {
-      border-width: var(--samp-space-size, var(--rh-border-width-sm));
+      border-width: var(--samp-space-size, var(--rh-border-width-sm, 1px));
     }
 
     &.md {
-      border-width: var(--samp-space-size, var(--rh-border-width-md));
+      border-width: var(--samp-space-size, var(--rh-border-width-md, 2px));
     }
 
     &.lg {
-      border-width: var(--samp-space-size, var(--rh-border-width-lg));
+      border-width: var(--samp-space-size, var(--rh-border-width-lg, 3px));
     }
   }
 
@@ -172,23 +172,23 @@ samp:not(.swatch) {
     opacity: var(--samp-opacity);
     background-color: black;
     display: block;
-    width: var(--rh-length-xl);
+    width: var(--rh-length-xl, 24px);
     aspect-ratio: 1;
   }
 
   /* Breakpoints */
   &.breakpoint img {
-    max-height: var(--rh-length-3xl);
+    max-height: var(--rh-length-3xl, 48px);
   }
 }
 
 samp.swatch {
   width: max-content;
-  border-radius: var(--rh-border-radius-pill);
-  border-width: var(--rh-border-width-sm);
+  border-radius: var(--rh-border-radius-pill, 64px);
+  border-width: var(--rh-border-width-sm, 1px);
   border-style: solid;
   border-color: oklch(from var(--swatch-color) calc(l + var(--_offset)) c h);
-  padding: var(--rh-space-xs) var(--rh-space-md);
+  padding: var(--rh-space-xs, 4px) var(--rh-space-md, 8px);
   display: inline;
   position: relative;
 
@@ -202,43 +202,48 @@ samp.swatch {
 
   &.color {
     transition-property: background-color, border-color;
-    transition-duration: var(--rh-animation-speed);
-    transition-timing-function: var(--rh-animation-timing);
+    transition-duration: var(--rh-animation-speed, 0.3s);
+    transition-timing-function:
+      var(--rh-animation-timing,
+        cubic-bezier(0.465, 0.183, 0.153, 0.946));
     background-color: var(--swatch-color);
-    font-family: var(--rh-font-family-body-text);
-    font-size: var(--rh-font-size-body-text-sm);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+    font-size: var(--rh-font-size-body-text-sm, 0.875rem);
 
     &.isLight {
-      color: var(--rh-color-text-primary-on-light);
+      color: var(--rh-color-text-primary-on-light, #151515);
     }
 
     &.isDark {
-      color: var(--rh-color-text-primary-on-dark);
+      color: var(--rh-color-text-primary-on-dark, #ffffff);
     }
   }
 
   &.font {
     color: var(--swatch-color);
-    transition: color var(--rh-animation-speed) var(--rh-animation-timing);
-    font-size: var(--rh-font-size-heading-lg);
-    font-weight: var(--rh-font-weight-heading-bold);
-    border-radius: var(--rh-border-radius-default);
-    padding: var(--rh-space-sm) var(--rh-space-md);
+    transition:
+      color var(--rh-animation-speed, 0.3s)
+      var(--rh-animation-timing,
+        cubic-bezier(0.465, 0.183, 0.153, 0.946));
+    font-size: var(--rh-font-size-heading-lg, 2.25rem);
+    font-weight: var(--rh-font-weight-heading-bold, 700);
+    border-radius: var(--rh-border-radius-default, 3px);
+    padding: var(--rh-space-sm, 6px) var(--rh-space-md, 8px);
 
     & span:last-child {
-      font-size: var(--rh-font-size-body-text-md);
+      font-size: var(--rh-font-size-body-text-md, 1rem);
     }
   }
 
   &.border {
     border-color: var(--swatch-color);
-    border-width: var(--rh-border-width-lg);
+    border-width: var(--rh-border-width-lg, 3px);
   }
 
   &.icon {
     display: inline-flex;
     align-items: center;
-    gap: var(--rh-space-xs);
+    gap: var(--rh-space-xs, 4px);
 
     & rh-icon {
       color: var(--swatch-color);

--- a/uxdot/uxdot-spacer-tokens-table.ts
+++ b/uxdot/uxdot-spacer-tokens-table.ts
@@ -12,6 +12,8 @@ import { StringListConverter } from '@patternfly/pfe-core';
 
 import '@rhds/elements/rh-table/rh-table.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import './uxdot-copy-button.js';
 
 import styles from './uxdot-spacer-tokens-table.css';
@@ -43,6 +45,7 @@ const getToken = (name: string) => {
 /**
  * Reads token data from @rhds/tokens and outputs a table for specified tokens
  */
+@themable
 @customElement('uxdot-spacer-tokens-table')
 export class UxdotSpacerTokensTable extends LitElement {
   static styles = [styles];

--- a/uxdot/uxdot-toc-item.css
+++ b/uxdot/uxdot-toc-item.css
@@ -9,19 +9,19 @@
    * pattern level style that should be in the pattern layer.
    */
   @container main (min-width: 1440px) {
-    padding-block-start: var(--_uxdot-toc-item-first-padding-block-start, var(--rh-space-md));
+    padding-block-start: var(--_uxdot-toc-item-first-padding-block-start, var(--rh-space-md, 8px));
   }
 }
 
 a {
   position: relative;
   outline: none;
-  padding-block-end: var(--_uxdot-toc-item-padding-block-end, var(--rh-space-lg));
+  padding-block-end: var(--_uxdot-toc-item-padding-block-end, var(--rh-space-lg, 16px));
   text-decoration: none;
   color: var(--rh-color-interactive-primary-default);
-  font-size: var(--_uxdot-toc-item-font-size, var(--rh-font-size-body-text-lg));
+  font-size: var(--_uxdot-toc-item-font-size, var(--rh-font-size-body-text-lg, 1.125rem));
   display: inline-flex;
-  gap: var(--rh-space-lg);
+  gap: var(--rh-space-lg, 16px);
   align-items: first baseline;
 
   svg {
@@ -68,11 +68,11 @@ slot[name='expanded'] {
 }
 
 ::slotted(uxdot-toc-list) {
-  --_uxdot-toc-item-padding-block-end: var(--rh-space-md);
+  --_uxdot-toc-item-padding-block-end: var(--rh-space-md, 8px);
   --_uxdot-toc-item-first-padding-block-start: 0;
   --_uxdot-toc-item-show-arrow: none;
-  --_uxdot-toc-item-font-size: var(--rh-font-size-body-text-md);
+  --_uxdot-toc-item-font-size: var(--rh-font-size-body-text-md, 1rem);
 
   margin-block-start: 0;
-  margin-inline-start: var(--rh-space-2xl);
+  margin-inline-start: var(--rh-space-2xl, 32px);
 }

--- a/uxdot/uxdot-toc-list.css
+++ b/uxdot/uxdot-toc-list.css
@@ -2,7 +2,7 @@
   display: block;
   columns: 16rem auto;
   padding: 0;
-  margin-block: var(--rh-space-lg) 0;
+  margin-block: var(--rh-space-lg, 16px) 0;
 
   /* TODO: This style is specific to the implementation on ux.redhat.com,
    * not ideal for the component lightdom files, maybe this is a

--- a/uxdot/uxdot-toc.css
+++ b/uxdot/uxdot-toc.css
@@ -11,7 +11,7 @@
    * pattern level style that should be in the pattern layer.
    */
   @container main (min-width: 1440px) {
-    height: calc(100dvh - (var(--uxdot-masthead-max-height) + var(--rh-space-2xl) * 5));
+    height: calc(100dvh - (var(--uxdot-masthead-max-height) + var(--rh-space-2xl, 32px) * 5));
     overflow-y: scroll;
   }
 }
@@ -19,9 +19,9 @@
 details {
   display: flex;
   flex-direction: column;
-  padding-inline: var(--rh-space-xl);
-  border-inline-start: var(--rh-border-width-lg) solid transparent;
-  border: var(--rh-border-width-sm) solid var(--rh-color-border-subtle);
+  padding-inline: var(--rh-space-xl, 24px);
+  border-inline-start: var(--rh-border-width-lg, 3px) solid transparent;
+  border: var(--rh-border-width-sm, 1px) solid var(--rh-color-border-subtle);
 }
 
 details[open]:after {
@@ -30,23 +30,23 @@ details[open]:after {
   inset-block: 0;
   inset-inline-start: 0;
   inset-block-start: -1px;
-  width: var(--rh-border-width-lg);
-  background-color: var(--rh-color-brand-red-on-light);
+  width: var(--rh-border-width-lg, 3px);
+  background-color: var(--rh-color-brand-red-on-light, #ee0000);
 }
 
 summary {
   list-style: none;
   display: inline-flex;
-  gap: var(--rh-space-sm);
+  gap: var(--rh-space-sm, 6px);
   align-items: center;
-  padding-block: var(--rh-space-lg);
+  padding-block: var(--rh-space-lg, 16px);
 }
 
 summary,
 .summary {
-  font-family: var(--rh-font-family-body-text);
-  font-size: var(--rh-font-size-body-text-xl) !important;
-  font-weight: var(--rh-font-weight-body-text-medium);
+  font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+  font-size: var(--rh-font-size-body-text-xl, 1.25rem) !important;
+  font-weight: var(--rh-font-weight-body-text-medium, 500);
 }
 
 summary:before {
@@ -69,7 +69,7 @@ details[open] > summary:before {
 }
 
 nav {
-  margin-block-end: var(--rh-space-lg);
+  margin-block-end: var(--rh-space-lg, 16px);
 }
 
 #expanded {

--- a/uxdot/uxdot-toc.ts
+++ b/uxdot/uxdot-toc.ts
@@ -4,11 +4,14 @@ import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './uxdot-toc.css';
 import listStyles from './uxdot-toc-list.css';
 import itemStyles from './uxdot-toc-item.css';
 import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
 
+@themable
 @customElement('uxdot-toc')
 export class UxdotToc extends LitElement {
   static styles = [styles];
@@ -47,6 +50,7 @@ export class UxdotTocList extends LitElement {
 }
 
 
+@themable
 @customElement('uxdot-toc-item')
 export class UxdotTocItem extends LitElement {
   static styles = [itemStyles];


### PR DESCRIPTION
## What I did

Resolved all require-token-fallback and max-line-length violations in uxdot component stylesheets.

1. Added `@themable` decorator to uxdot elements that use contextual theme tokens, so those tokens are exempted from needing inline fallbacks
2. Applied fallbacks via `stylelint --fix` to non-theme tokens across all 16 uxdot CSS files
3. Fixed line-length and indentation violations by breaking long light-dark(), cubic-bezier(), and border shorthand values into multi-line format

Closes #3134

## Testing Instructions

1.

## Notes to Reviewers

Remaining lint errors should be `elements/**/*.css` and the `felt-theme-preview.css`.