### PR TITLE
docs: improve link css examples

### DIFF
--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -227,17 +227,40 @@ The following elements are exempt from underlining requirements and should not h
   </uxdot-best-practice>
 </div>
 
-### Example CSS
+## Example CSS
 
-Developers can use the following CSS as a starting point for link underlining:
+Developers can use the following CSS as a starting point for link styling.
 
-- In practice, you will probably want to use a more specific selector than `:is(p, ul, ol, dl) a`, because this example selector applies to all links in paragraphs or lists on a page.
-- This example adds a `max()` function to the `text-underline-offset` property, allowing this value to grow proportionally at large font sizes.
-- As of this writing, Safari has some issues with the `text-decoration` shorthand property, so we separated it out into its component options `(-color, -line, -style, and -thickness)`.
+### Link colors
 
-<rh-code-block actions="wrap copy">
+Base color tokens for all links, including hover, focus, and visited states:
+
+<rh-code-block actions="wrap copy" highlighting="client" language="css" full-height>
   <script type="text/css">
-    :is(p, ul, ol, dl) a {
+    a {
+      color: var(--rh-color-interactive-primary-default);
+      &:hover {
+        color: var(--rh-color-interactive-primary-hover);
+      }
+      &:focus-within {
+        color: var(--rh-color-interactive-primary-focus);
+        &:hover { color: var(--rh-color-interactive-primary-focus); }
+      }
+      &:visited {
+        color: var(--rh-color-interactive-primary-visited-default);
+        &:hover { color: var(--rh-color-interactive-primary-visited-hover); }
+      }
+    }
+  </script>
+</rh-code-block>
+
+### Inline link underlines
+
+When links appear in content (paragraphs, lists, etc.), add dashed underlines that solidify on hover or focus:
+
+<rh-code-block actions="wrap copy" highlighting="client" language="css" full-height>
+  <script type="text/css">
+    :where(p, ul, ol, dl) a {
       text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
       text-decoration-line: underline;
       text-decoration-style: dashed;
@@ -253,6 +276,11 @@ Developers can use the following CSS as a starting point for link underlining:
     }
   </script>
 </rh-code-block>
+
+- The sample selector is broad by design. Scope it to contexts where inline link underlining applies, links that appear alongside non-link text and lack other visual affordance (see [Exceptions](#exceptions) above).
+- The `max()` function on `text-underline-offset` allows the underline gap to grow proportionally at large font size
+s.
+- Older versions of Safari may still have difficulty with the `text-decoration` shorthand property, so we separated it out into its longhand options (`-color`, `-line`, `-style`, and `-thickness`).
 
 ## Behavior
 

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -278,8 +278,7 @@ When links appear in content (paragraphs, lists, etc.), add dashed underlines th
 </rh-code-block>
 
 - The sample selector is broad by design. Scope it to contexts where inline link underlining applies, links that appear alongside non-link text and lack other visual affordance (see [Exceptions](#exceptions) above).
-- The `max()` function on `text-underline-offset` allows the underline gap to grow proportionally at large font size
-s.
+- The `max()` function on `text-underline-offset` allows the underline gap to grow proportionally at large font sizes.
 - Older versions of Safari may still have difficulty with the `text-decoration` shorthand property, so we separated it out into its longhand options (`-color`, `-line`, `-style`, and `-thickness`).
 
 ## Behavior

--- a/docs/foundations/interactions/links/index.md
+++ b/docs/foundations/interactions/links/index.md
@@ -238,17 +238,45 @@ Base color tokens for all links, including hover, focus, and visited states:
 <rh-code-block actions="wrap copy" highlighting="client" language="css" full-height>
   <script type="text/css">
     a {
-      color: var(--rh-color-interactive-primary-default);
+      color: var(--rh-color-interactive-primary-default, 
+        light-dark(
+          var(--rh-color-interactive-primary-default-on-light, #0066cc),
+          var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
+        ));
       &:hover {
-        color: var(--rh-color-interactive-primary-hover);
+        color: var(--rh-color-interactive-primary-hover,
+          light-dark(
+            var(--rh-color-interactive-primary-hover-on-light, #003366),
+            var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)
+        ));
       }
       &:focus-within {
-        color: var(--rh-color-interactive-primary-focus);
-        &:hover { color: var(--rh-color-interactive-primary-focus); }
+        color: var(--rh-color-interactive-primary-focus,
+          light-dark(
+            var(--rh-color-interactive-primary-focus-on-light, #003366),
+            var(--rh-color-interactive-primary-focus-on-dark, #b9dafc)
+          ));
+        &:hover {
+          color: var(--rh-color-interactive-primary-focus,
+            light-dark(
+              var(--rh-color-interactive-primary-focus-on-light, #003366),
+              var(--rh-color-interactive-primary-focus-on-dark, #b9dafc)
+            ));
+        }
       }
       &:visited {
-        color: var(--rh-color-interactive-primary-visited-default);
-        &:hover { color: var(--rh-color-interactive-primary-visited-hover); }
+        color: var(--rh-color-interactive-primary-visited-default,
+          light-dark(
+            var(--rh-color-interactive-primary-visited-default-on-light, #5e40be),
+            var(--rh-color-interactive-primary-visited-default-on-dark, #b6a6e9)
+          ));
+        &:hover {
+          color: var(--rh-color-interactive-primary-visited-hover,
+            light-dark(
+              var(--rh-color-interactive-primary-visited-hover-on-light, #21134d),
+              var(--rh-color-interactive-primary-visited-hover-on-dark, #ece6ff)
+            ));
+        }
       }
     }
   </script>
@@ -261,7 +289,7 @@ When links appear in content (paragraphs, lists, etc.), add dashed underlines th
 <rh-code-block actions="wrap copy" highlighting="client" language="css" full-height>
   <script type="text/css">
     :where(p, ul, ol, dl) a {
-      text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+      text-decoration-color: light-dark(var(--rh-color-gray-50, #707070), var(--rh-color-gray-40, #a3a3a3));
       text-decoration-line: underline;
       text-decoration-style: dashed;
       text-decoration-thickness: var(--rh-border-width-sm, 1px);

--- a/docs/foundations/interactions/links/inline-link-demo.html
+++ b/docs/foundations/interactions/links/inline-link-demo.html
@@ -2,18 +2,6 @@
 <p>This is body text with another <a href="#">inline link</a>. Hover over, tab to, or click the inline links in this demo. Use the color palette picker to see what inline links look like in dark contexts.</p>
 
 <style>
-  :is(p, ul, ol, dl, h1, h2, h3, h4, h5, h6) a {
-        text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
-        text-decoration-line: underline;
-        text-decoration-style: dashed;
-        text-decoration-thickness: 1px;
-        text-underline-offset: max(5px, 0.28em);
-        transition: ease all 0.3s;
-        &:is(:hover, :focus-within) {
-          text-decoration-color: inherit;
-          text-underline-offset: max(6px, 0.33em);
-        }
-      }
   a {
     color: var(--rh-color-interactive-primary-default);
     &:hover { color: var(--rh-color-interactive-primary-hover); }
@@ -29,7 +17,20 @@
     }
   }
 
-  /*The following CSS is not related to link styling */
+  :where(p, ul, ol, dl, h1, h2, h3, h4, h5, h6) a {
+    text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+    text-decoration-thickness: 1px;
+    text-underline-offset: max(5px, 0.28em);
+    transition: ease all 0.3s;
+    &:is(:hover, :focus-within) {
+      text-decoration-color: inherit;
+      text-underline-offset: max(6px, 0.33em);
+    }
+  }
+
+  /* The following CSS is not related to link styling */
   h2 {
     font-family: var(--rh-font-family-heading);
     color: var(--rh-color-text-primary);

--- a/docs/foundations/interactions/links/inline-link-demo.html
+++ b/docs/foundations/interactions/links/inline-link-demo.html
@@ -18,7 +18,7 @@
   }
 
   :where(p, ul, ol, dl, h1, h2, h3, h4, h5, h6) a {
-    text-decoration-color: light-dark(var(--rh-color-gray-50), var(--rh-color-gray-40));
+    text-decoration-color: light-dark(var(--rh-color-gray-50, #707070), var(--rh-color-gray-40, #a3a3a3));
     text-decoration-line: underline;
     text-decoration-style: dashed;
     text-decoration-thickness: 1px;


### PR DESCRIPTION
## What I did

1. Split the single code snippet into two sections: generic link colors (with hover, focus, and visited states) and inline link underlines (scoped to content regions). 
2. Changed the content selector from :is() to :where() for lower specificity, making overrides easier for consumers. 
3. Added syntax highlighting to both code blocks. Rephrased explanatory notes for clarity and updated the outdated Safari shorthand warning.

## Testing Instructions

1.  [View Deploy Preview foundations/links page](https://deploy-preview-3187--red-hat-design-system.netlify.app/foundations/interactions/links/)

## Notes to Reviewers
