### PR TITLE
docs(color): fix improper color page redirection

### DIFF
--- a/docs/_includes/partials/component/sidenav.njk
+++ b/docs/_includes/partials/component/sidenav.njk
@@ -47,11 +47,16 @@
           {%- set sideNavCollection = collections[link.collection] %}
           {%- endif -%}
 
+          {# Tag-based collections can include pages from other sections
+             (e.g. AI guidelines Color is tagged accessibility). Only render
+             links whose URL belongs to this dropdown's section. #}
           {%- for sublink in sideNavCollection -%}
+          {%- if sublink.url.startsWith(link.url) -%}
           {%- set active = sublink.url === page.url -%}
           <rh-navigation-link href="{{ sublink.url }}" {{ 'current-page' if active }}>
             {{- (sublink.data.sidenavTitle or sublink.data.title or sublink.title) -}}
           </rh-navigation-link>
+          {%- endif -%}
           {%- endfor -%}
           {% endif %}
     </rh-navigation-vertical-list>

--- a/docs/_plugins/rhds.ts
+++ b/docs/_plugins/rhds.ts
@@ -256,7 +256,7 @@ export default async function(
     // tag pages `color` (e.g. AI guidelines Color), which would otherwise
     // leak into Overview / Usage / Accessibility.
     const colorCollection = collectionApi.getFilteredByTags('color')
-        .filter(item => item.url?.startsWith('/foundations/color/'));
+        .filter(item => typeof item.url === 'string' && item.url.startsWith('/foundations/color/'));
     return colorCollection.sort((a, b) => {
       if (a.data.order > b.data.order) {
         return 1;

--- a/docs/_plugins/rhds.ts
+++ b/docs/_plugins/rhds.ts
@@ -252,7 +252,11 @@ export default async function(
   });
 
   eleventyConfig.addCollection('sortedColor', async function(collectionApi) {
-    const colorCollection = collectionApi.getFilteredByTags('color');
+    // Keep this subnav to Foundations Color pages. Other sections can also
+    // tag pages `color` (e.g. AI guidelines Color), which would otherwise
+    // leak into Overview / Usage / Accessibility.
+    const colorCollection = collectionApi.getFilteredByTags('color')
+        .filter(item => item.url?.startsWith('/foundations/color/'));
     return colorCollection.sort((a, b) => {
       if (a.data.order > b.data.order) {
         return 1;


### PR DESCRIPTION
## What I did

1. Scoped sidenav dropdowns to links whose URL belongs to that section, so AI guidelines > Color no longer appears under Accessibility
2. Scoped the Foundations > Color subnav to `/foundations/color/` pages so AI Color is not an extra tab
3. Closes #3113.

## Testing Instructions

1. Visit [Accessibility](https://deploy-preview-3190--red-hat-design-system.netlify.app/accessibility/) and confirm the sidenav has no Color item.
2. Visit [AI guidelines > Color](https://deploy-preview-3190--red-hat-design-system.netlify.app/ai-guidelines/color/) and confirm the page still loads from that dropdown.
4. Visit [Foundations > Color > Accessibility](https://deploy-preview-3190--red-hat-design-system.netlify.app/foundations/color/accessibility/) and confirm the subnav is Overview, Usage, and Accessibility only.
5. Confirm [Accessibility > Color](https://deploy-preview-3190--red-hat-design-system.netlify.app/accessibility/color/) still 404s.