### PR TITLE
fix(table): add css token fallbacks

### DIFF
--- a/.changeset/table-token-fallbacks.md
+++ b/.changeset/table-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-table>`: add default fallbacks for each RHDS token used

--- a/elements/rh-table/rh-table-lightdom.css
+++ b/elements/rh-table/rh-table-lightdom.css
@@ -47,10 +47,26 @@ rh-table {
   }
 
   & a {
-    color: var(--rh-color-interactive-primary-default);
+    color:
+      /** Table link color; theme-adaptive */
+      var(--rh-color-interactive-primary-default,
+        light-dark(
+          /** Table link color for light color schemes */
+          var(--rh-color-interactive-primary-default-on-light, #0066cc),
+          /** Table link color for dark color schemes */
+          var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
+        ));
 
     &:hover {
-      color: var(--rh-color-interactive-primary-hover);
+      color:
+        /** Table link hover color; theme-adaptive */
+        var(--rh-color-interactive-primary-hover,
+          light-dark(
+            /** Table link hover color for light color schemes */
+            var(--rh-color-interactive-primary-hover-on-light, #003366),
+            /** Table link hover color for dark color schemes */
+            var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)
+          ));
     }
   }
 


### PR DESCRIPTION
## What I did

1. Added canonical `light-dark()` fallbacks for `--rh-color-interactive-primary-default` and `--rh-color-interactive-primary-hover` in `rh-table-lightdom.css`. Shadow CSS was already clean because `<rh-table>` is `@themable`.
2. Closes #3180.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Table](http://localhost:8000/elements/table/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the table still has surface, text, border, and type as designed.
4. Check demos that include table links the same way. Confirm default and hover link color still resolve:
   - [Color context](http://localhost:8000/elements/table/color-context/)
   - [Auto data labels](http://localhost:8000/elements/table/auto-data-labels/)
   - [Title, headers, and summary](http://localhost:8000/elements/table/title-headers-and-summary/)
   - [Row headers](http://localhost:8000/elements/table/row-headers/)
   - [Headers and summary but no title](http://localhost:8000/elements/table/headers-and-summary-but-no-title/)
   - [No title, headers, or summary](http://localhost:8000/elements/table/no-title-headers-or-summary/)
5. Run `npm run lint` in the RHDS directory.
6. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
7. Ensure the changeset is accurate.
8. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.