### PR TITLE
fix(chip): ensure @themable is loaded instead of relying on transitiv…

### DIFF
--- a/.changeset/cozy-lines-wait.md
+++ b/.changeset/cozy-lines-wait.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-chip-group>`: ensure themable loads the default theme
+  

--- a/elements/rh-chip/rh-chip-group.ts
+++ b/elements/rh-chip/rh-chip-group.ts
@@ -7,6 +7,8 @@ import { query } from 'lit/decorators/query.js';
 
 import { RhChip, ChipChangeEvent } from './rh-chip.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
+
 import styles from './rh-chip-group.css' with { type: 'css' };
 
 /**
@@ -22,6 +24,7 @@ import styles from './rh-chip-group.css' with { type: 'css' };
  *          accessible label, styled with `--rh-font-size-body-text-md`.
  */
 @customElement('rh-chip-group')
+@themable
 export class RhChipGroup extends LitElement {
   static readonly styles = [styles];
 


### PR DESCRIPTION
## What I did

1.  Added `@themable` to `rh-chip-group.ts` instead of relying on transitive dep, lint isn't smart enough to follow transitive at this time.

Closes #3174 



## Testing Instructions

1.

## Notes to Reviewers

The missing fallbacks in that issue were because rh-chip-group.ts did not load `@themable` so the require-token-fallback lint suggests that you should load the fallbacks for the scheme tokens.  Instead adding `@themable` lets the lint know that we expect the default-theme to be loaded by this component so we don't need the fallback values.