### PR TITLE
docs(code-block): add css token fallbacks

### DIFF
--- a/elements/rh-code-block/demo/below-the-fold.html
+++ b/elements/rh-code-block/demo/below-the-fold.html
@@ -67,13 +67,13 @@ description: Code block positioned below the fold to test content-visibility opt
 
 <style>
   .tall-as-screen {
-    padding: var(--rh-length-lg);
+    padding: var(--rh-length-lg, 16px);
     min-height: calc(100vh + 500px);
   }
   rh-alert dl {
     display: grid;
-    font-family: var(--rh-font-family-code);
+    font-family: var(--rh-font-family-code, RedHatMono, 'Red Hat Mono', 'Courier New', Courier, monospace);
     grid-template-columns: auto auto;
-    gap: var(--rh-space-md);
+    gap: var(--rh-space-md, 8px);
   }
 </style>

--- a/elements/rh-code-block/demo/client-side-highlighting.html
+++ b/elements/rh-code-block/demo/client-side-highlighting.html
@@ -46,7 +46,7 @@ description: "Client-side syntax highlighting with Prism.js for HTML, CSS, and Y
         & h4 {
           font-weight: var(--rh-font-weight-heading-regular, 300);
           font-size: var(--rh-font-size-body-text-md, 1rem);
-          font-family: var(--rh-font-family-body-text);
+          font-family: var(--rh-font-family-body-text, RedHatText, 'Red Hat Text', Helvetica, Arial, sans-serif);
           line-height: var(--rh-line-height-body-text, 1.5);
         }
       }

--- a/elements/rh-code-block/demo/thousands-line-numbers-full-height.html
+++ b/elements/rh-code-block/demo/thousands-line-numbers-full-height.html
@@ -5,7 +5,7 @@ description: This demo loads 1000+ code blocks as full height and with line numb
   import '@rhds/elements/rh-code-block/rh-code-block.js';
 </script>
 
-<style>rh-code-block { margin-block-end: var(--rh-length-lg); }</style>
+<style>rh-code-block { margin-block-end: var(--rh-length-lg, 16px); }</style>
 
 <rh-code-block highlighting="prerendered" language="shell-session" actions="copy wrap" full-height>
 <pre class="language-shell-session" tabindex="-1"><code class="language-shell-session"><span class="token command"><span class="token shell-symbol important">$</span> <span class="token bash language-bash">oc <span class="token parameter variable">-n</span> openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-signer <span class="token parameter variable">-o</span> <span class="token assign-left variable">jsonpath</span><span class="token operator">=</span><span class="token string">'{.metadata.annotations.auth\.openshift\.io/certificate-not-after}'</span></span></span></code></pre>

--- a/elements/rh-code-block/demo/thousands-line-numbers.html
+++ b/elements/rh-code-block/demo/thousands-line-numbers.html
@@ -5,7 +5,7 @@ description: This demo loads 1000+ code blocks with line numbers and wrap action
   import '@rhds/elements/rh-code-block/rh-code-block.js';
 </script>
 
-<style>rh-code-block { margin-block-end: var(--rh-length-lg); }</style>
+<style>rh-code-block { margin-block-end: var(--rh-length-lg, 16px); }</style>
 
 <rh-code-block highlighting="prerendered" language="shell-session" actions="copy wrap">
 <pre class="language-shell-session" tabindex="-1"><code class="language-shell-session"><span class="token command"><span class="token shell-symbol important">$</span> <span class="token bash language-bash">oc <span class="token parameter variable">-n</span> openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-signer <span class="token parameter variable">-o</span> <span class="token assign-left variable">jsonpath</span><span class="token operator">=</span><span class="token string">'{.metadata.annotations.auth\.openshift\.io/certificate-not-after}'</span></span></span></code></pre>

--- a/elements/rh-code-block/demo/thousands.html
+++ b/elements/rh-code-block/demo/thousands.html
@@ -5,7 +5,7 @@ description: "This demo loads 1000+ code blocks.  The code blocks have the line-
   import '@rhds/elements/rh-code-block/rh-code-block.js';
 </script>
 
-<style>rh-code-block { margin-block-end: var(--rh-length-lg); }</style>
+<style>rh-code-block { margin-block-end: var(--rh-length-lg, 16px); }</style>
 
 <rh-code-block highlighting="prerendered" language="shell-session" line-numbers="hidden" actions="copy">
 


### PR DESCRIPTION
## What I did

1. Added canonical token fallbacks to inline CSS in the affected `<rh-code-block>` demos.
2. Closes #3138.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open each affected demo and confirm spacing and type still look as designed:
   - [Thousands](http://localhost:8000/elements/code-block/demo/thousands/)
   - [Thousands line numbers](http://localhost:8000/elements/code-block/demo/thousands-line-numbers/)
   - [Thousands line numbers full height](http://localhost:8000/elements/code-block/demo/thousands-line-numbers-full-height/)
   - [Below the fold](http://localhost:8000/elements/code-block/demo/below-the-fold/)
   - [Client-side highlighting](http://localhost:8000/elements/code-block/demo/client-side-highlighting/)
3. On [Client-side highlighting](http://localhost:8000/elements/code-block/demo/client-side-highlighting/), switch Light, Dark, and System (or use the context picker). Confirm the demo grid gap and the sample CSS font still resolve.
4. On [Below the fold](http://localhost:8000/elements/code-block/demo/below-the-fold/), confirm the tall-section padding and the toast legend font/gap still resolve.
5. Run `npm run lint` in the RHDS directory.
6. Open the demo HTML files changed in this PR in your editor. Ensure eslint/stylelint do not flag the `<style>` blocks (look for red squiggly lines).
7. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.