### PR TITLE
fix(footer): align logo heights in `<rh-footer>` and `<rh-footer-universal>`

### DIFF
--- a/.changeset/cute-knives-dress.md
+++ b/.changeset/cute-knives-dress.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-footer>`: align heights of footer wordmark and universal footer fedora logo at different viewports

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -126,21 +126,23 @@ rh-footer-universal [slot^='links'] a {
   text-underline-offset: max(6px, 0.33em);
 }
 
-:is(rh-footer) a[slot^='logo'] > :is(img, svg) {
+:is(rh-footer, rh-footer-universal) a[slot^='logo'] > :is(img, svg) {
   display: block;
   width: auto;
 
   /** Logo image height */
-  height: var(--rh-size-icon-03, 32px);
+  height: var(--rh-size-icon-02, 24px);
 }
 
-@media screen and (min-width: 768px) {
-  :is(rh-footer, rh-footer-universal) a[slot^='logo']:not(:has(img, svg, picture)) {
-    font-size: var(--rh-font-size-heading-sm, 1.5rem);
+@media screen and (min-width: 576px) {
+  :is(rh-footer, rh-footer-universal) a[slot^='logo'] > :is(img, svg) {
+    /** Logo image height at viewport >= xs */
+    height: var(--rh-size-icon-03, 32px);
   }
 
-  :is(rh-footer) a[slot^='logo'] > :is(img, svg) {
-    height: var(--rh-size-icon-03, 32px);
+  :is(rh-footer, rh-footer-universal) a[slot^='logo']:not(:has(img, svg, picture)) {
+    /** Subdomain name font size at viewport >= xs */
+    font-size: var(--rh-font-size-heading-sm, 1.5rem);
   }
 }
 

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -229,6 +229,8 @@
 .global-logo {
   grid-area: logo;
   width: auto;
+
+  /** Universal footer fedora logo height */
   height: var(--rh-size-icon-02, 24px);
 }
 
@@ -351,7 +353,7 @@
   width: auto;
 
   /** Logo image height */
-  height: var(--rh-size-icon-03, 32px);
+  height: var(--rh-size-icon-02, 24px);
 }
 
 .social-links {
@@ -514,21 +516,24 @@
   color: var(--rh-color-text-primary) !important;
 }
 
-@media screen and (min-width: 768px) {
-  .header-primary ::slotted(:not(a, img, svg, picture)) {
-    /** Subdomain name font size (desktop) */
-    font-size: var(--rh-font-size-heading-sm, 1.5rem);
-  }
-
+@media screen and (min-width: 576px) {
   .logo a > :is(img, svg) {
-    /** Logo image height (desktop) */
+    /** Logo image height at viewport >= xs */
     height: var(--rh-size-icon-03, 32px);
   }
 
   .global-logo {
-    height: var(--rh-size-icon-04, 40px);
+    /** Universal footer fedora logo height at viewport >= xs */
+    height: var(--rh-size-icon-03, 32px);
   }
 
+  .header-primary ::slotted(:not(a, img, svg, picture)) {
+    /** Subdomain name font size at viewport >= xs */
+    font-size: var(--rh-font-size-heading-sm, 1.5rem);
+  }
+}
+
+@media screen and (min-width: 768px) {
   /* stylelint-disable-next-line @stylistic/max-line-length */
   :is(.links, .global-links-primary, .global-links-secondary) ::slotted(:is(h1, h2, h3, h4, h5)) {
     /** Link header font size (desktop) */

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -237,6 +237,45 @@ describe('<rh-footer>', function() {
       });
     });
 
+    describe('logo heights match across rh-footer and rh-footer-universal', function() {
+      let wordmark: HTMLImageElement;
+      let fedora: SVGElement;
+
+      beforeEach(function() {
+        wordmark = element.querySelector('a[slot="logo"] img')!;
+        fedora = element.querySelector('rh-footer-universal')!
+            .shadowRoot!
+            .querySelector('.global-logo-image')!;
+      });
+
+      it('Mobile, portrait: both logos are --rh-size-icon-02', async function() {
+        await setViewport({ width: 360, height: 800 });
+        await element.updateComplete;
+        await aTimeout(200);
+
+        expect(getComputedStyle(wordmark).height).to.equal(tokens.get('--rh-size-icon-02'));
+        expect(getComputedStyle(fedora).height).to.equal(tokens.get('--rh-size-icon-02'));
+      });
+
+      it('Mobile, landscape: both logos are --rh-size-icon-03', async function() {
+        await setViewport({ width: parseInt(tokens.get('--rh-breakpoint-xs')), height: 800 });
+        await element.updateComplete;
+        await aTimeout(200);
+
+        expect(getComputedStyle(wordmark).height).to.equal(tokens.get('--rh-size-icon-03'));
+        expect(getComputedStyle(fedora).height).to.equal(tokens.get('--rh-size-icon-03'));
+      });
+
+      it('Desktop: both logos remain --rh-size-icon-03', async function() {
+        await setViewport({ width: 1200, height: 800 });
+        await element.updateComplete;
+        await aTimeout(200);
+
+        expect(getComputedStyle(wordmark).height).to.equal(tokens.get('--rh-size-icon-03'));
+        expect(getComputedStyle(fedora).height).to.equal(tokens.get('--rh-size-icon-03'));
+      });
+    });
+
     describe('Tablet, landscape', function() {
       let element: RhFooter;
 


### PR DESCRIPTION
## What I did

1. Matched the `<rh-footer>` wordmark and `<rh-footer-universal>` fedora to 24px below 576px and 32px from 576px up, so they no longer diverge on desktop or mobile.
2. Moved the subdomain / text-logo font size from 768px to the same 576px breakpoint (1.25rem → 1.5rem).
3. Added viewport tests that both logos stay the same height at 360, 576, and 1200.
4. Closes #3191.

## Testing Instructions

1. Open the production [Footer demo](https://ux.redhat.com/elements/footer/demo/).
2. Resize the viewport below 576px.
   - Note the fedora is smaller than the wordmark.
3. Resize the viewport above 576px.
   - Note the fedora is larger than the wordmark.
4. Open the DP [Footer demo](https://deploy-preview-3192--red-hat-design-system.netlify.app/elements/footer/demo/).
5. Resize the viewport below 576px.
   - Verify both logos are 24px tall.
   - Verify they match each other.
6. Resize the viewport to 576px or wider.
   - Verify both logos are 32px tall.
   - Verify they match each other.
7. Open the DP [Footer Universal](https://deploy-preview-3192--red-hat-design-system.netlify.app/elements/footer/demo/footer-universal/) demo.
8. Resize the viewport below 576px.
   - Verify the fedora is 24px tall.
9. Resize the viewport to 576px or wider.
   - Verify the fedora is 32px tall.
10. Open the DP [Subdomain](https://deploy-preview-3192--red-hat-design-system.netlify.app/elements/footer/demo/subdomain/) demo.
11. Resize the viewport below 576px.
    - Verify the “Docs” text is 1.25rem.
12. Resize the viewport to 576px or wider.
    - Verify the “Docs” text is 1.5rem.
13. Ensure everything looks as it should in Chrome, Firefox, and Safari. 

## Notes to reviewers

I have set this to be a patch release (aka not part of `staging/horsea`). If this should be part of our Q3 release, please speak up!