### PR TITLE
docs(project felt demo): turn switch on by default

### DIFF
--- a/docs/theming/themes/project-felt/demos.md
+++ b/docs/theming/themes/project-felt/demos.md
@@ -251,13 +251,16 @@ Preview the Project Felt theme on the elements below. Toggle the switch to compa
         root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
       }
     }
-    feltSwitch.addEventListener('change', function() {
+    function applyFeltTheme() {
       for (const pattern of document.querySelectorAll('uxdot-pattern')) {
         pattern.shadowRoot
           ?.querySelector('#content')
           ?.classList.toggle('felt-preview', feltSwitch.checked);
       }
-    });
+    }
+
+    applyFeltTheme();
+    feltSwitch.addEventListener('change', applyFeltTheme);
   }
 
   const nav = document.querySelector('#demos-nav');

--- a/docs/theming/themes/project-felt/demos.md
+++ b/docs/theming/themes/project-felt/demos.md
@@ -145,9 +145,10 @@ subnav:
 
 ## Try it out
 
-To apply the Project Felt preview theme to all of the elements below, toggle the switch.
+Preview the Project Felt theme on the elements below. Toggle the switch to compare with the default styles.
 
 <rh-switch id="felt-theme-switch"
+            checked
             message-on="Project Felt preview theme"
             message-off="Off"></rh-switch>
 


### PR DESCRIPTION
## What I did

1. Turned the theme switch on by default.
2. Updated the copy above it to make sense with the "on" state.


## Testing Instructions

1. Check the ["Try it out" section](https://deploy-preview-3185--red-hat-design-system.netlify.app/theming/themes/project-felt/demos/#try-it-out) for both of these changes.
2. Make sure that the revised copy sounds good.

## Notes to Reviewers
Closes #3184 