### PR TITLE
docs(avatar): add css token fallbacks

### DIFF
--- a/elements/rh-avatar/demo/layouts-in-narrow-containers.html
+++ b/elements/rh-avatar/demo/layouts-in-narrow-containers.html
@@ -71,12 +71,7 @@ description: Inline bordered avatars with linked names in a narrow container, de
           var(--rh-color-accent-base-on-light, #0066cc),
           var(--rh-color-accent-base-on-dark, #92c5f9)
         ));
-    --rh-color-interactive-primary-hover-on-dark:
-      var(--rh-color-accent-base,
-        light-dark(
-          var(--rh-color-accent-base-on-light, #0066cc),
-          var(--rh-color-accent-base-on-dark, #92c5f9)
-        ));
+    --rh-color-interactive-primary-hover-on-dark: #b9dafc;
     --rh-border-width-sm: var(--rh-length-xs, 4px);
 
     padding: var(--rh-space-lg, 16px);

--- a/elements/rh-avatar/demo/layouts-in-narrow-containers.html
+++ b/elements/rh-avatar/demo/layouts-in-narrow-containers.html
@@ -47,11 +47,36 @@ description: Inline bordered avatars with linked names in a narrow container, de
   rh-avatar {
     --rh-avatar-size: var(--rh-length-3xl, 48px);
     --rh-color-surface-darker: var(--rh-color-purple-70, #21134d);
-    --rh-color-border-subtle: var(--rh-color-brand-red, light-dark(var(--rh-color-brand-red-on-light, #ee0000), var(--rh-color-brand-red-on-dark, #ee0000)));
-    --rh-color-text-secondary: --var(--rh-color-accent-base, light-dark(var(--rh-color-accent-base-on-light, #0066cc), var(--rh-color-accent-base-on-dark, #92c5f9)));
-    --rh-color-interactive-primary-default-on-dark: var(--rh-color-accent-base, light-dark(var(--rh-color-accent-base-on-light, #0066cc), var(--rh-color-accent-base-on-dark, #92c5f9)));
-    --rh-color-interactive-primary-visited-default-on-dark: var(--rh-color-accent-base, light-dark(var(--rh-color-accent-base-on-light, #0066cc), var(--rh-color-accent-base-on-dark, #92c5f9)));
-    --rh-color-interactive-primary-hover-on-dark: var(--rh-color-accent);
+    --rh-color-border-subtle:
+      var(--rh-color-brand-red,
+        light-dark(
+          var(--rh-color-brand-red-on-light, #ee0000),
+          var(--rh-color-brand-red-on-dark, #ee0000)
+        ));
+    --rh-color-text-secondary:
+      var(--rh-color-accent-base,
+        light-dark(
+          var(--rh-color-accent-base-on-light, #0066cc),
+          var(--rh-color-accent-base-on-dark, #92c5f9)
+        ));
+    --rh-color-interactive-primary-default-on-dark:
+      var(--rh-color-accent-base,
+        light-dark(
+          var(--rh-color-accent-base-on-light, #0066cc),
+          var(--rh-color-accent-base-on-dark, #92c5f9)
+        ));
+    --rh-color-interactive-primary-visited-default-on-dark:
+      var(--rh-color-accent-base,
+        light-dark(
+          var(--rh-color-accent-base-on-light, #0066cc),
+          var(--rh-color-accent-base-on-dark, #92c5f9)
+        ));
+    --rh-color-interactive-primary-hover-on-dark:
+      var(--rh-color-accent-base,
+        light-dark(
+          var(--rh-color-accent-base-on-light, #0066cc),
+          var(--rh-color-accent-base-on-dark, #92c5f9)
+        ));
     --rh-border-width-sm: var(--rh-length-xs, 4px);
 
     padding: var(--rh-space-lg, 16px);


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks to inline CSS in the Avatar `layouts-in-narrow-containers` demo, including wrapped `light-dark()` fallbacks.
2. Closes #3136.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [layouts-in-narrow-containers](http://localhost:8000/elements/avatar/layouts-in-narrow-containers/) demo.
3. Confirm the avatars still have surface, text, border, and link colors as designed. Toggle reproduction and check wrapping.
4. Run `npm run lint` in the RHDS directory.
5. Open `elements/rh-avatar/demo/layouts-in-narrow-containers.html` in your editor. Ensure eslint does not flag any errors.
6. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.