### PR TITLE
docs(felt): cta focus ring correction

### DIFF
--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -938,13 +938,19 @@
        from the light DOM. box-shadow is unaffected and follows border-radius.
        Two layers: inner Canvas-colored shadow = visual gap, outer = the ring. */
     &:focus-within {
-      --felt-preview-cta-focus-ring-color: var(--felt-preview-color-interactive-primary-default);
-      --felt-preview-cta-focus-ring-size: calc(var(--felt-preview-cta-border-width-focus-ring) * 2);
+      position: relative;
+    }
 
+    &:focus-within:after {
+      content: '';
+      position: absolute;
+      top: -2px;
+      bottom: -2px;
+      left: -2px;
+      right: -2px;
+      outline: var(--felt-preview-cta-border-width-focus-ring) solid var(--felt-preview-color-interactive-primary-default);
       border-radius: var(--felt-preview-border-radius-pill);
-      box-shadow:
-        0 0 0 var(--felt-preview-cta-border-width-focus-ring) Canvas,
-        0 0 0 var(--felt-preview-cta-focus-ring-size) var(--felt-preview-cta-focus-ring-color);
+      pointer-events: none;
     }
 
     &[variant='primary'] {

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -945,7 +945,10 @@
       content: '';
       position: absolute;
       inset: -2px;
-      outline: var(--felt-preview-cta-border-width-focus-ring) solid var(--felt-preview-color-interactive-primary-default);
+      outline:
+        var(--felt-preview-cta-border-width-focus-ring)
+        solid
+        var(--felt-preview-color-interactive-primary-default);
       border-radius: var(--felt-preview-border-radius-action-plain);
       pointer-events: none;
     }

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -946,8 +946,12 @@
       position: absolute;
       inset: -2px;
       outline: var(--felt-preview-cta-border-width-focus-ring) solid var(--felt-preview-color-interactive-primary-default);
-      border-radius: var(--felt-preview-border-radius-pill);
+      border-radius: var(--felt-preview-border-radius-action-plain);
       pointer-events: none;
+    }
+
+    &[variant]:focus-within:after {
+      border-radius: var(--felt-preview-border-radius-pill);
     }
 
     &[variant='primary'] {

--- a/docs/theming/themes/project-felt/preview/felt-theme-preview.css
+++ b/docs/theming/themes/project-felt/preview/felt-theme-preview.css
@@ -944,10 +944,7 @@
     &:focus-within:after {
       content: '';
       position: absolute;
-      top: -2px;
-      bottom: -2px;
-      left: -2px;
-      right: -2px;
+      inset: -2px;
       outline: var(--felt-preview-cta-border-width-focus-ring) solid var(--felt-preview-color-interactive-primary-default);
       border-radius: var(--felt-preview-border-radius-pill);
       pointer-events: none;


### PR DESCRIPTION
## What I did

1. Corrected `rh-cta` focus ring, now correctly shows background color between ring and border `dark | darker` for the felt theme

Closes #3165 

## Testing Instructions

1.

## Notes to Reviewers
