### PR TITLE
feat(rh-tile): Add public tokens API for Felt preview theme

### DIFF
--- a/.changeset/wild-heads-go.md
+++ b/.changeset/wild-heads-go.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-tile>`: added new public CSS custom properties for theming border width, border color per state, disabled text, and focus ring (`--rh-tile-border-width`, `--rh-tile-focus-border-width`, `--rh-tile-hover-border-color`, `--rh-tile-active-border-color`, `--rh-tile-disabled-text-color`, `--rh-tile-focus-outline-color`). Border color and width now shift on hover/focus/active states. Focus border styles also apply via `:host(:focus-within)` for checkable tiles.

--- a/docs/theming/patterns/felt-preview-tile.html
+++ b/docs/theming/patterns/felt-preview-tile.html
@@ -1,6 +1,8 @@
 <link rel="stylesheet" href="/styles/demo/styles.css" media="all">
 <link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
-<link rel="stylesheet" href="/elements/rh-tile/rh-tile-lightdom.css">
+<style>
+@import url('/assets/packages/@rhds/elements/elements/rh-tile/rh-tile-lightdom.css');
+</style>
 
 <style>
   .example-row {
@@ -213,19 +215,19 @@
 <h3>Selectable tile (radio)</h3>
 <div class="tile-grid example-row">
   <rh-tile-group radio>
-    <rh-tile name="radio">
+    <rh-tile checkable name="radio">
       <h2 slot="headline">Headline</h2>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       <div slot="footer">Footer</div>
     </rh-tile>
 
-    <rh-tile name="radio" checked>
+    <rh-tile checkable name="radio" checked>
       <h2 slot="headline">Headline</h2>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       <div slot="footer">Footer</div>
     </rh-tile>
 
-    <rh-tile name="radio" disabled>
+    <rh-tile checkable name="radio" disabled>
       <h2 slot="headline">Headline</h2>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       <div slot="footer">Footer</div>

--- a/docs/theming/patterns/felt-preview-tile.html
+++ b/docs/theming/patterns/felt-preview-tile.html
@@ -1,0 +1,234 @@
+<link rel="stylesheet" href="/styles/demo/styles.css" media="all">
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
+<link rel="stylesheet" href="/elements/rh-tile/rh-tile-lightdom.css">
+
+<style>
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .tile-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-2xl, 32px);
+  }
+
+  .tile-grid rh-tile {
+    width: 320px;
+  }
+
+  .tile-grid-compact rh-tile {
+    width: 360px;
+  }
+</style>
+
+<h3>Link tile</h3>
+<div class="tile-grid example-row">
+  <rh-tile>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile desaturated>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile disabled>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Link tile with image</h3>
+<div class="tile-grid example-row">
+  <rh-tile bleed>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 200" width="100%">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="99%" height="99%"
+            fill="none"
+            stroke="var(--rh-color-icon-primary)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile bleed desaturated>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 200" width="100%">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="99%" height="99%"
+            fill="none"
+            stroke="var(--rh-color-icon-primary)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile bleed disabled>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 200" width="100%">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="99%" height="99%"
+            fill="none"
+            stroke="var(--rh-color-icon-primary)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Compact link tile</h3>
+<div class="tile-grid tile-grid-compact example-row">
+  <rh-tile compact>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact desaturated>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact disabled>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Compact link tile with image</h3>
+<div class="tile-grid tile-grid-compact example-row">
+  <rh-tile compact bleed>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="360" height="60"
+            fill="var(--rh-color-interactive-primary-default)"
+            fill-opacity="0.2"
+            stroke="var(--rh-color-interactive-primary-hover)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact bleed desaturated>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="360" height="60"
+            fill="var(--rh-color-interactive-primary-default)"
+            fill-opacity="0.2"
+            stroke="var(--rh-color-interactive-primary-hover)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact bleed disabled>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="360" height="60"
+            fill="var(--rh-color-interactive-primary-default)"
+            fill-opacity="0.2"
+            stroke="var(--rh-color-interactive-primary-hover)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Selectable tile (checkbox)</h3>
+<div class="tile-grid example-row">
+  <rh-tile-group>
+    <rh-tile checkable>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile checkable checked>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile checkable disabled>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+  </rh-tile-group>
+</div>
+
+<h3>Selectable tile (radio)</h3>
+<div class="tile-grid example-row">
+  <rh-tile-group radio>
+    <rh-tile name="radio">
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile name="radio" checked>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile name="radio" disabled>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+  </rh-tile-group>
+</div>

--- a/docs/theming/themes/project-felt/demos.md
+++ b/docs/theming/themes/project-felt/demos.md
@@ -34,6 +34,8 @@ subnav:
   import '@rhds/elements/rh-switch/rh-switch.js';
   import '@rhds/elements/rh-tabs/rh-tabs.js';
   import '@rhds/elements/rh-tag/rh-tag.js';
+  import '@rhds/elements/rh-tile/rh-tile.js';
+  import '@rhds/elements/rh-tile/rh-tile-group.js';
 </script>
 
 <link rel="stylesheet" data-helmet href="/theming/themes/project-felt/preview/felt-theme-preview.css">
@@ -230,6 +232,10 @@ Preview the Project Felt theme on the elements below. Toggle the switch to compa
 
 <uxdot-pattern src="../../patterns/felt-preview-tag.html">
   <uxdot-copy-permalink slot="heading"><h3 id="tag"><a href="#tag">Tags</a></h3></uxdot-copy-permalink>
+</uxdot-pattern>
+
+<uxdot-pattern src="../../patterns/felt-preview-tile.html">
+  <uxdot-copy-permalink slot="heading"><h3 id="tile" class="toc"><a href="#tile">Tile</a></h3></uxdot-copy-permalink>
 </uxdot-pattern>
 
 <uxdot-feedback>

--- a/docs/theming/themes/project-felt/demos.md
+++ b/docs/theming/themes/project-felt/demos.md
@@ -291,21 +291,21 @@ Preview the Project Felt theme on the elements below. Toggle the switch to compa
     pageToc.setAttribute('tabindex', '-1');
   }
 
-  // Force radio tile groups to set radioGroup on their tiles.
-  // In the SSR/uxdot-pattern context, rh-tile-group's firstUpdated
-  // fires before its children are adopted, and its slotchange listener
-  // (non-composed) never reaches the host. Set the property directly.
+  // Fix radio tile groups in uxdot-pattern SSR context.
+  // Lit's hydration caches the initial input type="checkbox" and
+  // doesn't re-render when radioGroup changes post-hydration.
+  // Patch the shadow DOM input type directly.
   await customElements.whenDefined('rh-tile-group');
   await customElements.whenDefined('rh-tile');
+  await new Promise(r => setTimeout(r, 0));
   for (const pattern of document.querySelectorAll('uxdot-pattern')) {
-    for (const group of pattern.shadowRoot?.querySelectorAll('rh-tile-group[radio]') ?? []) {
-      await group.updateComplete;
+    const root = pattern.shadowRoot;
+    if (!root) continue;
+    for (const group of root.querySelectorAll('rh-tile-group[radio]')) {
+      group.updateItems();
       for (const tile of group.querySelectorAll('rh-tile')) {
-        await tile.updateComplete;
-        tile.checkable = true;
-        tile.radioGroup = true;
-        tile.requestUpdate();
-        await tile.updateComplete;
+        const input = tile.shadowRoot?.querySelector('#input');
+        if (input) input.type = 'radio';
       }
     }
   }

--- a/docs/theming/themes/project-felt/demos.md
+++ b/docs/theming/themes/project-felt/demos.md
@@ -290,4 +290,23 @@ Preview the Project Felt theme on the elements below. Toggle the switch to compa
   if (pageToc) {
     pageToc.setAttribute('tabindex', '-1');
   }
+
+  // Force radio tile groups to set radioGroup on their tiles.
+  // In the SSR/uxdot-pattern context, rh-tile-group's firstUpdated
+  // fires before its children are adopted, and its slotchange listener
+  // (non-composed) never reaches the host. Set the property directly.
+  await customElements.whenDefined('rh-tile-group');
+  await customElements.whenDefined('rh-tile');
+  for (const pattern of document.querySelectorAll('uxdot-pattern')) {
+    for (const group of pattern.shadowRoot?.querySelectorAll('rh-tile-group[radio]') ?? []) {
+      await group.updateComplete;
+      for (const tile of group.querySelectorAll('rh-tile')) {
+        await tile.updateComplete;
+        tile.checkable = true;
+        tile.radioGroup = true;
+        tile.requestUpdate();
+        await tile.updateComplete;
+      }
+    }
+  }
 </script>

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -2331,11 +2331,15 @@
 
     /* Hover border: lighter blue */
     --rh-tile-hover-border-color:
-      var(--felt-preview-color-border-interactive-subtle-hover);
+      var(
+          --felt-preview-color-border-interactive-subtle-hover
+        );
 
     /* Active/focus border: darker blue */
     --rh-tile-active-border-color:
-      var(--felt-preview-color-border-interactive-subtle-active);
+      var(
+          --felt-preview-color-border-interactive-subtle-active
+        );
 
     /* Interactive color (icons, arrow, focus ring) */
     --rh-tile-interactive-color: var(--felt-preview-color-interactive-primary-default);
@@ -2358,27 +2362,31 @@
 
     /* Disabled text color */
     --rh-tile-disabled-text-color:
-      var(--felt-preview-color-text-status-on-disabled);
+      var(
+          --felt-preview-color-text-status-on-disabled
+        );
 
     /* Focus ring matches active/focus border color */
     --rh-tile-focus-outline-color:
-      var(--felt-preview-color-border-interactive-subtle-active);
+      var(
+          --felt-preview-color-border-interactive-subtle-active
+        );
 
     /* Suppress headline link outline (tile shows its own focus ring) */
-    & [slot="headline"] a:focus {
+    & [slot='headline'] a:focus {
       outline: none;
     }
 
-    /*
-     * Bleed image fix: the component's --_bleed only offsets padding,
-     * not the border width, leaving a gap at the border edge.
-     * Clip at the host level so the image fills to the outer border.
-     * TODO: remove once rh-tile accounts for border in --_bleed calc.
-     */
-    &[bleed] {
-      overflow: hidden;
-      border-radius:
-        calc(var(--felt-preview-border-radius-default) - 1px);
+    /* Round bleed image top corners to match the tile's inner border radius */
+    &[bleed] [slot='image'] {
+      border-start-start-radius:
+        calc(
+            var(--felt-preview-border-radius-default) - 1px
+          );
+      border-start-end-radius:
+        calc(
+            var(--felt-preview-border-radius-default) - 1px
+          );
     }
   }
 }

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -2317,4 +2317,68 @@
       }
     }
   }
+
+  /* Element: Tile */
+  & rh-tile {
+    /* Border radius → Felt 16px rounded */
+    --rh-border-radius-default: var(--felt-preview-border-radius-default);
+
+    /* Default border: subtle gray, 1px */
+    --rh-tile-border-color: var(--felt-preview-color-border-interactive-subtle-default);
+
+    /* Border thickens to 2px on hover/focus/active */
+    --rh-tile-focus-border-width: var(--felt-preview-border-width-md);
+
+    /* Hover border: lighter blue */
+    --rh-tile-hover-border-color:
+      var(--felt-preview-color-border-interactive-subtle-hover);
+
+    /* Active/focus border: darker blue */
+    --rh-tile-active-border-color:
+      var(--felt-preview-color-border-interactive-subtle-active);
+
+    /* Interactive color (icons, arrow, focus ring) */
+    --rh-tile-interactive-color: var(--felt-preview-color-interactive-primary-default);
+
+    /* Hover/focus/active interactive color */
+    --rh-tile-focus-interactive-color: var(--felt-preview-color-interactive-primary-hover);
+
+    /* Default heading/link color */
+    --rh-tile-link-color: var(--felt-preview-color-text-interactive-default);
+
+    /* Hover/focus surface stays flat (no gray shift) */
+    --rh-tile-focus-background-color: var(--felt-preview-color-surface-primary);
+
+    /* Disabled surface: gray-30 light / gray-60 dark */
+    --rh-tile-disabled-background-color:
+      light-dark(
+          var(--felt-preview-color-gray-30),
+          var(--felt-preview-color-gray-60)
+        );
+
+    /* Disabled text color */
+    --rh-tile-disabled-text-color:
+      var(--felt-preview-color-text-status-on-disabled);
+
+    /* Focus ring matches active/focus border color */
+    --rh-tile-focus-outline-color:
+      var(--felt-preview-color-border-interactive-subtle-active);
+
+    /* Suppress headline link outline (tile shows its own focus ring) */
+    & [slot="headline"] a:focus {
+      outline: none;
+    }
+
+    /*
+     * Bleed image fix: the component's --_bleed only offsets padding,
+     * not the border width, leaving a gap at the border edge.
+     * Clip at the host level so the image fills to the outer border.
+     * TODO: remove once rh-tile accounts for border in --_bleed calc.
+     */
+    &[bleed] {
+      overflow: hidden;
+      border-radius:
+        calc(var(--felt-preview-border-radius-default) - 1px);
+    }
+  }
 }

--- a/elements/rh-tile/demo/felt-theme.html
+++ b/elements/rh-tile/demo/felt-theme.html
@@ -1,7 +1,7 @@
 ---
 description: "Tile variants styled with the Project Felt preview theme."
 ---
-<link rel="stylesheet" href="/docs/theming/themes/project-felt/preview/felt-theme-preview.css">
+<link rel="stylesheet" href="/theming/themes/project-felt/preview/felt-theme-preview.css">
 <link rel="stylesheet" href="../rh-tile-lightdom.css">
 
 <style>

--- a/elements/rh-tile/demo/felt-theme.html
+++ b/elements/rh-tile/demo/felt-theme.html
@@ -1,0 +1,250 @@
+---
+description: "Tile variants styled with the Project Felt preview theme."
+---
+<link rel="stylesheet" href="/docs/theming/themes/project-felt/preview/felt-theme-preview.css">
+<link rel="stylesheet" href="../rh-tile-lightdom.css">
+
+<style>
+  .felt-preview {
+    display: contents;
+  }
+
+  .example-row {
+    margin-block: var(--rh-space-2xl, 32px);
+  }
+
+  .tile-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rh-space-2xl, 32px);
+  }
+
+  .tile-grid rh-tile {
+    width: 320px;
+  }
+
+  .tile-grid-compact rh-tile {
+    width: 360px;
+  }
+</style>
+
+<div class="felt-preview">
+
+<h3>Link tile</h3>
+<div class="tile-grid example-row">
+  <rh-tile>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile desaturated>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile disabled>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Link tile with image</h3>
+<div class="tile-grid example-row">
+  <rh-tile bleed>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 200" width="100%">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="99%" height="99%"
+            fill="none"
+            stroke="var(--rh-color-icon-primary)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile bleed desaturated>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 200" width="100%">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="99%" height="99%"
+            fill="none"
+            stroke="var(--rh-color-icon-primary)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile bleed disabled>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 200" width="100%">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="99%" height="99%"
+            fill="none"
+            stroke="var(--rh-color-icon-primary)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <div slot="title">Title</div>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Compact link tile</h3>
+<div class="tile-grid tile-grid-compact example-row">
+  <rh-tile compact>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact desaturated>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact disabled>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Compact link tile with image</h3>
+<div class="tile-grid tile-grid-compact example-row">
+  <rh-tile compact bleed>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="360" height="60"
+            fill="var(--rh-color-interactive-primary-default)"
+            fill-opacity="0.2"
+            stroke="var(--rh-color-interactive-primary-hover)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact bleed desaturated>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="360" height="60"
+            fill="var(--rh-color-interactive-primary-default)"
+            fill-opacity="0.2"
+            stroke="var(--rh-color-interactive-primary-hover)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+
+  <rh-tile compact bleed disabled>
+    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60">
+      <title>Placeholder image</title>
+      <rect x="0" y="0" width="360" height="60"
+            fill="var(--rh-color-interactive-primary-default)"
+            fill-opacity="0.2"
+            stroke="var(--rh-color-interactive-primary-hover)"
+            stroke-width="1"
+            stroke-dasharray="1 1" />
+    </svg>
+    <rh-icon slot="icon" set="standard" icon="cloud-automation"></rh-icon>
+    <h2 slot="headline"><a href="#top">Heading</a></h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nullam eleifend elit sed est egestas.
+    <div slot="footer">Footer</div>
+  </rh-tile>
+</div>
+
+<h3>Selectable tile (checkbox)</h3>
+<div class="tile-grid example-row">
+  <rh-tile-group>
+    <rh-tile checkable>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile checkable checked>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile checkable disabled>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+  </rh-tile-group>
+</div>
+
+<h3>Selectable tile (radio)</h3>
+<div class="tile-grid example-row">
+  <rh-tile-group radio>
+    <rh-tile checkable name="radio">
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile checkable name="radio" checked>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+
+    <rh-tile checkable name="radio" disabled>
+      <h2 slot="headline">Headline</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <div slot="footer">Footer</div>
+    </rh-tile>
+  </rh-tile-group>
+</div>
+
+</div>
+
+<script type="module">
+  import '@rhds/elements/rh-tile/rh-tile.js';
+  import '@rhds/elements/rh-tile/rh-tile-group.js';
+  import '@rhds/elements/rh-icon/rh-icon.js';
+</script>

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -87,19 +87,31 @@
   /** Tile border color */
   --_border-color: var(--rh-tile-border-color, var(--rh-color-border-subtle));
 
+  /** Tile border width */
+  --_border-width: var(--rh-tile-border-width, var(--rh-border-width-sm, 1px));
+
+  /** Border width on hover/focus/active */
+  --_focus-border-width:
+    var(--rh-tile-focus-border-width,
+      var(--rh-tile-border-width, var(--rh-border-width-sm, 1px)));
+
   /** Tile link color */
   --_link-color: var(--rh-tile-link-color, var(--_interactive-color));
 
   position: relative;
   padding: var(--_padding);
 
+  /** Border color on hover */
+  --_hover-border-color:
+    var(--rh-tile-hover-border-color, var(--_focus-interactive-color));
+
+  /** Border color on active/focus */
+  --_active-border-color:
+    var(--rh-tile-active-border-color, var(--_hover-border-color));
+
   /** Tile border radius */
   border-radius: var(--rh-border-radius-default, 3px);
-  border:
-    /** Tile border width */
-    var(--rh-border-width-sm, 1px)
-    solid
-    var(--_border-color);
+  border: var(--_border-width) solid var(--_border-color);
 
   /** Tile text color */
   color: var(--rh-tile-text-color, var(--rh-color-text-primary));
@@ -188,6 +200,25 @@
   &:focus,
   &:focus-within {
     --_interactive-color: var(--_focus-interactive-color);
+    --_link-color: var(--_focus-interactive-color);
+  }
+
+  &:hover {
+    border-color: var(--_hover-border-color);
+    box-shadow:
+      inset 0 0 0
+      calc(var(--_focus-border-width) - var(--_border-width))
+      var(--_hover-border-color);
+  }
+
+  &:active,
+  &:focus,
+  &:focus-within {
+    border-color: var(--_active-border-color);
+    box-shadow:
+      inset 0 0 0
+      calc(var(--_focus-border-width) - var(--_border-width))
+      var(--_active-border-color);
   }
 
   &:is(.desaturated, .checkable) {
@@ -252,7 +283,9 @@
 
   &.disabled {
     pointer-events: none !important;
-    color: var(--_text-color-secondary) !important;
+    color:
+      var(--rh-tile-disabled-text-color,
+        var(--_text-color-secondary)) !important;
     background-color: var(--_disabled-background-color) !important;
 
     --_interactive-color: var(--_text-color-secondary) !important;
@@ -260,8 +293,15 @@
 }
 
 :host(:focus-within) #outer {
-  outline: 3px solid var(--_interactive-color);
+  outline:
+    3px solid
+    var(--rh-tile-focus-outline-color, var(--_interactive-color));
   outline-offset: 2px;
+  border-color: var(--_active-border-color);
+  box-shadow:
+    inset 0 0 0
+    calc(var(--_focus-border-width) - var(--_border-width))
+    var(--_active-border-color);
 }
 
 :host(:is(:hover, :focus-within)) #outer {

--- a/elements/rh-tile/rh-tile.css
+++ b/elements/rh-tile/rh-tile.css
@@ -103,11 +103,13 @@
 
   /** Border color on hover */
   --_hover-border-color:
-    var(--rh-tile-hover-border-color, var(--_focus-interactive-color));
+    var(--rh-tile-hover-border-color,
+      var(--_focus-interactive-color));
 
   /** Border color on active/focus */
   --_active-border-color:
-    var(--rh-tile-active-border-color, var(--_hover-border-color));
+    var(--rh-tile-active-border-color,
+      var(--_hover-border-color));
 
   /** Tile border radius */
   border-radius: var(--rh-border-radius-default, 3px);


### PR DESCRIPTION
## What I did

1. Added `<rh-tile>` to the Felt preview theme CSS.
2. Added API: public CSS tokens for border width, state border colors, disabled text, and focus ring.


## Testing Instructions

1. Check [Felt Preview Theme's Tile demo](https://deploy-preview-3227--red-hat-design-system.netlify.app/theming/themes/project-felt/demos/#tile)
2. Cross check with [Tile's Felt Theme demo](https://deploy-preview-3227--red-hat-design-system.netlify.app/elements/tile/demos/#demo-felt-theme)

