### PR TITLE
docs(health-index): add css token fallbacks

### DIFF
--- a/elements/rh-health-index/demo/color-context.html
+++ b/elements/rh-health-index/demo/color-context.html
@@ -59,7 +59,12 @@ description: Health index in all sizes and grades on light and dark color contex
     gap: 2rem;
     & h2 {
       font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-      color: var(--rh-color-text-primary);
+      color:
+        var(--rh-color-text-primary,
+          light-dark(
+            var(--rh-color-text-primary-on-light, #151515),
+            var(--rh-color-text-primary-on-dark, #ffffff)
+          ));
     }
     & li {
       margin: 0;


### PR DESCRIPTION
## What I did

1. Added a canonical `light-dark()` fallback for `--rh-color-text-primary` in the color-context demo headings.
2. Closes #3140.

## Testing Instructions

1. Run `npm run dev` in the RHDS directory. The element demo server starts at http://localhost:8000.
2. Open the [Health index](http://localhost:8000/elements/health-index/) demo.
3. Switch Light, Dark, and System (or use the context picker). Confirm the control still has surface, text, border, and type as designed.
4. Check the affected demo the same way:
   - [Color context](http://localhost:8000/elements/health-index/demo/color-context/)
5. On Color context, the SM / Default / LG / XL headings should stay primary text in light and dark.
6. Run `npm run lint` in the RHDS directory. `elements/rh-health-index` should not appear in the error list.
7. Open the files changed in this PR in your editor. Ensure stylelint / eslint do not flag any errors (look for red squiggly lines).
8. Ensure the base branch targets `fix/css-var-fallbacks`.

## Notes to Reviewers

Other elements still fail `rhds/require-token-fallback`, so Netlify will not publish a deploy preview for this PR. We will likely have to merge this PR with these errors. Don't get led astray by the errors. We will see these lint errors until we have tackled all of #3119.