### PR TITLE
fix(scheme-dropdown): add css token fallbacks

### DIFF
--- a/.changeset/humble-phones-grin.md
+++ b/.changeset/humble-phones-grin.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-scheme-dropdown>`: add default fallbacks for each RHDS token used

--- a/.changeset/humble-phones-grin.md
+++ b/.changeset/humble-phones-grin.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-scheme-dropdown>`: add default fallbacks for each RHDS token used
+`<rh-scheme-dropdown>`: improved theming support

--- a/elements/rh-scheme-dropdown/demo/dropdown-placement.html
+++ b/elements/rh-scheme-dropdown/demo/dropdown-placement.html
@@ -17,8 +17,18 @@ description: "Two scheme dropdowns demonstrating dropdown positioning aligning o
   }
 
   #container {
-    background-color: var(--rh-color-surface);
-    color: var(--rh-color-text-primary);
+    background-color:
+      var(--rh-color-surface,
+        light-dark(
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515)
+        ));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)
+        ));
     display: flex;
     block-size: 100svh;
     justify-content: space-between;

--- a/elements/rh-scheme-dropdown/demo/events.html
+++ b/elements/rh-scheme-dropdown/demo/events.html
@@ -31,8 +31,18 @@ description: "Demonstrates the scheme-changed event fired when a user changes th
 <style>
   body {
     color-scheme: light dark;
-    background-color: var(--rh-color-surface);
-    color: var(--rh-color-text-primary);
+    background-color:
+      var(--rh-color-surface,
+        light-dark(
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515)
+        ));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)
+        ));
   }
 
   rh-scheme-dropdown {
@@ -42,6 +52,6 @@ description: "Demonstrates the scheme-changed event fired when a user changes th
   .container {
     margin-inline: 20px;
     margin-block-end: var(--rh-space-md, 8px);
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
   }
 </style>

--- a/elements/rh-scheme-dropdown/demo/index.html
+++ b/elements/rh-scheme-dropdown/demo/index.html
@@ -10,8 +10,18 @@ description: "Default scheme dropdown with light, dark, and system options."
 <style>
   body {
     color-scheme: light dark;
-    background-color: var(--rh-color-surface);
-    color: var(--rh-color-text-primary);
+    background-color:
+      var(--rh-color-surface,
+        light-dark(
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515)
+        ));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)
+        ));
   }
 
   rh-scheme-dropdown {

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.css
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.css
@@ -20,9 +20,15 @@ select {
   --_caret-dark: url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_4022_181)'%3E%3Cpath d='M9.46188 2.8086C9.38473 2.6216 9.20213 2.5 8.99998 2.5H0.999976C0.797826 2.5 0.615226 2.6216 0.538076 2.8086C0.460426 2.9956 0.503426 3.21045 0.646476 3.3535L4.46973 7.17675C4.61573 7.32325 4.80813 7.396 4.99998 7.396C5.19183 7.396 5.38428 7.32325 5.53023 7.17675L9.35348 3.3535C9.49653 3.21045 9.53953 2.9956 9.46188 2.8086Z' fill='%23ffffff'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_4022_181'%3E%3Crect width='10' height='10' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E");
 
   appearance: none;
-
-  /** Select surface color; theme-adaptive */
-  background-color: var(--rh-color-surface);
+  background-color:
+    /** Select surface color; theme-adaptive */
+    var(--rh-color-surface,
+      light-dark(
+        /** Select surface in light mode */
+        var(--rh-color-surface-lightest, #ffffff),
+        /** Select surface in dark mode */
+        var(--rh-color-surface-darkest, #151515)
+      ));
   background-image: var(--_caret-light);
   background-position: right 12px center;
   background-repeat: no-repeat;
@@ -31,18 +37,30 @@ select {
     var(--rh-border-width-sm, 1px)
     solid
     /** Select border color; theme-adaptive */
-    var(--rh-color-border-subtle);
+    var(--rh-color-border-subtle,
+      light-dark(
+        /** Select border color in light mode */
+        var(--rh-color-border-subtle-on-light, #c7c7c7),
+        /** Select border color in dark mode */
+        var(--rh-color-border-subtle-on-dark, #707070)
+      ));
 
   /** Select corner radius */
   border-radius: var(--rh-border-radius-default, 3px);
   box-sizing: border-box;
-
-  /** Select text color; theme-adaptive for accessible contrast */
-  color: var(--rh-color-text-primary);
+  color:
+    /** Select text color; theme-adaptive for accessible contrast */
+    var(--rh-color-text-primary,
+      light-dark(
+        /** Select text color in light mode */
+        var(--rh-color-text-primary-on-light, #151515),
+        /** Select text color in dark mode */
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      ));
   cursor: default;
 
   /** Select typeface */
-  font-family: var(--rh-font-family-body-text);
+  font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
 
   /** Select text size */
   font-size: var(--rh-font-size-body-text-md, 1rem);
@@ -68,19 +86,39 @@ select {
     var(--rh-space-lg, 16px);
 
   &:hover {
-    /** Hover border color; interactive theme color */
-    border-color: var(--rh-color-border-interactive);
+    border-color:
+      /** Hover border color; interactive theme color */
+      var(--rh-color-border-interactive,
+        light-dark(
+          /** Hover border color in light mode */
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          /** Hover border color in dark mode */
+          var(--rh-color-border-interactive-on-dark, #92c5f9)
+        ));
   }
 
   &:focus {
-    /** Focus border color; interactive theme color */
-    border-color: var(--rh-color-border-interactive);
+    border-color:
+      /** Focus border color; interactive theme color */
+      var(--rh-color-border-interactive,
+        light-dark(
+          /** Focus border color in light mode */
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          /** Focus border color in dark mode */
+          var(--rh-color-border-interactive-on-dark, #92c5f9)
+        ));
     outline:
       /** Focus outline width */
       var(--rh-border-width-lg, 3px)
       solid
       /** Focus outline color; interactive theme color */
-      var(--rh-color-border-interactive);
+      var(--rh-color-border-interactive,
+        light-dark(
+          /** Focus outline color in light mode */
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          /** Focus outline color in dark mode */
+          var(--rh-color-border-interactive-on-dark, #92c5f9)
+        ));
 
     /** Focus outline offset  */
     outline-offset: var(--rh-length-2xs, 3px);
@@ -127,13 +165,19 @@ select {
         var(--rh-border-width-sm, 1px)
         solid
         /** Picker border color; theme-adaptive */
-        var(--rh-color-border-subtle);
+        var(--rh-color-border-subtle,
+          light-dark(
+            /** Picker border color in light mode */
+            var(--rh-color-border-subtle-on-light, #c7c7c7),
+            /** Picker border color in dark mode */
+            var(--rh-color-border-subtle-on-dark, #707070)
+          ));
 
       /** Picker corner radius */
       border-radius: var(--rh-border-radius-default, 3px);
 
       /** Picker elevation shadow; depth cue for the overlay */
-      box-shadow: var(--rh-box-shadow-sm);
+      box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
 
       /** Picker top margin */
       margin-block-start: var(--rh-space-sm, 6px);
@@ -154,7 +198,13 @@ select {
         var(--rh-border-width-md, 2px)
         solid
         /** Open state outline color; interactive theme color */
-        var(--rh-color-border-interactive);
+        var(--rh-color-border-interactive,
+          light-dark(
+            /** Open state outline color in light mode */
+            var(--rh-color-border-interactive-on-light, #0066cc),
+            /** Open state outline color in dark mode */
+            var(--rh-color-border-interactive-on-dark, #92c5f9)
+          ));
     }
 
     &::picker-icon {
@@ -215,7 +265,13 @@ select {
         var(--rh-border-width-lg, 3px)
         solid
         /** Option focus outline color; interactive theme color */
-        var(--rh-color-border-interactive);
+        var(--rh-color-border-interactive,
+          light-dark(
+            /** Option focus outline color in light mode */
+            var(--rh-color-border-interactive-on-light, #0066cc),
+            /** Option focus outline color in dark mode */
+            var(--rh-color-border-interactive-on-dark, #92c5f9)
+          ));
       outline-offset: -3px;
     }
 
@@ -224,8 +280,15 @@ select {
     }
 
     & rh-icon.checkmark {
-      /** Checkmark icon color; interactive theme color for selected scheme */
-      color: var(--rh-color-interactive-primary-default);
+      color:
+        /** Checkmark icon color; interactive theme color for selected scheme */
+        var(--rh-color-interactive-primary-default,
+          light-dark(
+            /** Checkmark icon color in light mode */
+            var(--rh-color-interactive-primary-default-on-light, #0066cc),
+            /** Checkmark icon color in dark mode */
+            var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
+          ));
       display: none; /* Hide checkmark rh-icon by default, then show it when checked */
       position: absolute;
 

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.css
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.css
@@ -20,15 +20,9 @@ select {
   --_caret-dark: url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_4022_181)'%3E%3Cpath d='M9.46188 2.8086C9.38473 2.6216 9.20213 2.5 8.99998 2.5H0.999976C0.797826 2.5 0.615226 2.6216 0.538076 2.8086C0.460426 2.9956 0.503426 3.21045 0.646476 3.3535L4.46973 7.17675C4.61573 7.32325 4.80813 7.396 4.99998 7.396C5.19183 7.396 5.38428 7.32325 5.53023 7.17675L9.35348 3.3535C9.49653 3.21045 9.53953 2.9956 9.46188 2.8086Z' fill='%23ffffff'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_4022_181'%3E%3Crect width='10' height='10' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E");
 
   appearance: none;
-  background-color:
-    /** Select surface color; theme-adaptive */
-    var(--rh-color-surface,
-      light-dark(
-        /** Select surface in light mode */
-        var(--rh-color-surface-lightest, #ffffff),
-        /** Select surface in dark mode */
-        var(--rh-color-surface-darkest, #151515)
-      ));
+
+  /** Select surface color; theme-adaptive */
+  background-color: var(--rh-color-surface);
   background-image: var(--_caret-light);
   background-position: right 12px center;
   background-repeat: no-repeat;
@@ -37,26 +31,14 @@ select {
     var(--rh-border-width-sm, 1px)
     solid
     /** Select border color; theme-adaptive */
-    var(--rh-color-border-subtle,
-      light-dark(
-        /** Select border color in light mode */
-        var(--rh-color-border-subtle-on-light, #c7c7c7),
-        /** Select border color in dark mode */
-        var(--rh-color-border-subtle-on-dark, #707070)
-      ));
+    var(--rh-color-border-subtle);
 
   /** Select corner radius */
   border-radius: var(--rh-border-radius-default, 3px);
   box-sizing: border-box;
-  color:
-    /** Select text color; theme-adaptive for accessible contrast */
-    var(--rh-color-text-primary,
-      light-dark(
-        /** Select text color in light mode */
-        var(--rh-color-text-primary-on-light, #151515),
-        /** Select text color in dark mode */
-        var(--rh-color-text-primary-on-dark, #ffffff)
-      ));
+
+  /** Select text color; theme-adaptive for accessible contrast */
+  color: var(--rh-color-text-primary);
   cursor: default;
 
   /** Select typeface */
@@ -86,39 +68,19 @@ select {
     var(--rh-space-lg, 16px);
 
   &:hover {
-    border-color:
-      /** Hover border color; interactive theme color */
-      var(--rh-color-border-interactive,
-        light-dark(
-          /** Hover border color in light mode */
-          var(--rh-color-border-interactive-on-light, #0066cc),
-          /** Hover border color in dark mode */
-          var(--rh-color-border-interactive-on-dark, #92c5f9)
-        ));
+    /** Hover border color; interactive theme color */
+    border-color: var(--rh-color-border-interactive);
   }
 
   &:focus {
-    border-color:
-      /** Focus border color; interactive theme color */
-      var(--rh-color-border-interactive,
-        light-dark(
-          /** Focus border color in light mode */
-          var(--rh-color-border-interactive-on-light, #0066cc),
-          /** Focus border color in dark mode */
-          var(--rh-color-border-interactive-on-dark, #92c5f9)
-        ));
+    /** Focus border color; interactive theme color */
+    border-color: var(--rh-color-border-interactive);
     outline:
       /** Focus outline width */
       var(--rh-border-width-lg, 3px)
       solid
       /** Focus outline color; interactive theme color */
-      var(--rh-color-border-interactive,
-        light-dark(
-          /** Focus outline color in light mode */
-          var(--rh-color-border-interactive-on-light, #0066cc),
-          /** Focus outline color in dark mode */
-          var(--rh-color-border-interactive-on-dark, #92c5f9)
-        ));
+      var(--rh-color-border-interactive);
 
     /** Focus outline offset  */
     outline-offset: var(--rh-length-2xs, 3px);
@@ -165,13 +127,7 @@ select {
         var(--rh-border-width-sm, 1px)
         solid
         /** Picker border color; theme-adaptive */
-        var(--rh-color-border-subtle,
-          light-dark(
-            /** Picker border color in light mode */
-            var(--rh-color-border-subtle-on-light, #c7c7c7),
-            /** Picker border color in dark mode */
-            var(--rh-color-border-subtle-on-dark, #707070)
-          ));
+        var(--rh-color-border-subtle);
 
       /** Picker corner radius */
       border-radius: var(--rh-border-radius-default, 3px);
@@ -198,13 +154,7 @@ select {
         var(--rh-border-width-md, 2px)
         solid
         /** Open state outline color; interactive theme color */
-        var(--rh-color-border-interactive,
-          light-dark(
-            /** Open state outline color in light mode */
-            var(--rh-color-border-interactive-on-light, #0066cc),
-            /** Open state outline color in dark mode */
-            var(--rh-color-border-interactive-on-dark, #92c5f9)
-          ));
+        var(--rh-color-border-interactive);
     }
 
     &::picker-icon {
@@ -265,13 +215,7 @@ select {
         var(--rh-border-width-lg, 3px)
         solid
         /** Option focus outline color; interactive theme color */
-        var(--rh-color-border-interactive,
-          light-dark(
-            /** Option focus outline color in light mode */
-            var(--rh-color-border-interactive-on-light, #0066cc),
-            /** Option focus outline color in dark mode */
-            var(--rh-color-border-interactive-on-dark, #92c5f9)
-          ));
+        var(--rh-color-border-interactive);
       outline-offset: -3px;
     }
 
@@ -280,15 +224,8 @@ select {
     }
 
     & rh-icon.checkmark {
-      color:
-        /** Checkmark icon color; interactive theme color for selected scheme */
-        var(--rh-color-interactive-primary-default,
-          light-dark(
-            /** Checkmark icon color in light mode */
-            var(--rh-color-interactive-primary-default-on-light, #0066cc),
-            /** Checkmark icon color in dark mode */
-            var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
-          ));
+      /** Checkmark icon color; interactive theme color for selected scheme */
+      color: var(--rh-color-interactive-primary-default);
       display: none; /* Hide checkmark rh-icon by default, then show it when checked */
       position: absolute;
 

--- a/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
+++ b/elements/rh-scheme-dropdown/rh-scheme-dropdown.ts
@@ -5,6 +5,8 @@ import { property } from 'lit/decorators/property.js';
 import '@rhds/elements/rh-icon/rh-icon.js';
 import { observes } from '@patternfly/pfe-core/decorators.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './rh-scheme-dropdown.css' with { type: 'css' };
 
 declare global {
@@ -41,6 +43,7 @@ export class SchemeChangedEvent extends Event {
  * @fires {SchemeChangedEvent} scheme-changed - Fired when the color scheme changes
  */
 @customElement('rh-scheme-dropdown')
+@themable
 export class RhSchemeDropdown extends LitElement {
   static styles = [styles];
 


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in `rh-scheme-dropdown.css`, including `light-dark()` fallbacks for theme-adaptive colors.
2. Added the same fallbacks to the inline CSS in the index, events, and dropdown-placement demos.
3. Closes #3130, closes #3145.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Scheme dropdown](http://localhost:8000/elements/scheme-dropdown/) demo.
3. Switch Light, Dark, and System. Confirm the control still has surface, text, border, and type.
4. Check the other demos the same way:
   - [Events](http://localhost:8000/elements/scheme-dropdown/events/)
   - [Dropdown placement](http://localhost:8000/elements/scheme-dropdown/dropdown-placement/)
5. On those pages, confirm the page background and text still resolve.
6. Run `npm run lint` in the RHDS directory.
7. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
8. Ensure the changeset is accurate.
9. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119. 