### PR TITLE
fix(jump-links): add css token fallbacks

### DIFF
--- a/.changeset/jump-links-token-fallbacks.md
+++ b/.changeset/jump-links-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-jump-links>`: add default fallbacks for each RHDS token used

--- a/elements/rh-jump-links/demo/felt-theme.html
+++ b/elements/rh-jump-links/demo/felt-theme.html
@@ -12,11 +12,11 @@ description: Vertical, nested, and horizontal jump links with the [Project Felt]
 
     aside {
       h2 {
-        font-weight: var(--rh-font-weight-heading-medium);
-        font-family: var(--rh-font-family-body-text);
-        font-size: var(--rh-font-size-body-text-md);
+        font-weight: var(--rh-font-weight-heading-medium, 500);
+        font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+        font-size: var(--rh-font-size-body-text-md, 1rem);
         line-height: var(--rh-line-height-body-text, 1.5);
-        margin-block-end: var(--rh-space-lg);
+        margin-block-end: var(--rh-space-lg, 16px);
       }
     }
   }
@@ -25,11 +25,11 @@ description: Vertical, nested, and horizontal jump links with the [Project Felt]
     padding: var(--rh-space-lg, 16px);
 
     h2 {
-      font-weight: var(--rh-font-weight-heading-medium);
-      font-family: var(--rh-font-family-body-text);
-      font-size: var(--rh-font-size-body-text-md);
+      font-weight: var(--rh-font-weight-heading-medium, 500);
+      font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+      font-size: var(--rh-font-size-body-text-md, 1rem);
       line-height: var(--rh-line-height-body-text, 1.5);
-      margin-block-end: var(--rh-space-lg);
+      margin-block-end: var(--rh-space-lg, 16px);
     }
   }
   .felt-preview {

--- a/elements/rh-jump-links/demo/horizontal.html
+++ b/elements/rh-jump-links/demo/horizontal.html
@@ -249,28 +249,33 @@ description: Horizontal jump links layout with overflow scroll buttons.
 
     #jump-links-container,
     article {
-      background-color: var(--rh-color-surface);
+      background-color:
+        var(--rh-color-surface,
+          light-dark(
+            var(--rh-color-surface-lightest, #ffffff),
+            var(--rh-color-surface-darkest, #151515)
+          ));
     }
 
     article {
-      padding: var(--rh-space-2xl);
+      padding: var(--rh-space-2xl, 32px);
     }
 
     #jump-links-container {
       position: sticky;
-      padding-inline: var(--rh-space-2xl);
-      padding-block-start: var(--rh-space-2xl);
+      padding-inline: var(--rh-space-2xl, 32px);
+      padding-block-start: var(--rh-space-2xl, 32px);
       inset-block-start: 0;
     }
 
     #jump-links-title {
-      font-weight: var(--rh-font-weight-heading-medium);
-      font-family: var(--rh-font-family-body-text);
-      font-size: var(--rh-font-size-body-text-md);
+      font-weight: var(--rh-font-weight-heading-medium, 500);
+      font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+      font-size: var(--rh-font-size-body-text-md, 1rem);
       line-height: var(--rh-line-height-body-text, 1.5);
       text-align: center;
       margin: 0 auto;
-      margin-block-end: var(--rh-space-lg);
+      margin-block-end: var(--rh-space-lg, 16px);
     }
 
     h2 {

--- a/elements/rh-jump-links/demo/index.html
+++ b/elements/rh-jump-links/demo/index.html
@@ -28,11 +28,11 @@ description: Default vertical jump links with scroll spy tracking active section
 
     aside {
       h2 {
-        font-weight: var(--rh-font-weight-heading-medium);
-        font-family: var(--rh-font-family-body-text);
-        font-size: var(--rh-font-size-body-text-md);
+        font-weight: var(--rh-font-weight-heading-medium, 500);
+        font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+        font-size: var(--rh-font-size-body-text-md, 1rem);
         line-height: var(--rh-line-height-body-text, 1.5);
-        margin-block-end: var(--rh-space-lg);
+        margin-block-end: var(--rh-space-lg, 16px);
       }
     }
   }

--- a/elements/rh-jump-links/demo/nested.html
+++ b/elements/rh-jump-links/demo/nested.html
@@ -208,11 +208,11 @@ description: Jump links with nested rh-jump-links-list groups for hierarchical n
     max-width: 100dvw;
     display: grid;
     grid-template-columns: auto auto;
-    gap: var(--rh-space-lg);
+    gap: var(--rh-space-lg, 16px);
 
     #jump-links-container,
     article {
-      padding: var(--rh-space-2xl);
+      padding: var(--rh-space-2xl, 32px);
     }
 
     #jump-links-container {
@@ -223,10 +223,10 @@ description: Jump links with nested rh-jump-links-list groups for hierarchical n
   }
 
   #jump-links-title {
-    font-weight: var(--rh-font-weight-heading-medium);
-    font-family: var(--rh-font-family-body-text);
-    font-size: var(--rh-font-size-body-text-md);
+    font-weight: var(--rh-font-weight-heading-medium, 500);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+    font-size: var(--rh-font-size-body-text-md, 1rem);
     line-height: var(--rh-line-height-body-text, 1.5);
-    margin-block-end: var(--rh-space-lg);
+    margin-block-end: var(--rh-space-lg, 16px);
   }
 </style>

--- a/elements/rh-jump-links/demo/responsive.html
+++ b/elements/rh-jump-links/demo/responsive.html
@@ -145,17 +145,17 @@ description: Responsive jump links switching between vertical and horizontal lay
 <style>
   #responsive-container {
     max-width: 100dvw;
-    margin: var(--rh-space-xl);
+    margin: var(--rh-space-xl, 24px);
 
     & p {
-      margin-block-end: var(--rh-space-md);
+      margin-block-end: var(--rh-space-md, 8px);
     }
 
     & h2 {
-      font-size: var(--rh-font-size-heading-xl);
-      font-weight: var(--rh-font-weight-heading-regular);
-      font-family: var(--rh-font-family-heading);
-      margin-block: var(--rh-space-md);
+      font-size: var(--rh-font-size-heading-xl, 2.5rem);
+      font-weight: var(--rh-font-weight-heading-regular, 400);
+      font-family: var(--rh-font-family-heading, RedHatDisplay, 'Red Hat Display', Helvetica, Arial, sans-serif);
+      margin-block: var(--rh-space-md, 8px);
     }
 
     & .jump-links-title {
@@ -163,11 +163,11 @@ description: Responsive jump links switching between vertical and horizontal lay
         display: inline;
       }
 
-      font-weight: var(--rh-font-weight-heading-medium);
-      font-family: var(--rh-font-family-body-text);
-      font-size: var(--rh-font-size-body-text-md);
-      line-height: var(--rh-line-height-body-text);
-      margin-block-end: var(--rh-space-lg);
+      font-weight: var(--rh-font-weight-heading-medium, 500);
+      font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+      font-size: var(--rh-font-size-body-text-md, 1rem);
+      line-height: var(--rh-line-height-body-text, 1.5);
+      margin-block-end: var(--rh-space-lg, 16px);
     }
 
     & .desktop {
@@ -175,14 +175,14 @@ description: Responsive jump links switching between vertical and horizontal lay
     }
 
     & rh-disclosure {
-      margin-block-end: var(--rh-space-xl);
+      margin-block-end: var(--rh-space-xl, 24px);
     }
 
     /*--rh-media-md*/
     @media (width >=992px) {
       display: grid;
       grid-template-columns: auto 1fr;
-      gap: var(--rh-space-lg);
+      gap: var(--rh-space-lg, 16px);
       align-items: start;
 
       & .desktop {

--- a/elements/rh-jump-links/demo/with-content.html
+++ b/elements/rh-jump-links/demo/with-content.html
@@ -130,11 +130,11 @@ description: Jump links alongside page content demonstrating scroll spy behavior
   #page-content {
     display: grid;
     grid-template-columns: auto 1fr;
-    gap: var(--rh-space-lg);
+    gap: var(--rh-space-lg, 16px);
 
     #jump-links-container,
     article {
-      padding: var(--rh-space-2xl);
+      padding: var(--rh-space-2xl, 32px);
     }
   }
 
@@ -145,10 +145,10 @@ description: Jump links alongside page content demonstrating scroll spy behavior
   }
 
   #jump-links-title {
-    font-weight: var(--rh-font-weight-heading-medium);
-    font-family: var(--rh-font-family-body-text);
-    font-size: var(--rh-font-size-body-text-md);
+    font-weight: var(--rh-font-weight-heading-medium, 500);
+    font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
+    font-size: var(--rh-font-size-body-text-md, 1rem);
     line-height: var(--rh-line-height-body-text, 1.5);
-    margin-block-end: var(--rh-space-lg);
+    margin-block-end: var(--rh-space-lg, 16px);
   }
 </style>

--- a/elements/rh-jump-links/rh-jump-links.css
+++ b/elements/rh-jump-links/rh-jump-links.css
@@ -35,7 +35,7 @@
       /* scroll button width */
 
       /** Jump link horizontal margin */
-      margin-inline: var(--rh-space-3xl);
+      margin-inline: var(--rh-space-3xl, 48px);
       border-block-start:
         /** Horizontal top border width */
         var(--rh-border-width-sm, 1px)


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the element's CSS, including `light-dark()` fallbacks for theme-adaptive colors.
2. Added the same fallbacks to inline CSS in the affected demos.
3. Closes #3126, closes #3141.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Jump links](http://localhost:8000/elements/jump-links/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Check the other affected demos the same way:
   - [Nested](http://localhost:8000/elements/jump-links/nested/)
   - [With content](http://localhost:8000/elements/jump-links/with-content/)
   - [Horizontal](http://localhost:8000/elements/jump-links/horizontal/)
   - [Responsive](http://localhost:8000/elements/jump-links/responsive/)
   - [Felt theme](http://localhost:8000/elements/jump-links/felt-theme/)
5. On those pages, confirm demo page background and text still resolve if the demo sets them.
6. Run `npm run lint` in the RHDS directory.
7. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
8. Ensure the changeset is accurate.
9. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.