### PR TITLE
fix(navigation-secodary) missing fallbacks

### DIFF
--- a/.changeset/salty-areas-look.md
+++ b/.changeset/salty-areas-look.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-secondary>`: add default fallbacks for each RHDS token used
+  

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-dropdown.ts
@@ -4,6 +4,7 @@ import { state } from 'lit/decorators/state.js';
 import { query } from 'lit/decorators/query.js';
 import { classMap } from 'lit/directives/class-map.js';
 
+import { themable } from '@rhds/elements/lib/themable.js';
 import { ComposedEvent } from '@patternfly/pfe-core';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 import { bound, observes } from '@patternfly/pfe-core/decorators.js';
@@ -45,6 +46,7 @@ import styles from './rh-navigation-secondary-dropdown.css' with { type: 'css' }
  * @slot menu - The dropdown menu. Expects `<rh-navigation-secondary-menu>` element.
  */
 @customElement('rh-navigation-secondary-dropdown')
+@themable
 export class RhNavigationSecondaryDropdown extends LitElement {
   static readonly styles = [styles];
 

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -4,9 +4,12 @@ rh-navigation-secondary {
 
   /** Navigation link text color */
   --_nav-link-color:
+    /** Navigation link text color; theme-adaptive */
     var(--rh-color-text-primary,
       light-dark(
+        /** Navigation link text color for light color schemes */
         var(--rh-color-text-primary-on-light, #151515),
+        /** Navigation link text color for dark color schemes */
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
 

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -5,26 +5,30 @@ rh-navigation-secondary {
     /** Navigation link text color; theme-adaptive */
     var(--rh-color-text-primary,
       light-dark(
-        /** Navigation link text color for light color schemes */
+        /** Navigation link text color on light scheme */
         var(--rh-color-text-primary-on-light, #151515),
-        /** Navigation link text color for dark color schemes */
+        /** Navigation link text color on dark scheme */
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
   --_logo-link-color:
     /** Navigation logo link text color */
     var(--rh-color-text-primary,
       light-dark(
+        /** Navigation logo link text color on light scheme */
         var(--rh-color-text-primary-on-light, #151515),
+        /** Navigation logo link text color on dark scheme */
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
   --_nav-chevron-color:
     /** Navigation dropdown chevron indicators */
     var(--rh-color-text-primary,
       light-dark(
+        /** Navigation dropdown chevron indicators on light scheme */
         var(--rh-color-text-primary-on-light, #151515),
+        /** Navigation dropdown chevron indicators on dark scheme */
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
-  --rh-color-surface:
+  --_nav-background:
     light-dark(
         /** Navigation bar surface in light mode */
         var(--rh-color-surface-lighter, #f2f2f2),
@@ -35,14 +39,7 @@ rh-navigation-secondary {
   display: block;
   position: sticky;
   top: 0;
-
-  /** Navigation bar background */
-  background-color:
-    var(--rh-color-surface,
-      light-dark(
-        var(--rh-color-surface-lightest, #ffffff),
-        var(--rh-color-surface-darkest, #151515)
-      ));
+  background-color: var(--_nav-background);
   border-block-end:
     /** Navigation bar block-end border width */
     var(--rh-border-width-sm, 1px)

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -232,11 +232,13 @@ rh-navigation-secondary-dropdown > a {
 }
 
 rh-navigation-secondary [slot='nav'] > li > a[aria-current='page'] {
-  /** Navigation current-page link block-start accent color */
   border-block-start-color:
+     /** Navigation current-page link block-start accent color */
     var(--rh-color-brand-red,
       light-dark(
+        /** Navigation current-page link block-start accent color on light scheme */
         var(--rh-color-brand-red-on-light, #ee0000),
+        /** Navigation current-page link block-start accent color on dark scheme */
         var(--rh-color-brand-red-on-dark, #ee0000)
       ));
 }

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -30,7 +30,7 @@ rh-navigation-secondary {
       ));
   --_nav-background:
     light-dark(
-        /** Navigation bar surface in light mode */
+        /** Navigation bar surface on light scheme  */
         var(--rh-color-surface-lighter, #f2f2f2),
         /** Navigation bar surface in dark mode */
         var(--rh-color-surface-dark, #383838)

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -3,13 +3,28 @@ rh-navigation-secondary {
   --_min-height: 80px;
 
   /** Navigation link text color */
-  --_nav-link-color: var(--rh-color-text-primary);
+  --_nav-link-color:
+    var(--rh-color-text-primary,
+      light-dark(
+        var(--rh-color-text-primary-on-light, #151515),
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      ));
 
   /** Navigation logo link text color */
-  --_logo-link-color: var(--rh-color-text-primary);
+  --_logo-link-color:
+    var(--rh-color-text-primary,
+      light-dark(
+        var(--rh-color-text-primary-on-light, #151515),
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      ));
 
   /** Navigation dropdown chevron indicators */
-  --_nav-chevron-color: var(--rh-color-text-primary);
+  --_nav-chevron-color:
+    var(--rh-color-text-primary,
+      light-dark(
+        var(--rh-color-text-primary-on-light, #151515),
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      ));
   --rh-color-surface:
     light-dark(
         /** Navigation bar surface in light mode */
@@ -23,7 +38,12 @@ rh-navigation-secondary {
   top: 0;
 
   /** Navigation bar background */
-  background-color: var(--rh-color-surface);
+  background-color:
+    var(--rh-color-surface,
+      light-dark(
+        var(--rh-color-surface-lightest, #ffffff),
+        var(--rh-color-surface-darkest, #151515)
+      ));
   border-block-end:
     /** Navigation bar block-end border width */
     var(--rh-border-width-sm, 1px)
@@ -93,7 +113,12 @@ rh-navigation-secondary {
 
     &[aria-current='page'] {
       /** Navigation logo current-page block-start accent color */
-      border-block-start-color: var(--rh-color-brand-red);
+      border-block-start-color:
+        var(--rh-color-brand-red,
+          light-dark(
+            var(--rh-color-brand-red-on-light, #ee0000),
+            var(--rh-color-brand-red-on-dark, #ee0000)
+          ));
     }
   }
 
@@ -212,13 +237,23 @@ rh-navigation-secondary-dropdown > a {
 
 rh-navigation-secondary [slot='nav'] > li > a[aria-current='page'] {
   /** Navigation current-page link block-start accent color */
-  border-block-start-color: var(--rh-color-brand-red);
+  border-block-start-color:
+    var(--rh-color-brand-red,
+      light-dark(
+        var(--rh-color-brand-red-on-light, #ee0000),
+        var(--rh-color-brand-red-on-dark, #ee0000)
+      ));
 }
 
 rh-navigation-secondary [slot='nav'] > li > rh-navigation-link[current-page],
 rh-navigation-secondary [slot='nav'] > li > rh-navigation-link:has(a[aria-current='page']) {
   /** Navigation current-page link block-start accent color */
-  border-block-start-color: var(--rh-color-brand-red);
+  border-block-start-color:
+    var(--rh-color-brand-red,
+      light-dark(
+        var(--rh-color-brand-red-on-light, #ee0000),
+        var(--rh-color-brand-red-on-dark, #ee0000)
+      ));
 }
 
 rh-navigation-secondary > [slot='nav'] > li > a:hover,
@@ -284,7 +319,12 @@ rh-navigation-secondary > [slot='nav'] > li > rh-navigation-link {
   --_navigation-link-text-decoration-line: none;
 
   /** Navigation slotted rh-navigation-link color */
-  --_navigation-link-color-hover: var(--rh-color-text-primary);
+  --_navigation-link-color-hover:
+    var(--rh-color-text-primary,
+      light-dark(
+        var(--rh-color-text-primary-on-light, #151515),
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      ));
 
   display: flex;
   block-size: 100%;
@@ -307,7 +347,12 @@ rh-navigation-secondary > [slot='nav'] > li > rh-navigation-link {
 
     &:hover {
       /** Navigation link hovered block-start accent color at viewport >= lg */
-      border-block-start-color: var(--rh-color-text-brand);
+      border-block-start-color:
+        var(--rh-color-text-brand,
+          light-dark(
+            var(--rh-color-text-brand-on-light, #ee0000),
+            var(--rh-color-text-brand-on-dark, #ee0000)
+          ));
     }
   }
 }

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -1,8 +1,6 @@
 rh-navigation-secondary {
   --_max-height: max-content;
   --_min-height: 80px;
-
-  /** Navigation link text color */
   --_nav-link-color:
     /** Navigation link text color; theme-adaptive */
     var(--rh-color-text-primary,
@@ -12,17 +10,15 @@ rh-navigation-secondary {
         /** Navigation link text color for dark color schemes */
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
-
-  /** Navigation logo link text color */
   --_logo-link-color:
+    /** Navigation logo link text color */
     var(--rh-color-text-primary,
       light-dark(
         var(--rh-color-text-primary-on-light, #151515),
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
-
-  /** Navigation dropdown chevron indicators */
   --_nav-chevron-color:
+    /** Navigation dropdown chevron indicators */
     var(--rh-color-text-primary,
       light-dark(
         var(--rh-color-text-primary-on-light, #151515),

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -108,11 +108,13 @@ rh-navigation-secondary {
     }
 
     &[aria-current='page'] {
-      /** Navigation logo current-page block-start accent color */
       border-block-start-color:
+        /** Navigation logo current-page block-start accent color */
         var(--rh-color-brand-red,
           light-dark(
+            /** Navigation logo current-page block-start accent color on light scheme */
             var(--rh-color-brand-red-on-light, #ee0000),
+            /** Navigation logo current-page block-start accent color on dark scheme */
             var(--rh-color-brand-red-on-dark, #ee0000)
           ));
     }

--- a/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
+++ b/elements/rh-navigation-secondary/rh-navigation-secondary-lightdom.css
@@ -243,11 +243,13 @@ rh-navigation-secondary [slot='nav'] > li > a[aria-current='page'] {
 
 rh-navigation-secondary [slot='nav'] > li > rh-navigation-link[current-page],
 rh-navigation-secondary [slot='nav'] > li > rh-navigation-link:has(a[aria-current='page']) {
-  /** Navigation current-page link block-start accent color */
   border-block-start-color:
+    /** Navigation current-page link block-start accent color */
     var(--rh-color-brand-red,
       light-dark(
+        /** Navigation current-page link block-start accent color on light scheme */
         var(--rh-color-brand-red-on-light, #ee0000),
+        /** Navigation current-page link block-start accent color on dark scheme */
         var(--rh-color-brand-red-on-dark, #ee0000)
       ));
 }
@@ -313,12 +315,13 @@ rh-navigation-secondary > [slot='nav'] > li > rh-navigation-link {
     var(--rh-space-xl, 24px);
   --_navigation-link-font-weight: 500;
   --_navigation-link-text-decoration-line: none;
-
-  /** Navigation slotted rh-navigation-link color */
   --_navigation-link-color-hover:
+    /** Navigation slotted rh-navigation-link color */
     var(--rh-color-text-primary,
       light-dark(
+        /** Navigation slotted rh-navigation-link color on light scheme */
         var(--rh-color-text-primary-on-light, #151515),
+        /** Navigation slotted rh-navigation-link color on dark scheme */
         var(--rh-color-text-primary-on-dark, #ffffff)
       ));
 
@@ -342,11 +345,13 @@ rh-navigation-secondary > [slot='nav'] > li > rh-navigation-link {
       transparent;
 
     &:hover {
-      /** Navigation link hovered block-start accent color at viewport >= lg */
       border-block-start-color:
+        /** Navigation link hovered block-start accent color at viewport >= lg */
         var(--rh-color-text-brand,
           light-dark(
+            /** Navigation link hovered block-start accent color on light scheme at viewport >= lg */
             var(--rh-color-text-brand-on-light, #ee0000),
+            /** Navigation link hovered block-start accent color on dark scheme at viewport >= lg */
             var(--rh-color-text-brand-on-dark, #ee0000)
           ));
     }


### PR DESCRIPTION
## What I did

1. Added missing fallbacks

Closes #3177 

## Testing Instructions

1.

## Notes to Reviewers

Note `--rh-color-surface` was set directly incorrectly on the `rh-navigation-secondary` selector in lightdom.css.  This wasn't visible in anyway if you overrode it with a different color that I could create.  I fixed that by correctly renaming to a private var `--_nav-surface` which is later used as the background color on the tag selector.  A set value still isn't visible unless it is reproducible on a really slow paint where the internal #container isn't yet overlaying the host background which I'm not sure is possible.
