### PR TITLE
fix(scheme-dropdown): correct option labels, delegatesFocus, and SSR

### DIFF
--- a/.changeset/afraid-colts-cry.md
+++ b/.changeset/afraid-colts-cry.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-scheme-dropdown>`: fix custom select option label names

--- a/elements/rh-scheme-dropdown/demo/localization.html
+++ b/elements/rh-scheme-dropdown/demo/localization.html
@@ -1,0 +1,26 @@
+---
+description: "Scheme dropdown with Spanish accessible labels for light, dark, and system options."
+---
+<rh-scheme-dropdown accessible-label="Tema"
+                    accessible-label-light="Claro"
+                    accessible-label-dark="Oscuro"
+                    accessible-label-system="Sistema"></rh-scheme-dropdown>
+
+<script type="module">
+  import '@rhds/elements/rh-scheme-dropdown/rh-scheme-dropdown.js';
+</script>
+
+<style>
+  body {
+    color-scheme: light dark;
+    background-color: var(--rh-color-surface);
+    color: var(--rh-color-text-primary);
+  }
+
+  rh-scheme-dropdown {
+    /* Wider than the English defaults so Spanish option text fits. */
+    --rh-scheme-dropdown-select-inline-size: 120px;
+    --rh-scheme-dropdown-picker-inline-size: 160px;
+    padding: var(--rh-space-md, 8px);
+  }
+</style>

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -1,4 +1,5 @@
-import { html, isServer, LitElement } from 'lit';
+import { isServer, LitElement } from 'lit';
+import { html, unsafeStatic } from 'lit/static-html.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 
@@ -98,6 +99,16 @@ export class RhSchemeDropdown extends LitElement {
   }
 
   render() {
+    // IMPORTANT: do not put Lit child bindings (${...}) inside <option>.
+    // In Custom Select browsers, <selectedcontent> cloneNode()'s the selected
+    // option — including Lit's <!--?lit--> markers — which desyncs template
+    // parts and renders boolean values as labels ("false"). See lit#5349.
+    // unsafeStatic inlines escaped label text with no ChildPart markers.
+    // Author-facing strings must be HTML-escaped before unsafeStatic.
+    const labelSystem = unsafeStatic(this.#escapeHtml(this.accessibleLabelSystem));
+    const labelLight = unsafeStatic(this.#escapeHtml(this.accessibleLabelLight));
+    const labelDark = unsafeStatic(this.#escapeHtml(this.accessibleLabelDark));
+
     return html`
       <label for="scheme-dropdown" class="visually-hidden">${this.accessibleLabel}:</label>
       <select id="scheme-dropdown" @change="${this.#onChange}">
@@ -107,21 +118,35 @@ export class RhSchemeDropdown extends LitElement {
         </button>
         <option value="light dark" ?selected="${this.#isSystem}">
           <rh-icon set="ui" icon="auto-light-dark-mode"></rh-icon>
-          <span class="option-text">${this.accessibleLabelSystem}</span>
+          <span class="option-text">${labelSystem}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
         <option value="light" ?selected="${this.#isLight}">
           <rh-icon set="ui" icon="light-mode"></rh-icon>
-          <span class="option-text">${this.accessibleLabelLight}</span>
+          <span class="option-text">${labelLight}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
         <option value="dark" ?selected="${this.#isDark}">
           <rh-icon set="ui" icon="dark-mode"></rh-icon>
-          <span class="option-text">${this.accessibleLabelDark}</span>
+          <span class="option-text">${labelDark}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
       </select>
     `;
+  }
+
+  /**
+   * Escapes author-facing localization strings before inlining them
+   * with unsafeStatic. Required because unsafeStatic inserts raw
+   * HTML into the template.
+   * @param text - Plain text to escape for safe HTML inlining.
+   */
+  #escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
   }
 
   /**

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -119,7 +119,8 @@ export class RhSchemeDropdown extends LitElement {
   }
 
   /**
-   * Syncs `select.value` to `scheme` prop so the control matches after SSR hydration.
+   * Syncs `select.value` and option `selected` attrs to `scheme` after SSR
+   * hydration. Lit's `?selected` on `<option>` can stay stale otherwise.
    * @param changed - Reactive properties that changed this update cycle
    */
   protected override updated(changed: Map<PropertyKey, unknown>): void {
@@ -133,6 +134,15 @@ export class RhSchemeDropdown extends LitElement {
       const value = this.scheme ?? 'light dark';
       if (select.value !== value) {
         select.value = value;
+      }
+
+      // Realign `selected` attribute even when select.value already matches.
+      for (const option of select.options) {
+        if (option.value === value) {
+          option.setAttribute('selected', '');
+        } else {
+          option.removeAttribute('selected');
+        }
       }
     }
   }

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -50,15 +50,6 @@ export class RhSchemeDropdown extends LitElement {
     delegatesFocus: true,
   };
 
-  /** Whether the light option is currently selected. */
-  #isLight = false;
-
-  /** Whether the dark option is currently selected. */
-  #isDark = false;
-
-  /** Whether the system default option is currently selected. */
-  #isSystem = false;
-
   /**
    * Current color scheme setting. Reflects to the `scheme` attribute and
    * initializes from `localStorage.rhdsColorScheme` when available.
@@ -89,20 +80,6 @@ export class RhSchemeDropdown extends LitElement {
    */
   @property({ attribute: 'accessible-label-system' }) accessibleLabelSystem = 'System';
 
-  /**
-   * Syncs the selected-state flags before each render so the
-   * template always reflects the current `scheme` value.
-   */
-  protected override willUpdate(): void {
-    if (isServer) {
-      return;
-    }
-
-    this.#isLight = this.scheme === 'light';
-    this.#isDark = this.scheme === 'dark';
-    this.#isSystem = !this.#isLight && !this.#isDark;
-  }
-
   render() {
     // IMPORTANT: do not put Lit child bindings (${...}) inside <option>.
     // In Custom Select browsers, <selectedcontent> cloneNode()'s the selected
@@ -121,17 +98,18 @@ export class RhSchemeDropdown extends LitElement {
           <selectedcontent></selectedcontent>
           <rh-icon set="microns" icon="caret-down-fill"></rh-icon>
         </button>
-        <option value="light dark" ?selected="${this.#isSystem}">
+        <option value="light dark"
+                ?selected="${this.scheme !== 'light' && this.scheme !== 'dark'}">
           <rh-icon set="ui" icon="auto-light-dark-mode"></rh-icon>
           <span class="option-text">${labelSystem}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
-        <option value="light" ?selected="${this.#isLight}">
+        <option value="light" ?selected="${this.scheme === 'light'}">
           <rh-icon set="ui" icon="light-mode"></rh-icon>
           <span class="option-text">${labelLight}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
-        <option value="dark" ?selected="${this.#isDark}">
+        <option value="dark" ?selected="${this.scheme === 'dark'}">
           <rh-icon set="ui" icon="dark-mode"></rh-icon>
           <span class="option-text">${labelDark}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -84,10 +84,10 @@ export class RhSchemeDropdown extends LitElement {
     // IMPORTANT: no Lit child bindings (`${...}`) inside `<option>` — `<selectedcontent>`
     // `cloneNode()` copies `<!--?lit-->` markers and breaks the template (lit#5349).
     // Escaped `unsafeStatic` inlines labels without markers; Cannot use `.textContent`
-    // bindings because they flatten rich option content under appearance: base-select.
-    const labelSystem = unsafeStatic(this.#escapeHtml(this.accessibleLabelSystem));
-    const labelLight = unsafeStatic(this.#escapeHtml(this.accessibleLabelLight));
-    const labelDark = unsafeStatic(this.#escapeHtml(this.accessibleLabelDark));
+    // bindings because they flatten rich option content under `appearance: base-select`.
+    const labelSystem = unsafeStatic(this.#escapeHtml(this.accessibleLabelSystem ?? 'System'));
+    const labelLight = unsafeStatic(this.#escapeHtml(this.accessibleLabelLight ?? 'Light'));
+    const labelDark = unsafeStatic(this.#escapeHtml(this.accessibleLabelDark ?? 'Dark'));
 
     return html`
       <label for="scheme-dropdown" class="visually-hidden">${this.accessibleLabel}:</label>
@@ -148,11 +148,12 @@ export class RhSchemeDropdown extends LitElement {
   /**
    * Escapes author-facing localization strings before inlining them
    * with unsafeStatic. Required because unsafeStatic inserts raw
-   * HTML into the template.
-   * @param text - Plain text to escape for safe HTML inlining.
+   * HTML into the template. Nullish values fall back to English defaults
+   * via nullish coalescing (`??`).
+   * @param text - Plain text to escape for safe HTML inlining; nullish becomes ''.
    */
-  #escapeHtml(text: string): string {
-    return text
+  #escapeHtml(text?: string | null): string {
+    return String(text ?? '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -81,12 +81,10 @@ export class RhSchemeDropdown extends LitElement {
   @property({ attribute: 'accessible-label-system' }) accessibleLabelSystem = 'System';
 
   render() {
-    // IMPORTANT: do not put Lit child bindings (${...}) inside <option>.
-    // In Custom Select browsers, <selectedcontent> cloneNode()'s the selected
-    // option — including Lit's <!--?lit--> markers — which desyncs template
-    // parts and renders boolean values as labels ("false"). See lit#5349.
-    // unsafeStatic inlines escaped label text with no ChildPart markers.
-    // Author-facing strings must be HTML-escaped before unsafeStatic.
+    // IMPORTANT: no Lit child bindings (`${...}`) inside `<option>` — `<selectedcontent>`
+    // `cloneNode()` copies `<!--?lit-->` markers and breaks the template (lit#5349).
+    // Escaped `unsafeStatic` inlines labels without markers; Cannot use `.textContent`
+    // bindings because they flatten rich option content under appearance: base-select.
     const labelSystem = unsafeStatic(this.#escapeHtml(this.accessibleLabelSystem));
     const labelLight = unsafeStatic(this.#escapeHtml(this.accessibleLabelLight));
     const labelDark = unsafeStatic(this.#escapeHtml(this.accessibleLabelDark));

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -80,6 +80,16 @@ export class RhSchemeDropdown extends LitElement {
    */
   @property({ attribute: 'accessible-label-system' }) accessibleLabelSystem = 'System';
 
+  /**
+   * Valid `<select>` value for the current `scheme`. Unknown or nullish
+   * values map to System (`light dark`) so `render()` and `updated()` stay aligned.
+   */
+  get #resolvedScheme(): Scheme {
+    return this.scheme === 'light' || this.scheme === 'dark' ?
+      this.scheme
+      : 'light dark';
+  }
+
   render() {
     // IMPORTANT: no Lit child bindings (`${...}`) inside `<option>` — `<selectedcontent>`
     // `cloneNode()` copies `<!--?lit-->` markers and breaks the template (lit#5349).
@@ -97,17 +107,17 @@ export class RhSchemeDropdown extends LitElement {
           <rh-icon set="microns" icon="caret-down-fill"></rh-icon>
         </button>
         <option value="light dark"
-                ?selected="${this.scheme !== 'light' && this.scheme !== 'dark'}">
+                ?selected="${this.#resolvedScheme === 'light dark'}">
           <rh-icon set="ui" icon="auto-light-dark-mode"></rh-icon>
           <span class="option-text">${labelSystem}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
-        <option value="light" ?selected="${this.scheme === 'light'}">
+        <option value="light" ?selected="${this.#resolvedScheme === 'light'}">
           <rh-icon set="ui" icon="light-mode"></rh-icon>
           <span class="option-text">${labelLight}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
         </option>
-        <option value="dark" ?selected="${this.scheme === 'dark'}">
+        <option value="dark" ?selected="${this.#resolvedScheme === 'dark'}">
           <rh-icon set="ui" icon="dark-mode"></rh-icon>
           <span class="option-text">${labelDark}</span>
           <rh-icon set="ui" icon="check" class="checkmark"></rh-icon>
@@ -117,7 +127,7 @@ export class RhSchemeDropdown extends LitElement {
   }
 
   /**
-   * Syncs `select.value` and option `selected` attrs to `scheme` after SSR
+   * Syncs `select.value` and option `selected` attrs to `#resolvedScheme` after SSR
    * hydration. Lit's `?selected` on `<option>` can stay stale otherwise.
    * @param changed - Reactive properties that changed this update cycle
    */
@@ -129,7 +139,8 @@ export class RhSchemeDropdown extends LitElement {
 
     const select = this.shadowRoot?.querySelector('select');
     if (select) {
-      const value = this.scheme ?? 'light dark';
+      // Use the same fallback as render() so malformed scheme values keep System selected.
+      const value = this.#resolvedScheme;
       if (select.value !== value) {
         select.value = value;
       }

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -119,6 +119,25 @@ export class RhSchemeDropdown extends LitElement {
   }
 
   /**
+   * Syncs `select.value` to `scheme` prop so the control matches after SSR hydration.
+   * @param changed - Reactive properties that changed this update cycle
+   */
+  protected override updated(changed: Map<PropertyKey, unknown>): void {
+    super.updated(changed);
+    if (isServer) {
+      return;
+    }
+
+    const select = this.shadowRoot?.querySelector('select');
+    if (select) {
+      const value = this.scheme ?? 'light dark';
+      if (select.value !== value) {
+        select.value = value;
+      }
+    }
+  }
+
+  /**
    * Escapes author-facing localization strings before inlining them
    * with unsafeStatic. Required because unsafeStatic inserts raw
    * HTML into the template.

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -45,6 +45,11 @@ export class SchemeChangedEvent extends Event {
 export class RhSchemeDropdown extends LitElement {
   static styles = [styles];
 
+  static override readonly shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   /** Whether the light option is currently selected. */
   #isLight = false;
 

--- a/elements/rh-scheme-dropdown/test/rh-scheme-dropdown.spec.ts
+++ b/elements/rh-scheme-dropdown/test/rh-scheme-dropdown.spec.ts
@@ -334,6 +334,22 @@ describe('<rh-scheme-dropdown>', function() {
     it('should be accessible with custom labels', async function() {
       await expect(element).to.be.accessible();
     });
+
+    // Class field defaults only apply at construction; clearing labels at runtime
+    // (i18n load gap, or attribute removal) must not throw in render().
+    it('falls back to English option labels when accessible labels are cleared', async function() {
+      // Cast: public props are typed as string, but Lit/JS can set nullish at runtime.
+      element.accessibleLabelSystem = undefined as unknown as string;
+      element.accessibleLabelLight = undefined as unknown as string;
+      element.accessibleLabelDark = undefined as unknown as string;
+      await element.updateComplete;
+
+      const snapshot = await a11ySnapshot();
+      expect(snapshot)
+          .to.axContainQuery({ role: 'option', name: /System/ }).and
+          .to.axContainQuery({ role: 'option', name: /Light/ }).and
+          .to.axContainQuery({ role: 'option', name: /Dark/ });
+    });
   });
 
   describe('scheme-changed event', function() {

--- a/elements/rh-scheme-dropdown/test/rh-scheme-dropdown.spec.ts
+++ b/elements/rh-scheme-dropdown/test/rh-scheme-dropdown.spec.ts
@@ -497,5 +497,20 @@ describe('<rh-scheme-dropdown>', function() {
       await element.updateComplete;
       expect(selectedAttrValues(element)).to.deep.equal(['light']);
     });
+
+    it('keeps System selected for an unexpected scheme value', async function() {
+      element.scheme = 'light';
+      await element.updateComplete;
+
+      // Malformed non-null string must fall back to System (same as render()).
+      element.scheme = 'not-a-scheme' as typeof element.scheme;
+      await element.updateComplete;
+
+      const select = element.shadowRoot!.querySelector('select')!;
+      expect(select.value).to.equal('light dark');
+      expect(selectedAttrValues(element)).to.deep.equal(['light dark']);
+      const snapshot = await a11ySnapshot();
+      expect(snapshot).to.axContainQuery({ role: 'combobox', value: /System/ });
+    });
   });
 });

--- a/elements/rh-scheme-dropdown/test/rh-scheme-dropdown.spec.ts
+++ b/elements/rh-scheme-dropdown/test/rh-scheme-dropdown.spec.ts
@@ -433,5 +433,53 @@ describe('<rh-scheme-dropdown>', function() {
       const snapshot = await a11ySnapshot();
       expect(snapshot).to.axContainQuery({ role: 'combobox', value: /System/ });
     });
+
+    /** Option values that currently have the `selected` content attribute. */
+    function selectedAttrValues(el: RhSchemeDropdown): string[] {
+      const select = el.shadowRoot!.querySelector('select')!;
+      return [...select.options]
+          .filter(option => option.hasAttribute('selected'))
+          .map(option => option.value);
+    }
+
+    it('moves the selected content attribute to Light', async function() {
+      element.scheme = 'light';
+      await element.updateComplete;
+      expect(selectedAttrValues(element)).to.deep.equal(['light']);
+    });
+
+    it('moves the selected content attribute to Dark', async function() {
+      element.scheme = 'dark';
+      await element.updateComplete;
+      expect(selectedAttrValues(element)).to.deep.equal(['dark']);
+    });
+
+    it('moves the selected content attribute to System', async function() {
+      element.scheme = 'dark';
+      await element.updateComplete;
+      element.scheme = 'light dark';
+      await element.updateComplete;
+      expect(selectedAttrValues(element)).to.deep.equal(['light dark']);
+    });
+
+    it('repairs a stale selected attribute after requestUpdate', async function() {
+      element.scheme = 'light';
+      await element.updateComplete;
+
+      // Stale selected attr (SSR / Lit hydration quirk)
+      const select = element.shadowRoot!.querySelector('select')!;
+      for (const option of select.options) {
+        if (option.value === 'light dark') {
+          option.setAttribute('selected', '');
+        } else {
+          option.removeAttribute('selected');
+        }
+      }
+      expect(selectedAttrValues(element)).to.deep.equal(['light dark']);
+
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(selectedAttrValues(element)).to.deep.equal(['light']);
+    });
   });
 });

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -319,6 +319,7 @@ export default async function(eleventyConfig: UserConfig) {
       'elements/rh-navigation-vertical/rh-navigation-vertical.ts',
       'elements/rh-navigation-vertical/rh-navigation-vertical-list.ts',
       'elements/rh-pagination/rh-pagination.ts',
+      'elements/rh-scheme-dropdown/rh-scheme-dropdown.ts',
       'elements/rh-scheme-toggle/rh-scheme-toggle.ts',
       'elements/rh-select/rh-select.ts',
       'elements/rh-select/rh-option.ts',
@@ -361,7 +362,6 @@ export default async function(eleventyConfig: UserConfig) {
       // still not working nicely with ssr
       // 'elements/rh-audio-player/rh-audio-player.ts',
       // 'elements/rh-footer/rh-footer.ts',
-      // 'elements/rh-scheme-dropdown/rh-scheme-dropdown.ts',
     ],
     slotControllerElements: [
       'rh-alert',


### PR DESCRIPTION
## What I did

1. Fix customizable `<select>` option labels rendering as `"false"` / mangled text under SSR + hydration.
    * Lit child bindings inside `<option>` leave `<!--lit-part-->` markers that `<selectedcontent>` clones. This is a problem. See [lit#5349](https://github.com/lit/lit/issues/5349).
    * Option labels now use escaped `unsafeStatic` text instead.
1. Move `?selected` derivation into `render()` so SSR marks the correct option (no more client-only `#isLight` / `#isDark` / `#isSystem` flags).
1. Add `delegatesFocus` so host `.focus()` lands on the internal `<select>`.
1. Enable `<rh-scheme-dropdown>` in the Eleventy Lit SSR `componentModules` list.
1. After hydration, sync `select.value` and each option’s `selected` content attribute to scheme in `updated()` (Lit’s `?selected` can stay stale after SSR / user interaction).
1. Fall back nullish `accessible-label-*` values to English defaults (`System` / `Light` / `Dark`) so `render()` does not throw.
1. Map unknown or malformed `scheme` values to System (`light dark`) via `#resolvedScheme`.
1. Add tests for selected-attr sync, nullish accessible labels, and malformed scheme fallback.
1. Add a localization demo.

## Testing Instructions

1. First, view the [scheme dropdown demo on uxdot](https://ux.redhat.com/elements/scheme-dropdown/demo/) in Chrome/Edge.
1. Note the broken option labels (`false` / mangled text).
1. Now view the [scheme dropdown demo on this DP](https://deploy-preview-3183--red-hat-design-system.netlify.app/elements/scheme-dropdown/demo/).
    * Labels should read **System**, **Light**, and **Dark**
    * System should be selected by default (unless `localStorage.rhdsColorScheme` is set)
1. View page source on the DP demo and confirm:
    * Declarative shadow DOM is present on `<rh-scheme-dropdown>`
    * `<option value="light dark" selected>` is in the SSR HTML
    * No `<!--lit-part-->` / `<!--?lit-->` comments inside `<option>`
1. Switch Light → Dark → System and confirm selection + `document.body` color-scheme update.
1. Tab to the control and confirm the focus ring appears (host focus is delegated to the `<select>`).
1. Check the [localization demo on this DP](https://deploy-preview-3183--red-hat-design-system.netlify.app/elements/scheme-dropdown/demo/localization/) — labels should be **Sistema**, **Claro**, and **Oscuro**.
1. Hard-refresh demos and confirm there are no Lit hydration errors in the console related to option parts.
1. After switching options, confirm in DevTools that `selected` moves with the active `<option>` (not stuck on System).
1. In DevTools, set a nonsense `scheme` value (or clear an `accessible-label-*` prop) and confirm System / English defaults still show.

## Notes to Reviewers

Workaround for [lit#5349](https://github.com/lit/lit/issues/5349): child bindings inside `<option>` break under custom select / hydration. `?selected` is fine for SSR first paint, but can go stale after hydration — `updated()` realigns `select.value` and the `selected` attributes.

`rh-scheme-dropdown` was previously commented out of `componentModules` as “still not working nicely with ssr” — this PR re-enables it now that the custom-select label issue is addressed.