### PR TITLE
docs(felt theme): fix font size of nested vertical nav items

### DIFF
--- a/docs/theming/patterns/felt-preview-navigation-vertical.html
+++ b/docs/theming/patterns/felt-preview-navigation-vertical.html
@@ -9,12 +9,16 @@
 
 <div class="example-row">
   <rh-navigation-vertical accessible-label="Example side nav">
-    <rh-navigation-link href="#">Nav item 1</rh-navigation-link>
-    <rh-navigation-link href="#" current-page>Nav item 2</rh-navigation-link>
-    <rh-navigation-vertical-list summary="Nav group">
-      <rh-navigation-link href="#">Sub item 1</rh-navigation-link>
-      <rh-navigation-link href="#">Sub item 2</rh-navigation-link>
+    <rh-navigation-link href="#">Nav item 1 (level 1)</rh-navigation-link>
+    <rh-navigation-link href="#" current-page>Nav item 2 (level 1)</rh-navigation-link>
+    <rh-navigation-vertical-list summary="Nav group (level 2)" open>
+      <rh-navigation-link href="#">Sub item 1 (level 2)</rh-navigation-link>
+      <rh-navigation-vertical-list summary="Nav group (level 3)" open>
+        <rh-navigation-link href="#">Sub item 1 (level 3)</rh-navigation-link>
+        <rh-navigation-link href="#">Sub item 2 (level 3)</rh-navigation-link>
+      </rh-navigation-vertical-list>
+      <rh-navigation-link href="#">Sub item 2 (level 2)</rh-navigation-link>
     </rh-navigation-vertical-list>
-    <rh-navigation-link href="#">Nav item 3</rh-navigation-link>
+    <rh-navigation-link href="#">Nav item 3 (level 1)</rh-navigation-link>
   </rh-navigation-vertical>
 </div>

--- a/docs/theming/patterns/felt-preview-navigation-vertical.html
+++ b/docs/theming/patterns/felt-preview-navigation-vertical.html
@@ -9,16 +9,16 @@
 
 <div class="example-row">
   <rh-navigation-vertical accessible-label="Example side nav">
-    <rh-navigation-link href="#">Nav item 1 (level 1)</rh-navigation-link>
-    <rh-navigation-link href="#" current-page>Nav item 2 (level 1)</rh-navigation-link>
-    <rh-navigation-vertical-list summary="Nav group (level 2)" open>
-      <rh-navigation-link href="#">Sub item 1 (level 2)</rh-navigation-link>
-      <rh-navigation-vertical-list summary="Nav group (level 3)" open>
-        <rh-navigation-link href="#">Sub item 1 (level 3)</rh-navigation-link>
-        <rh-navigation-link href="#">Sub item 2 (level 3)</rh-navigation-link>
+    <rh-navigation-link href="#">Home</rh-navigation-link>
+    <rh-navigation-link href="#" current-page>About</rh-navigation-link>
+    <rh-navigation-vertical-list summary="Get started" open>
+      <rh-navigation-link href="#">Overview</rh-navigation-link>
+      <rh-navigation-vertical-list summary="Developers" open>
+        <rh-navigation-link href="#">Installation</rh-navigation-link>
+        <rh-navigation-link href="#">Usage</rh-navigation-link>
       </rh-navigation-vertical-list>
-      <rh-navigation-link href="#">Sub item 2 (level 2)</rh-navigation-link>
+      <rh-navigation-link href="#">Designers</rh-navigation-link>
     </rh-navigation-vertical-list>
-    <rh-navigation-link href="#">Nav item 3 (level 1)</rh-navigation-link>
+    <rh-navigation-link href="#">Get support</rh-navigation-link>
   </rh-navigation-vertical>
 </div>

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -2251,7 +2251,7 @@
     }
 
     & rh-navigation-vertical-list > rh-navigation-link {
-      --rh-navigation-link-font-size: var(--felt-preview-font-size-body-text-md);
+      --rh-navigation-link-font-size: var(--felt-preview-font-size-body-text-sm);
       --rh-navigation-link-border-inline-start-width: var(--felt-preview-border-width-lg);
     }
 

--- a/elements/rh-navigation-vertical/demo/felt-theme.html
+++ b/elements/rh-navigation-vertical/demo/felt-theme.html
@@ -16,13 +16,17 @@ description: Vertical navigation with nested groups and the [Project Felt](/them
 <div class="felt-preview">
   <div class="example-row">
     <rh-navigation-vertical accessible-label="Example side nav">
-      <rh-navigation-link href="#">Nav item 1</rh-navigation-link>
-      <rh-navigation-link href="#" current-page>Nav item 2</rh-navigation-link>
-      <rh-navigation-vertical-list summary="Nav group">
-        <rh-navigation-link href="#">Sub item 1</rh-navigation-link>
-        <rh-navigation-link href="#">Sub item 2</rh-navigation-link>
+      <rh-navigation-link href="#">Home</rh-navigation-link>
+      <rh-navigation-link href="#" current-page>About</rh-navigation-link>
+      <rh-navigation-vertical-list summary="Get started" open>
+        <rh-navigation-link href="#">Overview</rh-navigation-link>
+        <rh-navigation-vertical-list summary="Developers" open>
+          <rh-navigation-link href="#">Installation</rh-navigation-link>
+          <rh-navigation-link href="#">Usage</rh-navigation-link>
+        </rh-navigation-vertical-list>
+        <rh-navigation-link href="#">Designers</rh-navigation-link>
       </rh-navigation-vertical-list>
-      <rh-navigation-link href="#">Nav item 3</rh-navigation-link>
+      <rh-navigation-link href="#">Get support</rh-navigation-link>
     </rh-navigation-vertical>
   </div>
 </div>


### PR DESCRIPTION
## What I did

1. Updated the font size in `felt-theme-preview.css`
2. Added a level 3 nav group in the Felt demo


## Testing Instructions

1. Make sure the font size of the level 3 nav group text and level 2 and 3 sub items are 14px.
2. Make sure that this update is visible in the Felt demo for vertical nav under the [Project Felt demos](http://localhost:8082/theming/themes/project-felt/demos/#navigation-vertical) and the [vertical nav demos](http://localhost:8082/elements/navigation-vertical/demos/#demo-felt-theme).

## Notes to Reviewers
Closes #3199 