### PR TITLE
fix(jumplinks): text overflow wrap and felt pill border radius reduction

### DIFF
--- a/.changeset/tricky-flowers-lie.md
+++ b/.changeset/tricky-flowers-lie.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-jump-links>`: corrected text wrap when long jump links content is used
+  

--- a/.changeset/tricky-flowers-lie.md
+++ b/.changeset/tricky-flowers-lie.md
@@ -2,5 +2,5 @@
 "@rhds/elements": patch
 ---
 
-`<rh-jump-links>`: corrected text wrap when long jump links content is used
+`<rh-jump-links>`: correct text wrapping when long link text is used
   

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -2011,7 +2011,7 @@
 
     /* Pill hover on the <a> */
     --rh-jump-link-hover-background-color: var(--felt-preview-color-interactive-fill-plain-hover);
-    --rh-jump-link-hover-border-radius: var(--felt-preview-border-radius-pill);
+    --rh-jump-link-hover-border-radius: var(--felt-preview-border-radius-default);
 
     /* Keep text color subtle on hover/focus (same as default) */
     --rh-color-text-primary:

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -2009,7 +2009,7 @@
     /* Gap between track and pill */
     --rh-jump-link-gap: var(--felt-preview-space-md);
 
-    /* Pill hover on the <a> */
+    /* Pseudo-pill hover on the <a> */
     --rh-jump-link-hover-background-color: var(--felt-preview-color-interactive-fill-plain-hover);
     --rh-jump-link-hover-border-radius: var(--felt-preview-border-radius-default);
 

--- a/elements/rh-jump-links/demo/felt-theme.html
+++ b/elements/rh-jump-links/demo/felt-theme.html
@@ -4,23 +4,6 @@ description: Vertical, nested, and horizontal jump links with the [Project Felt]
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 
 <style>
-  #jump-links-demo-container {
-    display: grid;
-    grid-template-columns: max-content auto;
-    gap: var(--rh-space-2xl, 32px);
-    padding: var(--rh-space-lg, 16px);
-
-    aside {
-      h2 {
-        font-weight: var(--rh-font-weight-heading-medium);
-        font-family: var(--rh-font-family-body-text);
-        font-size: var(--rh-font-size-body-text-md);
-        line-height: var(--rh-line-height-body-text, 1.5);
-        margin-block-end: var(--rh-space-lg);
-      }
-    }
-  }
-
   #horizontal-demo {
     padding: var(--rh-space-lg, 16px);
 

--- a/elements/rh-jump-links/rh-jump-link.css
+++ b/elements/rh-jump-links/rh-jump-link.css
@@ -82,7 +82,6 @@ a {
     & a {
       /** Maximum width for each vertical jump link */
       max-width: var(--rh-jump-link-max-width, calc(var(--rh-length-md, 8px) * 40));
-      min-width: max-content;
       padding-block:
         var(--_link-padding-block,
           /** Vertical link block padding */


### PR DESCRIPTION
## What I did

1.  Corrected jump links text wrap when long jump links text is used
2. Applied a reduced border-radius to felt theme preview for when jump links wrap to two lines.

Closes #3167

## Testing Instructions

1.

## Notes to Reviewers
