### PR TITLE
fix(tile): add css token fallbacks

### DIFF
--- a/.changeset/tile-token-fallbacks.md
+++ b/.changeset/tile-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-tile>`: add default fallbacks for each RHDS token used

--- a/elements/rh-tile/demo/compact-link-with-fullwidth-image-and-icon.html
+++ b/elements/rh-tile/demo/compact-link-with-fullwidth-image-and-icon.html
@@ -29,7 +29,12 @@ description: Compact link tile with a full-width bleed image and an icon.
 
 <style>
   rh-tile rh-icon {
-    color: var(--rh-color-brand-red);
+    color:
+      var(--rh-color-brand-red,
+        light-dark(
+          var(--rh-color-brand-red-on-light, #ee0000),
+          var(--rh-color-brand-red-on-dark, #ee0000)
+        ));
   }
 </style>
 

--- a/elements/rh-tile/demo/compact-link-with-icon.html
+++ b/elements/rh-tile/demo/compact-link-with-icon.html
@@ -15,7 +15,12 @@ description: Compact link tile with a desaturated heading and a slotted icon.
 
 <style>
   rh-tile rh-icon {
-    color: var(--rh-color-brand-red);
+    color:
+      var(--rh-color-brand-red,
+        light-dark(
+          var(--rh-color-brand-red-on-light, #ee0000),
+          var(--rh-color-brand-red-on-dark, #ee0000)
+        ));
   }
 </style>
 

--- a/elements/rh-tile/demo/compact-link-with-image-and-icon.html
+++ b/elements/rh-tile/demo/compact-link-with-image-and-icon.html
@@ -29,7 +29,12 @@ description: Compact link tile with both an image and a slotted icon.
 
 <style>
   rh-tile rh-icon {
-    color: var(--rh-color-brand-red);
+    color:
+      var(--rh-color-brand-red,
+        light-dark(
+          var(--rh-color-brand-red-on-light, #ee0000),
+          var(--rh-color-brand-red-on-dark, #ee0000)
+        ));
   }
 </style>
 

--- a/elements/rh-tile/demo/compact-link-with-image.html
+++ b/elements/rh-tile/demo/compact-link-with-image.html
@@ -15,7 +15,12 @@ description: Compact link tile with a desaturated heading and image slot.
 
 <style>
   rh-tile rh-icon {
-    color: var(--rh-color-brand-red);
+    color:
+      var(--rh-color-brand-red,
+        light-dark(
+          var(--rh-color-brand-red-on-light, #ee0000),
+          var(--rh-color-brand-red-on-dark, #ee0000)
+        ));
   }
 </style>
 

--- a/elements/rh-tile/demo/without-footer-content.html
+++ b/elements/rh-tile/demo/without-footer-content.html
@@ -31,7 +31,7 @@ description: "Tiles without footer content, including headline-only variants."
   .grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: var(--rh-space-xl);
-    padding: var(--rh-space-xl);
+    gap: var(--rh-space-xl, 24px);
+    padding: var(--rh-space-xl, 24px);
   }
 </style>

--- a/elements/rh-tile/rh-tile-lightdom.css
+++ b/elements/rh-tile/rh-tile-lightdom.css
@@ -31,7 +31,14 @@ rh-tile a:not([slot='image'], [slot='headline']) {
 rh-tile[aria-disabled='true'] a {
   color:
     var(--_text-color-secondary,
-      var(--rh-color-text-secondary)) !important;
+      /** Disabled tile link color; theme-adaptive */
+      var(--rh-color-text-secondary,
+      light-dark(
+        /** Disabled tile link color for light color schemes */
+        var(--rh-color-text-secondary-on-light, #4d4d4d),
+        /** Disabled tile link color for dark color schemes */
+        var(--rh-color-text-secondary-on-dark, #c7c7c7)
+      ))) !important;
 }
 
 rh-tile *:is([slot='image'], [slot='headline']) a {


### PR DESCRIPTION
## What I did

1. Added a canonical `light-dark()` fallback for `--rh-color-text-secondary` in `rh-tile-lightdom.css`. Shadow CSS was already clean because `<rh-tile>` is `@themable`.
2. Added the same class of fallbacks to inline CSS in the affected demos (`--rh-color-brand-red` on the compact-link icon demos, `--rh-space-xl` on without-footer-content).
3. Closes #3181, closes #3151.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Tile](http://localhost:8000/elements/tile/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the tile still has surface, text, border, and type.
4. Check the other affected demos the same way:
   - [Disabled](http://localhost:8000/elements/tile/disabled/)
   - [Compact link with icon](http://localhost:8000/elements/tile/compact-link-with-icon/)
   - [Compact link with image](http://localhost:8000/elements/tile/compact-link-with-image/)
   - [Compact link with image and icon](http://localhost:8000/elements/tile/compact-link-with-image-and-icon/)
   - [Compact link with fullwidth image and icon](http://localhost:8000/elements/tile/compact-link-with-fullwidth-image-and-icon/)
   - [Without footer content](http://localhost:8000/elements/tile/without-footer-content/)
5. On Disabled, the headline link should stay muted secondary text (not interactive blue) in light and dark. On the compact-link demos, the mug icon should stay brand red (`#ee0000`) in light and dark. On Without footer content, the 2×2 grid should still have about 24px gap and padding.
6. Run `npm run lint` in the RHDS directory. `elements/rh-tile` should not appear in the error list.
7. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
8. Ensure the changeset is accurate.
9. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.