### PR TITLE
fix(scheme-toggle): add css token fallbacks

### DIFF
--- a/.changeset/scheme-toggle-token-fallbacks.md
+++ b/.changeset/scheme-toggle-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-scheme-toggle>`: add default fallbacks for each RHDS token used

--- a/.changeset/scheme-toggle-token-fallbacks.md
+++ b/.changeset/scheme-toggle-token-fallbacks.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-scheme-toggle>`: add default fallbacks for each RHDS token used
+`<rh-scheme-toggle>`: improved theming support

--- a/elements/rh-scheme-toggle/demo/events.html
+++ b/elements/rh-scheme-toggle/demo/events.html
@@ -31,10 +31,18 @@ description: "Demonstrates the scheme-changed event fired when a user changes th
 <style>
   body {
     color-scheme: light dark;
-    background-color: light-dark(var(--rh-color-surface-lightest, #ffffff),
-        var(--rh-color-surface-darkest, #151515));
-    color: light-dark(var(--rh-color-text-primary-default-on-light, #151515),
-        var(--rh-color-text-primary-default-on-dark, #ffffff));
+    background-color:
+      var(--rh-color-surface,
+        light-dark(
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515)
+        ));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)
+        ));
   }
 
   rh-scheme-toggle {
@@ -44,6 +52,6 @@ description: "Demonstrates the scheme-changed event fired when a user changes th
   .container {
     margin-inline: 20px;
     margin-block-end: var(--rh-space-md, 8px);
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
   }
 </style>

--- a/elements/rh-scheme-toggle/demo/index.html
+++ b/elements/rh-scheme-toggle/demo/index.html
@@ -10,10 +10,18 @@ description: "Default scheme toggle with light, dark, and system options."
 <style>
   body {
     color-scheme: light dark;
-    background-color: light-dark(var(--rh-color-surface-lightest, #ffffff),
-        var(--rh-color-surface-darkest, #151515));
-    color: light-dark(var(--rh-color-text-primary-default-on-light, #151515),
-        var(--rh-color-text-primary-default-on-dark, #ffffff));
+    background-color:
+      var(--rh-color-surface,
+        light-dark(
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515)
+        ));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)
+        ));
   }
 
   rh-scheme-toggle {

--- a/elements/rh-scheme-toggle/demo/stacked-legend.html
+++ b/elements/rh-scheme-toggle/demo/stacked-legend.html
@@ -10,10 +10,18 @@ description: "Scheme toggle with a stacked legend (i.e., vertical orientation)."
 <style>
   body {
     color-scheme: light dark;
-    background-color: light-dark(var(--rh-color-surface-lightest, #ffffff),
-        var(--rh-color-surface-darkest, #151515));
-    color: light-dark(var(--rh-color-text-primary-default-on-light, #151515),
-        var(--rh-color-text-primary-default-on-dark, #ffffff));
+    background-color:
+      var(--rh-color-surface,
+        light-dark(
+          var(--rh-color-surface-lightest, #ffffff),
+          var(--rh-color-surface-darkest, #151515)
+        ));
+    color:
+      var(--rh-color-text-primary,
+        light-dark(
+          var(--rh-color-text-primary-on-light, #151515),
+          var(--rh-color-text-primary-on-dark, #ffffff)
+        ));
   }
 
   rh-scheme-toggle {

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.css
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.css
@@ -47,9 +47,15 @@ label {
   /** Toggle button border width */
   border-width: var(--rh-border-width-sm, 1px);
   border-style: solid;
-
-  /** Toggle button border color */
-  border-color: var(--rh-color-border-subtle);
+  border-color:
+    /** Toggle button border color; theme-adaptive */
+    var(--rh-color-border-subtle,
+      light-dark(
+        /** Toggle button border color for light color schemes */
+        var(--rh-color-border-subtle-on-light, #c7c7c7),
+        /** Toggle button border color for dark color schemes */
+        var(--rh-color-border-subtle-on-dark, #707070)
+      ));
   display: flex;
 
   /** Toggle button height */
@@ -82,25 +88,39 @@ label {
 
   &:focus-within,
   &:hover {
-    /** Toggle button hover/focus background */
     background-color:
       light-dark(
+          /** Toggle button hover/focus background for light color schemes */
           var(--rh-color-surface-light, #e0e0e0),
+          /** Toggle button hover/focus background for dark color schemes */
           var(--rh-color-surface-dark, #383838)
         );
   }
 
   &:has(input:checked) {
-    /** Selected toggle button background */
-    background-color: var(--rh-color-interactive-primary-default);
-
-    /** Selected toggle button border color */
-    border-color: var(--rh-color-border-interactive);
+    background-color:
+      /** Selected toggle button background; theme-adaptive */
+      var(--rh-color-interactive-primary-default,
+        light-dark(
+          /** Selected toggle button background for light color schemes */
+          var(--rh-color-interactive-primary-default-on-light, #0066cc),
+          /** Selected toggle button background for dark color schemes */
+          var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
+        ));
+    border-color:
+      /** Selected toggle button border color; theme-adaptive */
+      var(--rh-color-border-interactive,
+        light-dark(
+          /** Selected toggle button border color for light color schemes */
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          /** Selected toggle button border color for dark color schemes */
+          var(--rh-color-border-interactive-on-dark, #92c5f9)
+        ));
     color:
       light-dark(
-          /** Selected toggle button icon color in light mode */
+          /** Selected toggle button icon color for light color schemes */
           var(--rh-color-text-primary-on-dark, #ffffff),
-          /** Selected toggle button icon color in dark mode */
+          /** Selected toggle button icon color for dark color schemes */
           var(--rh-color-text-primary-on-light, #151515)
         );
     z-index: 1;
@@ -121,8 +141,14 @@ input {
       /** Focus outline width */
       var(--rh-border-width-lg, 3px)
       solid
-      /** Focus outline color */
-      var(--rh-color-border-interactive);
+      /** Focus outline color; theme-adaptive */
+      var(--rh-color-border-interactive,
+        light-dark(
+          /** Focus outline color for light color schemes */
+          var(--rh-color-border-interactive-on-light, #0066cc),
+          /** Focus outline color for dark color schemes */
+          var(--rh-color-border-interactive-on-dark, #92c5f9)
+        ));
     transition: none;
   }
 }

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.css
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.css
@@ -47,15 +47,9 @@ label {
   /** Toggle button border width */
   border-width: var(--rh-border-width-sm, 1px);
   border-style: solid;
-  border-color:
-    /** Toggle button border color; theme-adaptive */
-    var(--rh-color-border-subtle,
-      light-dark(
-        /** Toggle button border color for light color schemes */
-        var(--rh-color-border-subtle-on-light, #c7c7c7),
-        /** Toggle button border color for dark color schemes */
-        var(--rh-color-border-subtle-on-dark, #707070)
-      ));
+
+  /** Toggle button border color */
+  border-color: var(--rh-color-border-subtle);
   display: flex;
 
   /** Toggle button height */
@@ -98,24 +92,11 @@ label {
   }
 
   &:has(input:checked) {
-    background-color:
-      /** Selected toggle button background; theme-adaptive */
-      var(--rh-color-interactive-primary-default,
-        light-dark(
-          /** Selected toggle button background for light color schemes */
-          var(--rh-color-interactive-primary-default-on-light, #0066cc),
-          /** Selected toggle button background for dark color schemes */
-          var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
-        ));
-    border-color:
-      /** Selected toggle button border color; theme-adaptive */
-      var(--rh-color-border-interactive,
-        light-dark(
-          /** Selected toggle button border color for light color schemes */
-          var(--rh-color-border-interactive-on-light, #0066cc),
-          /** Selected toggle button border color for dark color schemes */
-          var(--rh-color-border-interactive-on-dark, #92c5f9)
-        ));
+    /** Selected toggle button background */
+    background-color: var(--rh-color-interactive-primary-default);
+
+    /** Selected toggle button border color */
+    border-color: var(--rh-color-border-interactive);
     color:
       light-dark(
           /** Selected toggle button icon color for light color schemes */
@@ -141,14 +122,8 @@ input {
       /** Focus outline width */
       var(--rh-border-width-lg, 3px)
       solid
-      /** Focus outline color; theme-adaptive */
-      var(--rh-color-border-interactive,
-        light-dark(
-          /** Focus outline color for light color schemes */
-          var(--rh-color-border-interactive-on-light, #0066cc),
-          /** Focus outline color for dark color schemes */
-          var(--rh-color-border-interactive-on-dark, #92c5f9)
-        ));
+      /** Focus outline color */
+      var(--rh-color-border-interactive);
     transition: none;
   }
 }

--- a/elements/rh-scheme-toggle/rh-scheme-toggle.ts
+++ b/elements/rh-scheme-toggle/rh-scheme-toggle.ts
@@ -5,6 +5,8 @@ import { property } from 'lit/decorators/property.js';
 import '@rhds/elements/rh-icon/rh-icon.js';
 import { observes } from '@patternfly/pfe-core/decorators.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './rh-scheme-toggle.css' with { type: 'css' };
 
 declare global {
@@ -48,6 +50,7 @@ export class SchemeChangedEvent extends Event {
  *        `event.scheme` (`'light'`, `'dark'`, or `'light dark'`).
  */
 @customElement('rh-scheme-toggle')
+@themable
 export class RhSchemeToggle extends LitElement {
   static styles = [styles];
 


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the scheme toggle CSS, including `light-dark()` fallbacks for theme-adaptive colors.
2. Added the same fallbacks to inline CSS in the default, events, and stacked-legend demos.
3. Closes #3178, closes #3146.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Scheme toggle](http://localhost:8000/elements/scheme-toggle/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Check the other affected demos the same way:
   - [Events](http://localhost:8000/elements/scheme-toggle/events/)
   - [Stacked legend](http://localhost:8000/elements/scheme-toggle/stacked-legend/)
5. On those pages, confirm demo page background and text still resolve if the demo sets them.
6. Run `npm run lint` in the RHDS directory.
7. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
8. Ensure the changeset is accurate.
9. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.