### PR TITLE
fix(navigation-vertical): corrected aria-labelledby target missing id

### DIFF
--- a/.changeset/whole-trees-agree.md
+++ b/.changeset/whole-trees-agree.md
@@ -2,5 +2,4 @@
 "@rhds/elements": patch
 ---
 
-`<rh-navigation-vertical>`: improved accessibility
-  
+`<rh-navigation-vertical>`: improved accessibility of the navigation label for screen readers

--- a/.changeset/whole-trees-agree.md
+++ b/.changeset/whole-trees-agree.md
@@ -1,0 +1,6 @@
+---
+"@rhds/elements": patch
+---
+
+`<rh-navigation-vertical>`: improved accessibility
+  

--- a/elements/rh-navigation-vertical/rh-navigation-vertical.ts
+++ b/elements/rh-navigation-vertical/rh-navigation-vertical.ts
@@ -53,7 +53,7 @@ export class RhNavigationVertical extends LitElement {
 
   render(): TemplateResult<1> {
     return html`
-      <h2 class="visually-hidden">${this.accessibleLabel}</h2>
+      <h2 id="title" class="visually-hidden">${this.accessibleLabel}</h2>
       <div id="container" role="list">
         <!-- summary: Navigation items
              description: |


### PR DESCRIPTION
## What I did

1. Improved accessibility by adding missing title id correcting internal `aria-labeledby`

Closes #2915 

## Testing Instructions

1.

## Notes to Reviewers
