### PR TITLE
feat(footer): add accessible name attributes for social links and logo

### DIFF
--- a/.changeset/loud-pianos-invite.md
+++ b/.changeset/loud-pianos-invite.md
@@ -1,0 +1,15 @@
+---
+"@rhds/elements": minor
+---
+
+`<rh-footer-links>`: added `accessible-label` for the link group name
+`<rh-footer>`: added `social-links-label` and `logo-label`
+`<rh-footer-universal>`: added `logo-label`
+
+If you slot social links in the `tertiary` slot, add `accessible-label` on
+`<rh-footer-links role="list">` so the group has an accessible name. See
+the [default demo](https://ux.redhat.com/elements/footer/demos/#demo-footer)
+for example code.
+
+Use `social-links-label` on `<rh-footer>` only for the [legacy
+`slot="social-links"` pattern](https://ux.redhat.com/elements/footer/demos/#demo-legacy).

--- a/elements/rh-footer/README.md
+++ b/elements/rh-footer/README.md
@@ -91,11 +91,13 @@ import '@rhds/elements/rh-footer/rh-footer.js';
       <li><a href="#" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
     <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
-    <rh-footer-social-link slot="tertiary" icon="linkedin" href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn" accessible-label="LinkedIn"></rh-footer-social-link>
-    <rh-footer-social-link slot="tertiary" icon="youtube" href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube" accessible-label="YouTube"></rh-footer-social-link>
-    <rh-footer-social-link slot="tertiary" icon="facebook" href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook" accessible-label="Facebook"></rh-footer-social-link>
-    <rh-footer-social-link slot="tertiary" icon="x" href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="X/Twitter" accessible-label="X/Twitter"></rh-footer-social-link>
-    <rh-footer-social-link slot="tertiary" icon="instagram" href="https://www.instagram.com/redhat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Instagram" accessible-label="Instagram"></rh-footer-social-link>
+    <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
+      <rh-footer-social-link icon="linkedin" href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn" accessible-label="LinkedIn"></rh-footer-social-link>
+      <rh-footer-social-link icon="youtube" href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube" accessible-label="YouTube"></rh-footer-social-link>
+      <rh-footer-social-link icon="facebook" href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook" accessible-label="Facebook"></rh-footer-social-link>
+      <rh-footer-social-link icon="x" href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="X/Twitter" accessible-label="X/Twitter"></rh-footer-social-link>
+      <rh-footer-social-link icon="instagram" href="https://www.instagram.com/redhat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Instagram" accessible-label="Instagram"></rh-footer-social-link>
+    </rh-footer-links>
   </rh-footer-universal>
 </rh-footer>
 ```
@@ -137,11 +139,13 @@ import '@rhds/elements/rh-footer/rh-footer-universal.js';
     <li><a href="#" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Cookie preferences">Cookie preferences</a></li>
   </ul>
   <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
-  <rh-footer-social-link slot="tertiary" icon="linkedin" href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn" accessible-label="LinkedIn"></rh-footer-social-link>
-  <rh-footer-social-link slot="tertiary" icon="youtube" href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube" accessible-label="YouTube"></rh-footer-social-link>
-  <rh-footer-social-link slot="tertiary" icon="facebook" href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook" accessible-label="Facebook"></rh-footer-social-link>
-  <rh-footer-social-link slot="tertiary" icon="x" href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="X/Twitter" accessible-label="X/Twitter"></rh-footer-social-link>
-  <rh-footer-social-link slot="tertiary" icon="instagram" href="https://www.instagram.com/redhat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Instagram" accessible-label="Instagram"></rh-footer-social-link>
+  <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
+    <rh-footer-social-link icon="linkedin" href="https://www.linkedin.com/company/red-hat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="LinkedIn" accessible-label="LinkedIn"></rh-footer-social-link>
+    <rh-footer-social-link icon="youtube" href="https://www.youtube.com/user/RedHatVideos" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="YouTube" accessible-label="YouTube"></rh-footer-social-link>
+    <rh-footer-social-link icon="facebook" href="https://www.facebook.com/redhatinc" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Facebook" accessible-label="Facebook"></rh-footer-social-link>
+    <rh-footer-social-link icon="x" href="https://twitter.com/RedHat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="X/Twitter" accessible-label="X/Twitter"></rh-footer-social-link>
+    <rh-footer-social-link icon="instagram" href="https://www.instagram.com/redhat" data-analytics-region="social-links-exit" data-analytics-category="Footer|social-links" data-analytics-text="Instagram" accessible-label="Instagram"></rh-footer-social-link>
+  </rh-footer-links>
 </rh-footer-universal>
 ```
 

--- a/elements/rh-footer/demo/footer-universal.html
+++ b/elements/rh-footer/demo/footer-universal.html
@@ -57,7 +57,7 @@ description: Standalone universal footer used on orphan pages or landing pages w
          data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
   <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
-  <rh-footer-links slot="tertiary" role="list">
+  <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
     <rh-footer-social-link icon="linkedin"
                            href="https://www.linkedin.com/company/red-hat"
                            data-analytics-region="social-links-exit"

--- a/elements/rh-footer/demo/index.html
+++ b/elements/rh-footer/demo/index.html
@@ -180,7 +180,7 @@ description: "Full website footer with logo, social links, navigation columns, p
            data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
     <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
-    <rh-footer-links slot="tertiary" role="list">
+    <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
       <rh-footer-social-link icon="linkedin"
                              href="https://www.linkedin.com/company/red-hat"
                              data-analytics-region="social-links-exit"

--- a/elements/rh-footer/demo/slotted-social-links.html
+++ b/elements/rh-footer/demo/slotted-social-links.html
@@ -181,7 +181,7 @@ description: Footer using slotted anchor elements inside rh-footer-social-link i
     </ul>
     <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
     <!-- Slotted <a> pattern: anchor elements inside rh-footer-social-link -->
-    <rh-footer-links slot="tertiary" role="list">
+    <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
       <rh-footer-social-link icon="linkedin"><a href="https://www.linkedin.com/company/red-hat"
          data-analytics-region="social-links-exit"
          data-analytics-category="Footer|social-links"

--- a/elements/rh-footer/demo/subdomain.html
+++ b/elements/rh-footer/demo/subdomain.html
@@ -131,7 +131,7 @@ description: "Subdomain footer for docs or other Red Hat properties. Shows domai
            data-analytics-text="Cookie preferences">Cookie preferences</a></li>
     </ul>
     <rh-footer-copyright slot="tertiary">&copy; 2026 Red Hat</rh-footer-copyright>
-    <rh-footer-links slot="tertiary" role="list">
+    <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
       <rh-footer-social-link icon="linkedin"
                              href="https://www.linkedin.com/company/red-hat"
                              data-analytics-region="social-links-exit"

--- a/elements/rh-footer/docs/40-accessibility.md
+++ b/elements/rh-footer/docs/40-accessibility.md
@@ -1,3 +1,11 @@
+## Social links and logo names
+
+Name the social links list so screen readers can distinguish it from other groups. On the current pattern, set `accessible-label` on `<rh-footer-links role="list">`. On the legacy `slot="social-links"` pattern, set `social-links-label` on `<rh-footer>` (default: "Red Hat social media links").
+
+Localize the surrounding words. Keep the brand as "Red Hat" except in Simplified Chinese, where it is `红帽`. Override the group name only when the accounts are not corporate Red Hat.
+
+The default logo link is named with `logo-label` (default: "Red Hat") when the `logo` slot is empty. Slotted logos should keep using `alt` or `aria-label` on the slotted content; `logo-label` does not apply to them.
+
 ## Landmark roles
 
 `<rh-footer>` and `<rh-footer-universal>` (when used outside of `<rh-footer>`) already include a [`contentinfo`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/contentinfo_role) landmark role and therefore do not need to be wrapped in a native `<footer>` element. This `contentinfo` role is applied automatically through the [ElementInternals API](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals).

--- a/elements/rh-footer/rh-footer-links.ts
+++ b/elements/rh-footer/rh-footer-links.ts
@@ -22,7 +22,7 @@ export class RhFooterLinks extends LitElement {
   /**
    * Visually hides the header slot content while preserving it for screen
    * readers. The `aria-labelledby` association remains active regardless
-   * of this setting. USE when the heading should be accessible but not
+   * of this setting. Use when the heading should be accessible but not
    * visible (e.g. social links group). Defaults to false.
    */
   @property({
@@ -30,6 +30,16 @@ export class RhFooterLinks extends LitElement {
     attribute: 'header-hidden',
     reflect: true,
   }) headerHidden = false;
+
+  /**
+   * Accessible name for this link group, applied as `aria-label` on the host
+   * when no `header` is slotted. Use to name a social links list
+   * (`role="list"`). Localize surrounding words; keep "Red Hat" except in
+   * Simplified Chinese (`红帽`). Override only when the accounts are not
+   * corporate Red Hat. Defaults to undefined. A slotted header still wins
+   * via `aria-labelledby` on the inner `<ul>`.
+   */
+  @property({ attribute: 'accessible-label' }) accessibleLabel?: string;
 
   #mo = new MutationObserver(() => this.updateAccessibility());
 
@@ -52,6 +62,16 @@ export class RhFooterLinks extends LitElement {
       header.id ||= getRandomId('rh-footer-links');
       ul.setAttribute('aria-labelledby', header.id);
     }
+    // Name the host list from accessible-label when authors did not slot a
+    // header. Do not strip a native aria-label if the property is unset.
+    if (!header && this.accessibleLabel) {
+      this.setAttribute('aria-label', this.accessibleLabel);
+    }
+  }
+
+  override updated() {
+    // Re-apply when accessible-label or slotted header content changes.
+    this.updateAccessibility();
   }
 
   render() {

--- a/elements/rh-footer/rh-footer-links.ts
+++ b/elements/rh-footer/rh-footer-links.ts
@@ -43,6 +43,13 @@ export class RhFooterLinks extends LitElement {
 
   #mo = new MutationObserver(() => this.updateAccessibility());
 
+  /**
+   * Last host `aria-label` this component wrote from `accessible-label`.
+   * Used so we remove only our own value and must not strip an author-set
+   * native `aria-label`.
+   */
+  #appliedAriaLabel?: string;
+
   protected slots = new SlotController(this, 'header');
 
   connectedCallback() {
@@ -63,9 +70,22 @@ export class RhFooterLinks extends LitElement {
       ul.setAttribute('aria-labelledby', header.id);
     }
     // Name the host list from accessible-label when authors did not slot a
-    // header. Do not strip a native aria-label if the property is unset.
+    // header. Record the value we wrote so later updates can clear it.
+    // Do not strip a native aria-label if the property is unset or a header
+    // is slotted later — only remove aria-label when it still matches what
+    // we applied.
     if (!header && this.accessibleLabel) {
       this.setAttribute('aria-label', this.accessibleLabel);
+      this.#appliedAriaLabel = this.accessibleLabel;
+    } else {
+      // Header present, or accessible-label empty/unset: drop our generated
+      // name if it is still the current host aria-label. Leave an author-set
+      // native label alone.
+      if (this.getAttribute('aria-label') === this.#appliedAriaLabel) {
+        this.removeAttribute('aria-label');
+      }
+      // Forget the recorded value so a later coincidental match is not ours.
+      this.#appliedAriaLabel = undefined;
     }
   }
 

--- a/elements/rh-footer/rh-footer-universal.ts
+++ b/elements/rh-footer/rh-footer-universal.ts
@@ -47,6 +47,15 @@ export class RhFooterUniversal extends LitElement {
    */
   @property({ attribute: 'logo-href' }) logoHref = DEFAULT_LOGO_HREF;
 
+  /**
+   * Accessible name for the default logo link. Applied as `aria-label` on the
+   * fallback logo `<a>` when the `logo` slot is empty. Keep "Red Hat" except
+   * in Simplified Chinese (`红帽`). Has no effect when authors slot a custom
+   * logo; use `alt` or `aria-label` on that slotted content instead.
+   * Defaults to `'Red Hat'`.
+   */
+  @property({ attribute: 'logo-label' }) logoLabel = 'Red Hat';
+
   #internals = InternalsController.of(this);
 
   #slots = new SlotController(
@@ -143,7 +152,7 @@ export class RhFooterUniversal extends LitElement {
                      Expects block elements: an \`<a>\` wrapping an \`<img>\` or \`<svg>\`.
                      Replaces the default link, so \`logo-href\` no longer applies.
                      Defaults to the Red Hat logo SVG linking to https://www.redhat.com/en. Screen
-                     readers rely on the anchor \`aria-label\` for identification. -->
+                     readers rely on the anchor \`aria-label\` (\`logo-label\`) for identification. -->
               <slot name="logo">
                 <!--
                   part:
@@ -152,7 +161,7 @@ export class RhFooterUniversal extends LitElement {
                 <a class="global-logo-anchor"
                     part="logo-anchor"
                     href="${this.logoHref?.trim() || DEFAULT_LOGO_HREF}"
-                    aria-label="Red Hat">
+                    aria-label="${this.logoLabel}">
                   <!--
                     part:
                       description: Logo image or SVG element.
@@ -161,8 +170,8 @@ export class RhFooterUniversal extends LitElement {
                        part="logo-image"
                        data-name="Layer 1"
                        xmlns="http://www.w3.org/2000/svg"
-                       viewBox="0 0 192 145">
-                      <title>Red Hat logo</title>
+                       viewBox="0 0 192 145"
+                       aria-hidden="true">
                     <defs>
                       <style>
                         .band {

--- a/elements/rh-footer/rh-footer.ts
+++ b/elements/rh-footer/rh-footer.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
+import { property } from 'lit/decorators/property.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
@@ -45,6 +46,25 @@ export class RhFooter extends LitElement {
   static readonly version = '{{version}}';
 
   static readonly styles = [style];
+
+  /**
+   * Accessible name for the default social links list (`slot="social-links"`).
+   * Applied as `accessible-label` on the inner `<rh-footer-links>`. Localize
+   * surrounding words; keep "Red Hat" except in Simplified Chinese (`红帽`).
+   * Override only when the accounts are not corporate Red Hat. Has no effect
+   * when authors replace `header-secondary` or put social links in the
+   * universal `tertiary` slot. Defaults to `'Red Hat social media links'`.
+   */
+  @property({ attribute: 'social-links-label' }) socialLinksLabel = 'Red Hat social media links';
+
+  /**
+   * Accessible name for the default logo link. Applied as `aria-label` on the
+   * fallback logo `<a>` when the `logo` slot is empty. Keep "Red Hat" except
+   * in Simplified Chinese (`红帽`). Has no effect when authors slot a custom
+   * logo; use `alt` or `aria-label` on that slotted content instead.
+   * Defaults to `'Red Hat'`.
+   */
+  @property({ attribute: 'logo-label' }) logoLabel = 'Red Hat';
 
   /**
    * Isomorphic import.meta.url function
@@ -143,9 +163,9 @@ export class RhFooter extends LitElement {
                          description: |
                            Expects block elements: an \`<a>\` wrapping an image. Defaults to the
                            Red Hat corporate logo. Screen readers rely on the img \`alt\` attribute
-                           or link text for identification. -->
+                           or the default link \`logo-label\` for identification. -->
                     <slot name="logo">
-                      <a href="https://www.redhat.com/en" aria-label="Red Hat">
+                      <a href="https://www.redhat.com/en" aria-label="${this.logoLabel}">
                         <svg preserveAspectRatio="xMinYMid slice" viewBox="0 0 613 145" role="img" aria-hidden="true">
                           <path fill="var(--rh-color-brand-red, #ee0000)" d="M127.47,83.49c12.51,0,30.61-2.58,30.61-17.46a14,14,0,0,0-.31-3.42l-7.45-32.36c-1.72-7.12-3.23-10.35-15.73-16.6C124.89,8.69,103.76.5,97.51.5,91.69.5,90,8,83.06,8c-6.68,0-11.64-5.6-17.89-5.6-6,0-9.91,4.09-12.93,12.5,0,0-8.41,23.72-9.49,27.16A6.43,6.43,0,0,0,42.53,44c0,9.22,36.3,39.45,84.94,39.45M160,72.07c1.73,8.19,1.73,9.05,1.73,10.13,0,14-15.74,21.77-36.43,21.77C78.54,104,37.58,76.6,37.58,58.49a18.45,18.45,0,0,1,1.51-7.33C22.27,52,.5,55,.5,74.22c0,31.48,74.59,70.28,133.65,70.28,45.28,0,56.7-20.48,56.7-36.65,0-12.72-11-27.16-30.83-35.78"/>
                           <path d="M160,72.07c1.73,8.19,1.73,9.05,1.73,10.13,0,14-15.74,21.77-36.43,21.77C78.54,104,37.58,76.6,37.58,58.49a18.45,18.45,0,0,1,1.51-7.33l3.66-9.06A6.43,6.43,0,0,0,42.53,44c0,9.22,36.3,39.45,84.94,39.45,12.51,0,30.61-2.58,30.61-17.46a14,14,0,0,0-.31-3.42Z"/>
@@ -167,7 +187,7 @@ export class RhFooter extends LitElement {
                     <rh-footer-links class="social-links-item"
                                      part="social-links"
                                      role="list"
-                                     aria-label="Red Hat social media links">
+                                     accessible-label="${this.socialLinksLabel}">
                       <!-- summary: social media icon links
                          description: |
                            Expects block elements: \`<rh-footer-social-link>\` elements. Each link

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -3,6 +3,7 @@ import { fixture, expect, aTimeout, nextFrame } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import { tokens } from '@rhds/tokens';
 import { RhFooter, RhFooterUniversal } from '../rh-footer.js';
+import { RhFooterLinks } from '../rh-footer-links.js';
 
 import '@patternfly/pfe-tools/test/stub-logger.js';
 
@@ -97,7 +98,7 @@ const KITCHEN_SINK_TEMPLATE = html`
         <li><a href="#">Cookie preferences</a></li>
       </ul>
       <rh-footer-copyright slot="tertiary"></rh-footer-copyright>
-      <rh-footer-links slot="tertiary" role="list">
+      <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
         <rh-footer-social-link icon="linkedin"
                                href="https://www.linkedin.com/company/red-hat"
                                accessible-label="LinkedIn"></rh-footer-social-link>
@@ -139,7 +140,7 @@ const UNIVERSAL_FOOTER_TEMPLATE = html`
       <li><a href="#">Cookie preferences</a></li>
     </ul>
     <rh-footer-copyright slot="tertiary"></rh-footer-copyright>
-    <rh-footer-links slot="tertiary" role="list">
+    <rh-footer-links slot="tertiary" role="list" accessible-label="Red Hat social media links">
       <rh-footer-social-link icon="linkedin"
                              href="https://www.linkedin.com/company/red-hat"
                              accessible-label="LinkedIn"></rh-footer-social-link>
@@ -269,6 +270,152 @@ describe('<rh-footer>', function() {
         expect(slotted).to.have.attribute('href', 'https://example.com/');
         const slot = universalFooter.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="logo"]');
         expect(slot?.assignedElements()[0]).to.equal(slotted);
+      });
+    });
+  });
+
+  describe('social-links-label', function() {
+    /**
+     * Default social links list in rh-footer shadow DOM.
+     * Fallback content only; used when authors slot `social-links`.
+     * @param el footer under test
+     */
+    function socialLinks(el: RhFooter) {
+      return el.shadowRoot?.querySelector<RhFooterLinks>('rh-footer-links[part="social-links"]');
+    }
+
+    describe('with no attribute', function() {
+      beforeEach(async function() {
+        element = await fixture<RhFooter>(html`
+          <rh-footer>
+            <rh-footer-social-link slot="social-links"
+                                   icon="linkedin"
+                                   href="#"
+                                   accessible-label="LinkedIn"></rh-footer-social-link>
+          </rh-footer>
+        `);
+        await element.updateComplete;
+        await socialLinks(element)?.updateComplete;
+        expect(socialLinks(element)?.getAttribute('aria-label'))
+            .to.equal('Red Hat social media links');
+      });
+    });
+
+    describe('with a custom label', function() {
+      beforeEach(async function() {
+        element = await fixture<RhFooter>(html`
+          <rh-footer social-links-label="OpenShift social media links">
+            <rh-footer-social-link slot="social-links"
+                                   icon="linkedin"
+                                   href="#"
+                                   accessible-label="LinkedIn"></rh-footer-social-link>
+          </rh-footer>
+        `);
+        await element.updateComplete;
+        await socialLinks(element)?.updateComplete;
+        expect(socialLinks(element)?.getAttribute('aria-label'))
+            .to.equal('OpenShift social media links');
+      });
+    });
+  });
+
+  describe('accessible-label on rh-footer-links', function() {
+    describe('with accessible-label and no header', function() {
+      let links: RhFooterLinks;
+
+      beforeEach(async function() {
+        links = await fixture<RhFooterLinks>(html`
+          <rh-footer-links role="list" accessible-label="Red Hat social media links">
+            <rh-footer-social-link icon="linkedin"
+                                   href="#"
+                                   accessible-label="LinkedIn"></rh-footer-social-link>
+          </rh-footer-links>
+        `);
+        await links.updateComplete;
+      });
+
+      it('sets aria-label on the host', function() {
+        expect(links.getAttribute('aria-label')).to.equal('Red Hat social media links');
+      });
+    });
+
+    describe('with a slotted header', function() {
+      let links: RhFooterLinks;
+
+      beforeEach(async function() {
+        links = await fixture<RhFooterLinks>(html`
+          <rh-footer-links accessible-label="Should not apply">
+            <h3 slot="header">Social</h3>
+            <ul>
+              <li><a href="#">One</a></li>
+            </ul>
+          </rh-footer-links>
+        `);
+        await links.updateComplete;
+      });
+
+      it('does not set aria-label from accessible-label', function() {
+        expect(links.hasAttribute('aria-label')).to.be.false;
+      });
+
+      it('wires aria-labelledby from the header to the list', function() {
+        const header = links.querySelector('[slot="header"]');
+        const ul = links.querySelector('ul');
+        expect(ul).to.have.attribute('aria-labelledby', header?.id);
+      });
+    });
+  });
+
+  describe('logo-label', function() {
+    /**
+     * Default logo anchor in shadow DOM.
+     * Fallback content only; not assigned when authors slot `logo`.
+     * @param el universal footer under test
+     */
+    function logoAnchor(el: RhFooterUniversal) {
+      return el.shadowRoot?.querySelector<HTMLAnchorElement>('a[part="logo-anchor"]');
+    }
+
+    describe('with no attribute', function() {
+      beforeEach(async function() {
+        universalFooter = await fixture<RhFooterUniversal>(html`<rh-footer-universal></rh-footer-universal>`);
+      });
+
+      it('uses the default Red Hat logo name', function() {
+        expect(logoAnchor(universalFooter)?.getAttribute('aria-label')).to.equal('Red Hat');
+      });
+
+      it('hides the default SVG from assistive technology', function() {
+        const svg = logoAnchor(universalFooter)?.querySelector('svg');
+        expect(svg).to.have.attribute('aria-hidden', 'true');
+        expect(svg?.querySelector('title')).to.be.null;
+      });
+    });
+
+    describe('with a Simplified Chinese label', function() {
+      beforeEach(async function() {
+        universalFooter = await fixture<RhFooterUniversal>(html`
+          <rh-footer-universal logo-label="红帽"></rh-footer-universal>
+        `);
+      });
+
+      it('updates the default logo link name', function() {
+        expect(logoAnchor(universalFooter)?.getAttribute('aria-label')).to.equal('红帽');
+      });
+    });
+
+    describe('with a slotted logo', function() {
+      beforeEach(async function() {
+        universalFooter = await fixture<RhFooterUniversal>(html`
+          <rh-footer-universal logo-label="红帽">
+            <a slot="logo" href="https://example.com/" aria-label="Custom">Custom logo</a>
+          </rh-footer-universal>
+        `);
+      });
+
+      it('does not apply logo-label to the slotted link', function() {
+        const slotted = universalFooter.querySelector('[slot="logo"]');
+        expect(slotted).to.have.attribute('aria-label', 'Custom');
       });
     });
   });

--- a/elements/rh-footer/test/rh-footer.spec.ts
+++ b/elements/rh-footer/test/rh-footer.spec.ts
@@ -364,6 +364,88 @@ describe('<rh-footer>', function() {
         expect(ul).to.have.attribute('aria-labelledby', header?.id);
       });
     });
+
+    describe('after removing accessible-label', function() {
+      let links: RhFooterLinks;
+
+      beforeEach(async function() {
+        links = await fixture<RhFooterLinks>(html`
+          <rh-footer-links role="list" accessible-label="Red Hat social media links">
+            <rh-footer-social-link icon="linkedin"
+                                   href="#"
+                                   accessible-label="LinkedIn"></rh-footer-social-link>
+          </rh-footer-links>
+        `);
+        await links.updateComplete;
+        links.removeAttribute('accessible-label');
+        await links.updateComplete;
+      });
+
+      it('removes the host aria-label it applied', function() {
+        expect(links.hasAttribute('aria-label')).to.be.false;
+      });
+    });
+
+    describe('after slotting a header over an applied label', function() {
+      let links: RhFooterLinks;
+
+      beforeEach(async function() {
+        links = await fixture<RhFooterLinks>(html`
+          <rh-footer-links role="list" accessible-label="Red Hat social media links">
+            <rh-footer-social-link icon="linkedin"
+                                   href="#"
+                                   accessible-label="LinkedIn"></rh-footer-social-link>
+          </rh-footer-links>
+        `);
+        await links.updateComplete;
+        const header = document.createElement('h3');
+        header.slot = 'header';
+        header.textContent = 'Social';
+        const ul = document.createElement('ul');
+        ul.innerHTML = '<li><a href="#">One</a></li>';
+        links.append(header, ul);
+        await links.updateComplete;
+        await nextFrame();
+      });
+
+      it('removes the host aria-label it applied', function() {
+        expect(links.hasAttribute('aria-label')).to.be.false;
+      });
+
+      it('wires aria-labelledby from the header to the list', function() {
+        const header = links.querySelector('[slot="header"]');
+        const ul = links.querySelector('ul');
+        expect(ul).to.have.attribute('aria-labelledby', header?.id);
+      });
+    });
+
+    describe('with a native aria-label and no accessible-label', function() {
+      let links: RhFooterLinks;
+
+      beforeEach(async function() {
+        links = await fixture<RhFooterLinks>(html`
+          <rh-footer-links role="list" aria-label="Native">
+            <rh-footer-social-link icon="linkedin"
+                                   href="#"
+                                   accessible-label="LinkedIn"></rh-footer-social-link>
+          </rh-footer-links>
+        `);
+        await links.updateComplete;
+        const header = document.createElement('h3');
+        header.slot = 'header';
+        header.textContent = 'Social';
+        links.append(header);
+        await links.updateComplete;
+        await nextFrame();
+        header.remove();
+        await links.updateComplete;
+        await nextFrame();
+      });
+
+      it('does not delete the native aria-label', function() {
+        expect(links.getAttribute('aria-label')).to.equal('Native');
+      });
+    });
   });
 
   describe('logo-label', function() {


### PR DESCRIPTION
## What I did

1. Related to #2932 (the hardcoded social-links `aria-label` item).
1. Added `accessible-label` on `<rh-footer-links>` so authors can name a social links list.
2. Added `social-links-label` on `<rh-footer>` (default "Red Hat social media links") for the legacy `slot="social-links"` wrapper.
3. Added `logo-label` on `<rh-footer>` and `<rh-footer-universal>` (default "Red Hat") and hid the default universal SVG from assistive tech so the link has a single name.
4. Documented the tertiary pattern in demos, the README, and the accessibility page.

## Testing Instructions

1. Determine if these properties are actually worth adding versus forcing people to just override the various footer slots.
1. Open the [footer demo](https://deploy-preview-3243--red-hat-design-system.netlify.app/elements/footer/demo/).
2. In the accessibility tree (or DevTools), confirm the tertiary `rh-footer-links[role="list"]` is named "Red Hat social media links".
3. Check the other demos:
   - [Legacy](https://deploy-preview-3243--red-hat-design-system.netlify.app/elements/footer/demo/legacy/) — same list name on the shadow social list
   - [Footer Universal](https://deploy-preview-3243--red-hat-design-system.netlify.app/elements/footer/demo/footer-universal/) — default fedora link named "Red Hat" only (no extra "Red Hat logo" from the SVG)
   - [Subdomain](https://deploy-preview-3243--red-hat-design-system.netlify.app/elements/footer/demo/subdomain/) and [Slotted social links](https://deploy-preview-3243--red-hat-design-system.netlify.app/elements/footer/demo/slotted-social-links/) — tertiary list still named
4. On the universal demo, add the following attribute in DevTools to `<rh-footer-universal>`: `logo-label="红帽"`. Confirm that is the only logo name.
5. On the main footer demo, set `accessible-label="Liens des réseaux sociaux Red Hat"` on the `<rh-footer-links>` tertiary list and confirm the name updates.
6. Skim the [accessibility page](https://deploy-preview-3243--red-hat-design-system.netlify.app/elements/footer/accessibility/) for the social list / logo-label note.