### PR TITLE
fix(menu-dropdown): add css token fallbacks

### DIFF
--- a/.changeset/menu-dropdown-token-fallbacks.md
+++ b/.changeset/menu-dropdown-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-menu-dropdown>`: add default fallbacks for each RHDS token used

--- a/.changeset/menu-dropdown-token-fallbacks.md
+++ b/.changeset/menu-dropdown-token-fallbacks.md
@@ -2,4 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-menu-dropdown>`: add default fallbacks for each RHDS token used
+`<rh-menu-dropdown>`: improved theming support

--- a/elements/rh-menu-dropdown/rh-menu-dropdown.css
+++ b/elements/rh-menu-dropdown/rh-menu-dropdown.css
@@ -30,9 +30,15 @@
         /** Border color in dark mode */
         var(--rh-color-gray-50, #707070)
       );
-
-  /** Default text color */
-  --_color: var(--rh-color-text-primary);
+  --_color:
+    /** Default text color; theme-adaptive */
+    var(--rh-color-text-primary,
+      light-dark(
+        /** Default text color for light color schemes */
+        var(--rh-color-text-primary-on-light, #151515),
+        /** Default text color for dark color schemes */
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      ));
 
   position: relative;
   display: inline-block;

--- a/elements/rh-menu-dropdown/rh-menu-dropdown.css
+++ b/elements/rh-menu-dropdown/rh-menu-dropdown.css
@@ -30,15 +30,9 @@
         /** Border color in dark mode */
         var(--rh-color-gray-50, #707070)
       );
-  --_color:
-    /** Default text color; theme-adaptive */
-    var(--rh-color-text-primary,
-      light-dark(
-        /** Default text color for light color schemes */
-        var(--rh-color-text-primary-on-light, #151515),
-        /** Default text color for dark color schemes */
-        var(--rh-color-text-primary-on-dark, #ffffff)
-      ));
+
+  /** Default text color */
+  --_color: var(--rh-color-text-primary);
 
   position: relative;
   display: inline-block;

--- a/elements/rh-menu-dropdown/rh-menu-dropdown.ts
+++ b/elements/rh-menu-dropdown/rh-menu-dropdown.ts
@@ -14,6 +14,8 @@ import '@rhds/elements/rh-menu/rh-menu.js';
 
 import { RhMenuItem } from '../rh-menu/rh-menu-item.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './rh-menu-dropdown.css' with { type: 'css' };
 
 /** Fired when a user selects an action or link from the menu */
@@ -43,6 +45,7 @@ export class MenuDropdownSelectEvent extends Event {
  *        `RhMenuItem` element and its text content.
  */
 @customElement('rh-menu-dropdown')
+@themable
 export class RhMenuDropdown extends LitElement {
   static readonly styles: CSSStyleSheet[] = [styles];
   private static instances = new Set<RhMenuDropdown>();


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the element's CSS, including `light-dark()` fallbacks for theme-adaptive colors.
2. Closes #3179.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Menu dropdown](http://localhost:8000/elements/menu-dropdown/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Run `npm run lint` in the RHDS directory.
5. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
6. Ensure the changeset is accurate.
7. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.