### PR TITLE
fix(audio-player): add css token fallbacks

### DIFF
--- a/.changeset/audio-player-token-fallbacks.md
+++ b/.changeset/audio-player-token-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-audio-player>`: add default fallbacks for each RHDS token used

--- a/elements/rh-audio-player/demo/right-to-left.html
+++ b/elements/rh-audio-player/demo/right-to-left.html
@@ -152,14 +152,14 @@ description: Audio player with right-to-left Hebrew content demonstrating bidire
 
 <style>
   #rtl {
-    margin: var(--rh-space-xl);
+    margin: var(--rh-space-xl, 24px);
     & label {
       display: flex;
       align-items: center;
     }
 
     & select {
-      margin-inline-end: var(--rh-space-md);
+      margin-inline-end: var(--rh-space-md, 8px);
       flex: 1 0 auto;
     }
   }

--- a/elements/rh-audio-player/rh-audio-player-lightdom.css
+++ b/elements/rh-audio-player/rh-audio-player-lightdom.css
@@ -17,8 +17,14 @@ rh-audio-player {
   color:
     /** Player text color override */
     var(--rh-audio-player-text-color,
-      /** Player text color */
-      var(--rh-color-text-primary));
+      /** Player text color; theme-adaptive */
+      var(--rh-color-text-primary,
+      light-dark(
+        /** Player text color for light color schemes */
+        var(--rh-color-text-primary-on-light, #151515),
+        /** Player text color for dark color schemes */
+        var(--rh-color-text-primary-on-dark, #ffffff)
+      )));
 
   &[color-palette^='dark'] > * {
     background-color:


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks in the element's CSS, including `light-dark()` fallbacks for theme-adaptive colors.
2. Added the same fallbacks to inline CSS in the affected demos.
3. Closes #3172, closes #3135.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Audio player](http://localhost:8000/elements/audio-player/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Check the other affected demo the same way:
   - [Right to left](http://localhost:8000/elements/audio-player/right-to-left/)
5. On those pages, confirm demo page background and text still resolve if the demo sets them.
6. Run `npm run lint` in the RHDS directory.
7. Open the CSS files changed in this PR in your editor. Ensure stylelint does not flag any errors (look for red squiggly lines).
8. Ensure the changeset is accurate.
9. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.