### PR TITLE
fix(footer)!: remove deprecated `--rh-footer-nojs-min-height`

### DIFF
--- a/.changeset/brave-footer-height.md
+++ b/.changeset/brave-footer-height.md
@@ -1,0 +1,21 @@
+---
+"@rhds/elements": major
+---
+
+`<rh-footer>`: removed deprecated `--rh-footer-nojs-min-height`. Target `rh-footer:not(:defined)` directly if a no-JS min-height is still needed.
+
+Before:
+
+```css
+rh-footer {
+  --rh-footer-nojs-min-height: 750px;
+}
+```
+
+After:
+
+```css
+rh-footer:not(:defined) {
+  min-height: 750px;
+}
+```

--- a/elements/rh-footer/rh-footer-lightdom.css
+++ b/elements/rh-footer/rh-footer-lightdom.css
@@ -211,9 +211,6 @@ rh-footer:not(:defined) {
     'global';
   grid-template-rows: 1fr auto;
 
-  /** Minimum height without JS; prefer `rh-footer:not(:defined)` in CSS */
-  min-height: var(--rh-footer-nojs-min-height);
-
   & > *:not(rh-footer-universal) {
     padding-inline: var(--_section-side-gap);
   }

--- a/elements/rh-footer/rh-footer.css
+++ b/elements/rh-footer/rh-footer.css
@@ -16,19 +16,8 @@
   color-scheme: only dark !important;
 }
 
-/* Should only be applied if scripting is disabled */
-@media (scripting: none) {
-  :host {
-    /** Minimum footer height when scripting is disabled */
-    min-height: var(--rh-footer-nojs-min-height);
-  }
-}
-
 :host,
 ::slotted(rh-footer-universal) {
-  --_fallback-animation: nothing-doing !important;
-  --_fallback-opacity: 1 !important;
-
   overflow-y: initial;
 }
 

--- a/elements/rh-footer/rh-footer.ts
+++ b/elements/rh-footer/rh-footer.ts
@@ -31,7 +31,6 @@ function isHeaderTagName(tagName: string) {
  *
  * @summary Site footer with navigation links, social icons, and legal content
  *
- * @cssprop --rh-footer-nojs-min-height - Minimum height when JavaScript is disabled. @deprecated target `rh-footer:not(:defined)` directly
  * @cssprop --rh-footer-icon-color - Default icon color. Uses --rh-color-gray-40 design token
  * @cssprop --rh-footer-icon-color-hover - Icon color on hover/focus. Uses --rh-color-gray-30 design token
  * @cssprop --rh-footer-border-color - Border color for section dividers. Uses --rh-color-border-subtle-on-dark design token


### PR DESCRIPTION
## What I did

1. Removed `--rh-footer-nojs-min-height` from `<rh-footer>` shadow CSS, light DOM `:not(:defined)` styles, and `@cssprop` docs.
2. Removed leftover `--_fallback-animation` and `--_fallback-opacity` from the old CLS fade-in.
3. Related to #2932.

## Testing Instructions

1. Open the production [Footer demo](https://ux.redhat.com/elements/footer/demo/). Disable JavaScript in DevTools, refresh, and note the layout (no reserved 750px/545px band is expected on current production either).
2. Open the deploy preview [Footer demo](https://deploy-preview-3241--red-hat-design-system.netlify.app/elements/footer/demo/). Footer should match current design with no extra empty space below the content.
3. Disable JavaScript, refresh. Light DOM grid should still show the logo, link columns, and universal footer, without a forced min-height.
4. Check [subdomain](https://deploy-preview-3241--red-hat-design-system.netlify.app/elements/footer/demo/subdomain/) and [footer-universal](https://deploy-preview-3241--red-hat-design-system.netlify.app/elements/footer/demo/footer-universal/).
5. On the [Code](https://deploy-preview-3241--red-hat-design-system.netlify.app/elements/footer/code/) page, confirm `--rh-footer-nojs-min-height` is gone from CSS Custom Properties. The site chrome footer at the bottom should look normal.

## Notes to Reviewers

This is a RHDS v5 breaking change.