### PR TITLE
fix(select): add css token fallbacks

### DIFF
--- a/.changeset/select-token-fallbacks.md
+++ b/.changeset/select-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-select>`: add default fallbacks for each RHDS token used

--- a/elements/rh-select/demo/color-context.html
+++ b/elements/rh-select/demo/color-context.html
@@ -37,7 +37,7 @@ description: Select rendered across light and dark color contexts to verify surf
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/dynamic-options.html
+++ b/elements/rh-select/demo/dynamic-options.html
@@ -153,7 +153,7 @@ description: "Select with buttons to dynamically add and remove options at the t
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }
@@ -161,27 +161,32 @@ description: "Select with buttons to dynamically add and remove options at the t
   .button-group {
     display: flex;
     flex-direction: column;
-    gap: var(--rh-space-sm, 8px);
+    gap: var(--rh-space-sm, 6px);
     margin-inline: 20px;
     margin-block-start: var(--rh-space-lg, 16px);
   }
 
   .button-group-label {
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-size: var(--rh-font-size-body-text-sm, 0.875rem);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
-    color: var(--rh-color-text-secondary, #6a6e73);
+    color:
+      var(--rh-color-text-secondary,
+        light-dark(
+          var(--rh-color-text-secondary-on-light, #4d4d4d),
+          var(--rh-color-text-secondary-on-dark, #c7c7c7)
+        ));
   }
 
   .button-row {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--rh-space-sm, 8px);
+    gap: var(--rh-space-sm, 6px);
   }
 
   .button-row button {
-    font-family: var(--rh-font-family-body-text);
-    padding: var(--rh-space-sm, 8px) var(--rh-space-md, 16px);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+    padding: var(--rh-space-sm, 6px) var(--rh-space-md, 8px);
   }
 
   .button-row button:disabled {

--- a/elements/rh-select/demo/events.html
+++ b/elements/rh-select/demo/events.html
@@ -54,7 +54,7 @@ description: "Demonstrates the change, open, and close events fired by the selec
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/index.html
+++ b/elements/rh-select/demo/index.html
@@ -27,7 +27,7 @@ description: "Basic select with a label, placeholder text, and a list of options
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/methods-simple.html
+++ b/elements/rh-select/demo/methods-simple.html
@@ -45,7 +45,7 @@ description: "Uses the show(), hide(), and toggle() methods with plain HTML butt
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/methods.html
+++ b/elements/rh-select/demo/methods.html
@@ -46,7 +46,7 @@ description: "Uses the show(), hide(), and toggle() methods to programmatically 
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/option-descriptions.html
+++ b/elements/rh-select/demo/option-descriptions.html
@@ -32,7 +32,7 @@ description: Options with description text using the description attribute and t
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/option-group.html
+++ b/elements/rh-select/demo/option-group.html
@@ -65,7 +65,7 @@ description: "Options organized into labeled groups using rh-option-group, inclu
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/option-icons.html
+++ b/elements/rh-select/demo/option-icons.html
@@ -41,7 +41,7 @@ description: Options with icons using the icon and icon-set attributes on rh-opt
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/required.html
+++ b/elements/rh-select/demo/required.html
@@ -31,7 +31,7 @@ description: Required select within a form that validates on submit and shows a 
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }
@@ -41,6 +41,11 @@ description: Required select within a form that validates on submit and shows a 
   }
 
   .required {
-    color: var(--rh-color-status-danger);
+    color:
+      var(--rh-color-status-danger,
+        light-dark(
+          var(--rh-color-status-danger-on-light, #b1380b),
+          var(--rh-color-status-danger-on-dark, #f0561d)
+        ));
   }
 </style>

--- a/elements/rh-select/demo/states.html
+++ b/elements/rh-select/demo/states.html
@@ -62,7 +62,7 @@ description: "Select controls in success, warning, danger, and default states wi
 
   label {
     display: block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }

--- a/elements/rh-select/demo/tooltip.html
+++ b/elements/rh-select/demo/tooltip.html
@@ -36,7 +36,7 @@ description: Select paired with an rh-tooltip providing additional context about
 
   label {
     display: inline-block;
-    font-family: var(--rh-font-family-body-text);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
     font-weight: var(--rh-font-weight-body-text-medium, 500);
     margin-block: var(--rh-space-md, 8px);
   }
@@ -56,11 +56,21 @@ description: Select paired with an rh-tooltip providing additional context about
     padding: 0;
 
     &:hover {
-      color: var(--rh-color-interactive-primary-hover);
+      color:
+        var(--rh-color-interactive-primary-hover,
+          light-dark(
+            var(--rh-color-interactive-primary-hover-on-light, #003366),
+            var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)
+          ));
     }
 
     &:focus-visible {
-      outline-color: var(--rh-color-border-interactive);
+      outline-color:
+        var(--rh-color-border-interactive,
+          light-dark(
+            var(--rh-color-border-interactive-on-light, #0066cc),
+            var(--rh-color-border-interactive-on-dark, #92c5f9)
+          ));
     }
   }
 </style>

--- a/elements/rh-select/rh-select.css
+++ b/elements/rh-select/rh-select.css
@@ -63,7 +63,7 @@
   border-radius: var(--rh-border-radius-default, 3px);
 
   /** Small shadow design token for dropdown elevation */
-  box-shadow: var(--rh-box-shadow-sm);
+  box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21, 21, 21, 0.2));
 
   /** Medium spacing design token for vertical padding */
   padding-block: var(--rh-space-md, 8px);


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the element's CSS.
2. Added the same fallbacks to inline CSS in the affected demos, including `light-dark()` fallbacks for theme-adaptive colors.
3. Closes #3131, closes #3147.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Select](http://localhost:8000/elements/select/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Check the other affected demos the same way:
   - [Color context](http://localhost:8000/elements/select/color-context/)
   - [Dynamic options](http://localhost:8000/elements/select/dynamic-options/)
   - [Events](http://localhost:8000/elements/select/events/)
   - [Methods](http://localhost:8000/elements/select/methods/)
   - [Methods simple](http://localhost:8000/elements/select/methods-simple/)
   - [Option descriptions](http://localhost:8000/elements/select/option-descriptions/)
   - [Option group](http://localhost:8000/elements/select/option-group/)
   - [Option icons](http://localhost:8000/elements/select/option-icons/)
   - [Required](http://localhost:8000/elements/select/required/)
   - [States](http://localhost:8000/elements/select/states/)
   - [Tooltip](http://localhost:8000/elements/select/tooltip/)
5. On those pages, confirm demo page background and text still resolve if the demo sets them.
6. Run `npm run lint` in the RHDS directory.
7. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
8. Ensure the changeset is accurate.
9. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.