### PR TITLE
fix(back-to-top): add css token fallbacks

### DIFF
--- a/.changeset/back-to-top-token-fallbacks.md
+++ b/.changeset/back-to-top-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-back-to-top>`: add default fallbacks for each RHDS token used

--- a/elements/rh-back-to-top/rh-back-to-top.css
+++ b/elements/rh-back-to-top/rh-back-to-top.css
@@ -33,8 +33,14 @@
   background-color:
     /** Trigger background color override */
     var(--rh-back-to-top-background-color,
-      /** Trigger background color */
-      var(--rh-color-accent-base));
+      /** Trigger background color; theme-adaptive */
+      var(--rh-color-accent-base,
+      light-dark(
+        /** Trigger background color for light color schemes */
+        var(--rh-color-accent-base-on-light, #0066cc),
+        /** Trigger background color for dark color schemes */
+        var(--rh-color-accent-base-on-dark, #92c5f9)
+      )));
   text-decoration: none;
 
   /** Trigger text size */
@@ -72,8 +78,14 @@
     /** Trigger hover/focus outline width */
     var(--rh-border-width-md, 2px)
     solid
-    /** Trigger hover/focus outline color */
-    var(--rh-color-interactive-primary-hover);
+    /** Trigger hover/focus outline color; theme-adaptive */
+    var(--rh-color-interactive-primary-hover,
+      light-dark(
+        /** Trigger hover/focus outline color for light color schemes */
+        var(--rh-color-interactive-primary-hover-on-light, #003366),
+        /** Trigger hover/focus outline color for dark color schemes */
+        var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)
+      ));
   border:
     /** Trigger hover/focus border width */
     var(--rh-border-width-md, 2px)
@@ -84,9 +96,15 @@
         /** Trigger hover/focus border color in dark mode */
         var(--rh-color-border-strong-on-light, #151515)
       );
-
-  /** Trigger hover/focus background color */
-  background-color: var(--rh-color-interactive-primary-hover);
+  background-color:
+    /** Trigger hover/focus background color; theme-adaptive */
+    var(--rh-color-interactive-primary-hover,
+      light-dark(
+        /** Trigger hover/focus background color for light color schemes */
+        var(--rh-color-interactive-primary-hover-on-light, #003366),
+        /** Trigger hover/focus background color for dark color schemes */
+        var(--rh-color-interactive-primary-hover-on-dark, #b9dafc)
+      ));
 }
 
 [part='trigger'][hidden] {


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the element's CSS, including `light-dark()` fallbacks for theme-adaptive colors.
2. Closes #3173.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Back to top](http://localhost:8000/elements/back-to-top/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Check the other demos the same way:
   - [Color context](http://localhost:8000/elements/back-to-top/color-context/)
   - [Always visible](http://localhost:8000/elements/back-to-top/always-visible/)
   - [Scroll distance](http://localhost:8000/elements/back-to-top/scroll-distance/)
   - [No slotted text](http://localhost:8000/elements/back-to-top/no-slotted-text/)
5. Run `npm run lint` in the RHDS directory.
6. Open `elements/rh-back-to-top/rh-back-to-top.css` in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
7. Ensure the changeset is accurate.
8. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.