### PR TITLE
fix(pagination): add css token fallbacks

### DIFF
--- a/.changeset/pagination-token-fallbacks.md
+++ b/.changeset/pagination-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-pagination>`: add default fallbacks for each RHDS token used

--- a/elements/rh-pagination/rh-pagination-lightdom.css
+++ b/elements/rh-pagination/rh-pagination-lightdom.css
@@ -38,11 +38,15 @@ rh-pagination {
         outline: var(--rh-border-width-md, 2px) solid transparent;
         outline-color:
           /** Page link focus outline color override */
-          var(
-              --rh-pagination-accent-color,
-              /** Page link focus outline color */
-              var(--rh-color-interactive-primary-default)
-            );
+          var(--rh-pagination-accent-color,
+            /** Page link focus outline color; theme-adaptive */
+            var(--rh-color-interactive-primary-default,
+            light-dark(
+              /** Page link focus outline color in light mode */
+              var(--rh-color-interactive-primary-default-on-light, #0066cc),
+              /** Page link focus outline color in dark mode */
+              var(--rh-color-interactive-primary-default-on-dark, #92c5f9)
+            )));
       }
 
       &:hover:after,
@@ -84,11 +88,15 @@ rh-pagination {
       &[aria-current='page']:after {
         border-block-color:
           /** Page link focus/active accent color override */
-          var(
-              --rh-pagination-accent-color,
-              /** Page link focus/active accent color */
-              var(--rh-color-border-interactive)
-            );
+          var(--rh-pagination-accent-color,
+            /** Page link focus/active accent color; theme-adaptive */
+            var(--rh-color-border-interactive,
+            light-dark(
+              /** Page link focus/active accent color in light mode */
+              var(--rh-color-border-interactive-on-light, #0066cc),
+              /** Page link focus/active accent color in dark mode */
+              var(--rh-color-border-interactive-on-dark, #92c5f9)
+            )));
       }
     }
   }

--- a/elements/rh-pagination/rh-pagination.css
+++ b/elements/rh-pagination/rh-pagination.css
@@ -361,7 +361,7 @@ input {
   form {
     display: flex;
     flex-direction: row;
-    gap: var(--rh-space-md);
+    gap: var(--rh-space-md, 8px);
   }
 
   & a {
@@ -369,8 +369,8 @@ input {
     text-decoration: underline dashed var(--rh-border-width-sm, 1px);
     text-decoration-color:
       light-dark(
-          /** Total link underline in light mode */ var(--rh-color-gray-50),
-          /** Total link underline in dark mode */ var(--rh-color-gray-40)
+          /** Total link underline in light mode */ var(--rh-color-gray-50, #707070),
+          /** Total link underline in dark mode */ var(--rh-color-gray-40, #a3a3a3)
         );
     text-underline-offset: max(5px, 0.28em);
     transition-timing-function: ease;


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the element's CSS, including `light-dark()` fallbacks for theme-adaptive colors in lightdom.
2. Closes #3129.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Pagination](http://localhost:8000/elements/pagination/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm page links, steppers, the page input, and type still look as designed.
4. Check the [Color context](http://localhost:8000/elements/pagination/color-context/) demo the same way.
5. Run `npm run lint` in the RHDS directory.
6. Open `rh-pagination.css` and `rh-pagination-lightdom.css` in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
7. Ensure the changeset is accurate.
8. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.